### PR TITLE
Fix for static asset serving 

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -4,9 +4,11 @@ require "rails"
 module RailsAdmin
   class Engine < Rails::Engine
     initializer "static assets" do |app|
-      app.middleware.use ::ActionDispatch::Static, "#{root}/public"
+      if app.config.serve_static_assets
+        app.middleware.insert 0, ::ActionDispatch::Static, "#{root}/public"
+      end
     end
-
+    
     rake_tasks do
       load "rails_admin/railties/tasks.rake"
     end


### PR DESCRIPTION
hi guys,

When using this gem in development everything worked fine, but when pushing to production (heroku) assets weren't properly servered. We debugged this and it came down to moving the middleware up the stack. The middleware is also only needed when you set the configuration option 'serve_static_assets' to true.

Thanks,
Josh & Jeroen
