### PR TITLE
Devise reference in DEFAULT_CURRENT_USER

### DIFF
--- a/lib/rails_admin.rb
+++ b/lib/rails_admin.rb
@@ -33,8 +33,8 @@ module RailsAdmin
   DEFAULT_AUTHORIZE = Proc.new {}
 
   DEFAULT_CURRENT_USER = Proc.new do
-    return nil unless resource = Devise::mappings.keys.first {|r| signed_in?(r)}
-    send("current_#{resource}")
+    devise_resource = defined?(Devise) && Devise::mappings.keys.first {|r| signed_in?(r)}
+    send("current_#{devise_resource||'user'}")
   end
 
   # Setup authentication to be run as a before filter


### PR DESCRIPTION
Hi guys,

i'm using your nice gem without Devise at the moment (with warble+omniauth). Kaapa's commit 92faca8 [1] has a direct reference to Devise that breaks my app.

Kaapa has told me to create this pull request to generate some discussion on the topic.

He starts the discussion with this question: is `current_user` such a strong rails idiom in authentication that it should be assumed the default if Devise is not there?

Thanks!

[1] https://github.com/sferik/rails_admin/commit/92faca8
