### PR TITLE
No need to depend on Bundler on the generators

### DIFF
--- a/lib/generators/rails_admin/install_admin_generator.rb
+++ b/lib/generators/rails_admin/install_admin_generator.rb
@@ -8,10 +8,7 @@ module RailsAdmin
       puts "Hello!
 Rails_admin works with devise. Checking for a current installation of devise!
 "
-      loaded_gems = Bundler.setup.gems
-      is_loaded = loaded_gems.reject{|t| t.name == "devise" ? false : true}.size == 1 ? true : false
-
-      if is_loaded
+      if defined?(Devise)
         check_for_devise_models
       else
         puts "Please put gem 'devise' into your Gemfile"


### PR DESCRIPTION
Projects using other dependency management libraries such as Isolate can't run the generators to install the admin. This is easily fixed by doing the standard in ruby `if defined?(Devise)` instead of checking the gems loaded by Bundler, and should work for users of any dependency manager.
