### PR TITLE
Allow loading the Devise mappings in the admin

### DIFF
--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -8,7 +8,9 @@ module RailsAdmin
       str = ""
 
       excluded_models = RailsAdmin::Config.excluded_models.map(&:to_s)
-      excluded_models << ::Devise.mappings.keys[0].to_param.capitalize if defined?(::Devise)
+      if defined?(::Devise) && RailsAdmin::Config.exclude_devise_mappings
+        excluded_models << ::Devise.mappings.keys[0].to_param.capitalize
+      end
       excluded_models << ['History']
 
       Dir.glob(Rails.root.join("app/models/**/*.rb")).each do |filename|

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -10,6 +10,11 @@ module RailsAdmin
     @@excluded_models = []
     mattr_accessor :excluded_models
 
+    if defined?(::Devise)
+      @@exclude_devise_mappings = true
+      mattr_accessor :exclude_devise_mappings
+    end
+
     # Loads a model configuration instance from the registry or registers
     # a new one if one is yet to be added.
     #

--- a/spec/requests/rails_admin_spec.rb
+++ b/spec/requests/rails_admin_spec.rb
@@ -87,6 +87,15 @@ describe "RailsAdmin" do
         end
       end
 
+      it "should make hiding Devise models configurable" do
+        if defined?(::Devise)
+          RailsAdmin::Config.exclude_devise_mappings = false
+          RailsAdmin::AbstractModel.all.detect {|am| am.model == User }.should be_present
+          RailsAdmin::Config.exclude_devise_mappings = true
+          RailsAdmin::AbstractModel.all.detect {|am| am.model == User }.should be_blank
+        end
+      end
+
       it "should raise NotFound for the list view" do
         get rails_admin_list_path(:model_name => "fan")
         response.status.should equal(404)


### PR DESCRIPTION
We need to edit/add/etc users from the admin panel. Was there a specific reason why this was hardcoded and not configurable? (ie, a specific error or incompatibility when editing users?)
