### PR TITLE
Allow for customization on how to determine the current user

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -6,6 +6,8 @@ module RailsAdmin
     before_filter :_authorize!
     before_filter :set_plugin_name
 
+    helper_method :_current_user
+
     private
 
     def _authenticate!
@@ -14,6 +16,10 @@ module RailsAdmin
 
     def _authorize!
       instance_eval &RailsAdmin.authorize_with
+    end
+
+    def _current_user
+      instance_eval &RailsAdmin.current_user_method
     end
 
     def set_plugin_name

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -350,7 +350,7 @@ module RailsAdmin
           :message => message,
           :item => @object.id,
           :table => @abstract_model.pretty_name,
-          :username => current_user ? current_user.email : "",
+          :username => _current_user ? _current_user.email : "",
           :month => date.month,
           :year => date.year
         )

--- a/app/views/layouts/rails_admin/dashboard.html.erb
+++ b/app/views/layouts/rails_admin/dashboard.html.erb
@@ -36,7 +36,7 @@
 <%= render(:partial => 'rails_admin/main/navigation') %>
 
       <div id="headerRight">
-<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => current_user}) %>
+<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => _current_user}) %>
       </div>
     </div>
 

--- a/app/views/layouts/rails_admin/delete.html.erb
+++ b/app/views/layouts/rails_admin/delete.html.erb
@@ -38,7 +38,7 @@
 <%= render(:partial => 'rails_admin/main/navigation') %>
 
       <div id="headerRight">
-<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => current_user}) %>
+<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => _current_user}) %>
       </div>
     </div>
     <div id="content">

--- a/app/views/layouts/rails_admin/form.html.erb
+++ b/app/views/layouts/rails_admin/form.html.erb
@@ -70,7 +70,7 @@
 <%= render(:partial => 'rails_admin/main/navigation') %>
 
       <div id="headerRight">
-<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => current_user}) %>
+<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => _current_user}) %>
       </div>
     </div>
     <div id="content">

--- a/app/views/layouts/rails_admin/list.html.erb
+++ b/app/views/layouts/rails_admin/list.html.erb
@@ -56,7 +56,7 @@
 <%= render(:partial => 'rails_admin/main/navigation') %>
 
       <div id="headerRight">
-<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => current_user}) %>
+<%= render(:partial => 'rails_admin/main/user_info', :locals => {:current_user => _current_user}) %>
       </div>
     </div>
     <div id="content">

--- a/app/views/rails_admin/main/_user_info.html.erb
+++ b/app/views/rails_admin/main/_user_info.html.erb
@@ -1,4 +1,4 @@
-<% if current_user %>
+<% if current_user = _current_user %>
 <div class="user_info">
   <img src="http://www.gravatar.com/avatar/<%=Digest::MD5.hexdigest current_user.email %>?s=30" alt="" />
   <ul>

--- a/lib/rails_admin.rb
+++ b/lib/rails_admin.rb
@@ -32,6 +32,10 @@ module RailsAdmin
 
   DEFAULT_AUTHORIZE = Proc.new {}
 
+  DEFAULT_CURRENT_USER = Proc.new do
+    current_user
+  end
+
   # Setup authentication to be run as a before filter
   # This is run inside the controller instance so you can setup any authentication you need to
   #
@@ -70,6 +74,22 @@ module RailsAdmin
   def self.authorize_with(&blk)
     @authorize = blk if blk
     @authorize || DEFAULT_AUTHORIZE
+  end
+
+  # Setup a different method to determine the current user or admin logged in.
+  # This is run inside the controller instance and made available as a helper.
+  #
+  # By default, _current_user_ will be used.
+  #
+  # @example Custom
+  #   RailsAdmin.current_user_method do
+  #     current_admin
+  #   end
+  #
+  # @see RailsAdmin::DEFAULT_CURRENT_USER
+  def self.current_user_method(&blk)
+    @current_user = blk if blk
+    @current_user || DEFAULT_CURRENT_USER
   end
 
   # Setup RailsAdmin


### PR DESCRIPTION
Hi Guys,

This patch adds the ability for the default way to determine the _current_user_ to be changed. This is pretty important because when you change the default authentication (eg. instead of authenticate_user! you use authenticate_admin!), using _current_user_ will return the wrong user.

Let me know if you have any questions or comments.

Thanks

Josh
