### PR TITLE
copy_assets task not working 

### DIFF
--- a/lib/rails_admin/railties/tasks.rake
+++ b/lib/rails_admin/railties/tasks.rake
@@ -15,7 +15,7 @@ namespace :admin do
 
   desc "Copy assets files - javascripts, stylesheets and images"
   task :copy_assets do
-    #require 'rails/generators/base'
+    require 'rails/generators/base'
     origin      = File.join(RailsAdmin::Engine.root, "public")
     destination = File.join(Rails.root, "public")
     Rails::Generators::Base.source_root(origin)


### PR DESCRIPTION
Hi guys,

We tried the copy_assets rake task, because we needed to copy over the assets in order to have it working on heroku (there seems to be a small error with serving engine assets). This task however had one missing require. So simple patch, but important.

Thanks,

Jeroen & Josh
