### PR TITLE
Add inspect methods to objects with circular references

### DIFF
--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -139,6 +139,11 @@ module RailsAdmin
           !(bindings[:object].errors[name].nil? || bindings[:object].errors[name].empty?)
         end
 
+        # Override inspect for nicer console output
+        def inspect
+          "#{to_s} - Configuration for #{name} field in #{abstract_model.model.name}'s #{parent.class.name.demodulize.downcase} view"
+        end
+
         # Reader whether field is optional.
         #
         # @see RailsAdmin::Config::Fields::Base.register_instance_option(:required?)

--- a/lib/rails_admin/config/fields/group.rb
+++ b/lib/rails_admin/config/fields/group.rb
@@ -43,6 +43,11 @@ module RailsAdmin
           selected
         end
 
+        # Override inspect for nicer console output
+        def inspect
+          "#{to_s} - Configuration for #{name} group in #{abstract_model.model.name}'s #{parent.class.name.demodulize.downcase} view"
+        end
+
         # Reader for fields that are marked as visible
         def visible_fields
           fields.select {|f| f.visible? }

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -39,6 +39,11 @@ module RailsAdmin
         end
       end
 
+      # Override inspect for nicer console output
+      def inspect
+        "#{self.to_s} - Configuration object for #{abstract_model.model.name} model"
+      end
+
       # Act as a proxy for the section configurations that actually
       # store the configurations.
       def method_missing(m, *args, &block)

--- a/lib/rails_admin/config/sections/create.rb
+++ b/lib/rails_admin/config/sections/create.rb
@@ -5,6 +5,10 @@ module RailsAdmin
     module Sections
       # Configuration of the edit view for a new object
       class Create < RailsAdmin::Config::Sections::Update
+        # Override inspect for nicer console output
+        def inspect
+          "#{self.to_s} - Configuration for #{abstract_model.model.name}'s create view"
+        end
       end
     end
   end

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -24,6 +24,11 @@ module RailsAdmin
           end
         end
 
+        # Override inspect for nicer console output
+        def inspect
+          "#{self.to_s} - Configuration for #{abstract_model.model.name}'s list view"
+        end
+
         # Default items per page value used if a model level option has not
         # been configured
         cattr_accessor :default_items_per_page

--- a/lib/rails_admin/config/sections/update.rb
+++ b/lib/rails_admin/config/sections/update.rb
@@ -38,6 +38,11 @@ module RailsAdmin
             end
           end
         end
+
+        # Override inspect for nicer console output
+        def inspect
+          "#{self.to_s} - Configuration for #{abstract_model.model.name}'s update view"
+        end
       end
     end
   end


### PR DESCRIPTION
Debugging some of the config objects via rails console with p or pp is nasty due to circular references and depth of the config tree cause a massive unreadable output.

I don't know if this is good ruby practice, but these changes did ease my console session a lot.

What do you think? Should this be merged to master?
