### PR TITLE
Generalised authentication and authorization

### DIFF
--- a/app/controllers/rails_admin_controller.rb
+++ b/app/controllers/rails_admin_controller.rb
@@ -1,7 +1,8 @@
 require 'rails_admin/abstract_model'
 
 class RailsAdminController < ApplicationController
-  before_filter :authenticate_user!
+  before_filter :_authenticate!
+  before_filter :_authorize!
 
   before_filter :get_model, :except => [:index, :history, :get_history]
   before_filter :get_object, :only => [:edit, :update, :delete, :destroy]
@@ -419,4 +420,11 @@ class RailsAdminController < ApplicationController
     end
   end
 
+  def _authenticate!
+    instance_eval &RailsAdmin.authenticate_with
+  end
+
+  def _authorize!
+    instance_eval &RailsAdmin.authorize_with
+  end
 end

--- a/lib/rails_admin.rb
+++ b/lib/rails_admin.rb
@@ -5,4 +5,62 @@ Bundler.setup
 
 module RailsAdmin
   require 'rails_admin/engine' if defined?(Rails)
+
+  # RailsAdmin is setup to try and authenticate with warden
+  # If warden is found, then it will try to authenticate
+  #
+  # This is valid for custom warden setups, and also devise
+  # If you're using the admin setup for devise, you should set RailsAdmin to use the admin
+  #
+  # @see RailsAdmin.authenticate_with
+  # @see RailsAdmin.authorize_with
+  DEFAULT_AUTHENTICATION = lambda do
+    warden = request.env['warden']
+    if warden
+      warden.authenticate!
+    end
+  end
+
+  DEFAULT_AUTHORIZE = lambda {}
+
+  # Setup authentication to be run as a before filter
+  # This is run inside the controller instance so you can setup any authentication you need to
+  #
+  # By default, the authentication will run via warden if available
+  # and will run the default.
+  #
+  # If you use devise, this will authenticate the same as _authenticate_user!_
+  #
+  # @example Devise admin
+  #   RailsAdmin.authenticate_with do
+  #     authenticate_admin!
+  #   end
+  #
+  # @example Custom Warden
+  #   RailsAdmin.authenticate_with do
+  #     warden.authenticate! :scope => :paranoid
+  #   end
+  #
+  # @see RailsAdmin::DEFAULT_AUTHENTICATION
+  def self.authenticate_with(&blk)
+    @authenticate = blk if blk
+    @authenticate || DEFAULT_AUTHENTICATION
+  end
+
+  # Setup authorization to be run as a before filter
+  # This is run inside the controller instance so you can setup any authorization you need to
+  #
+  # By default, there is no authorization.
+  #
+  # @example Custom
+  #   RailsAdmin.authorize_with do
+  #     warden.user.is_admin?
+  #   end
+  #
+  # @see RailsAdmin::DEFAULT_AUTHORIZE
+  def self.authorize_with(&blk)
+    @authorize = blk if blk
+    @authorize || DEFAULT_AUTHORIZE
+  end
+
 end


### PR DESCRIPTION
Hey lads,

Just a starting point to some conversation about generalising the authentication and authorization setup for rails_admin.

If you're happy with this as a foundation, I think the next step is to add a way to integrate smoothly and transparently (perhaps even magically) with devise.  The setup in this commit will work with devise as is, but if the owner of the application wants to use devise with admin then perhaps this could be detected?  

Even if this is done long hand at the moment it would look like:

RailsAdmin.authenticate_with { authenticate_admin! }

So not entirely terrible, but not sure how you guys feel about it.

It also addresses the authorization with a simliar setup

RailsAdmin.authorize_with { current_user.is_admin? }

So, lemme know.. ping me here, twitter, irc, IM whatever.  I would like to use this, but at the moment it's setup just for Devise which is precluding me :(

Cheers
Daniel
