### PR TITLE
Fix for "list" action

### DIFF
--- a/app/views/layouts/rails_admin/list.html.erb
+++ b/app/views/layouts/rails_admin/list.html.erb
@@ -11,7 +11,7 @@
   <script type="text/javascript" language="javascript">
     function updatePage(paramList){
 
-      new Ajax.Updater('content', '/admin/<%= @abstract_model.pretty_name.downcase %>',{
+      new Ajax.Updater('content', '/admin/<%= @abstract_model.to_param %>',{
         parameters: paramList,
         onComplete: function(){
           initPages();


### PR DESCRIPTION
I "stumbled upon" this problem when testing rails_admin with a model named like AccountSetting: that JS fragmet ended up containing "/admin/account setting" instead of "/admin/account_setting".
