### PR TITLE
Assets copy rake

### DIFF
--- a/lib/rails_admin/railties/tasks.rake
+++ b/lib/rails_admin/railties/tasks.rake
@@ -12,4 +12,19 @@ namespace :admin do
     Rake::Task["dummy:data:import"].reenable
     Rake::Task["dummy:data:import"].invoke
   end
+
+  desc "Copy assets files - javascripts, stylesheets and images"
+  task :copy_assets do
+    #require 'rails/generators/base'
+    origin      = File.join(RailsAdmin::Engine.root, "public")
+    destination = File.join(Rails.root, "public")
+    Rails::Generators::Base.source_root(origin)
+    copier = Rails::Generators::Base.new
+    %w( stylesheets images javascripts ).each do |directory|
+      Dir[File.join(origin,directory,'rails_admin','*')].each do |file|
+        relative = file.gsub(/^#{origin}\//, '')
+        copier.copy_file(file, File.join(destination,relative))
+      end
+    end
+  end
 end


### PR DESCRIPTION
Rake for copying assets when ActionDispatch::Static does not works (ie in Heroku). 
