### PR TITLE
Devise admin model name

### DIFF
--- a/lib/generators/rails_admin/install_admin_generator.rb
+++ b/lib/generators/rails_admin/install_admin_generator.rb
@@ -1,6 +1,7 @@
 module RailsAdmin
   class InstallAdminGenerator < Rails::Generators::Base
     source_root File.expand_path('../templates', __FILE__)
+    argument :model_name, :type => :string, :default => 'user'
 
     desc "RailsAdmin Install"
 
@@ -61,7 +62,7 @@ Rails_admin works with devise. Checking for a current installation of devise!
     def set_devise
       puts "Setting up devise for you!
 ======================================================"
-      invoke 'devise', ['user']
+      invoke 'devise', [model_name]
     end
 
     def copy_locales_files


### PR DESCRIPTION
This commit allows a user to specify a model name when invoking the `rails_admin install_admin` generator. This means you're not limited to using the default `user` model name, when perhaps `admin` or something similar may be more applicable.

There currently aren't any specs built for testing against generators, so I haven't added any for this feature. If this commit is rejected on that basis I can work on generator specs if it helps.
