### PR TITLE
Foundations of HABTM association support

### DIFF
--- a/lib/rails_admin/active_record_support.rb
+++ b/lib/rails_admin/active_record_support.rb
@@ -106,10 +106,10 @@ module RailsAdmin
         case association.macro
         when :belongs_to
           association.klass
-        when :has_one, :has_many
+        when :has_one, :has_many, :has_and_belongs_to_many
           association.active_record
         else
-          raise "Unknown association type"
+          raise "Unknown association type: #{association.macro.inspect}"
         end
       end
 
@@ -121,10 +121,10 @@ module RailsAdmin
         case association.macro
         when :belongs_to
           association.active_record
-        when :has_one, :has_many
+        when :has_one, :has_many, :has_and_belongs_to_many
           association.klass
         else
-          raise "Unknown association type"
+          raise "Unknown association type: #{association.macro.inspect}"
         end
       end
 
@@ -132,10 +132,10 @@ module RailsAdmin
         case association.macro
         when :belongs_to
           ["#{association.class_name.underscore}_id".to_sym]
-        when :has_one, :has_many
+        when :has_one, :has_many, :has_and_belongs_to_many
           [association.primary_key_name.to_sym]
         else
-          raise "Unknown association type"
+          raise "Unknown association type: #{association.macro.inspect}"
         end
       end
 


### PR DESCRIPTION
Is there a reason has_and_belongs_to_many associations weren't in the activerecord related association handling? I have a couple models that fail without the pull request in there. Don't know the code well enough to understand if this is just a bug or a feature, but if you'd like a fix here ya go. 

j
