### PR TITLE
Copy assets help

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -58,6 +58,11 @@ and unpack the 'ckeditor' folder into your default 'public/javascripts' folder. 
 non-Windows system, you can try to use the automatic downloader:
     $ rake admin:ckeditor_download
 
+When running RailsAdmin in production the images, stylesheets, and javascript assets may return 404
+not found error's depending on your servers static assets configuration.  To prevent this issue you
+can copy assets directly into your application by running:
+    $ rake admin:copy_assets
+        
 Usage
 -----
 Start the server:


### PR DESCRIPTION
Ran into an issue that some others also had with running RailsAdmin in production:
https://github.com/sferik/rails_admin/issues#issue/183

This may help avoid some confusion for others, but I'm thinking this could be prompted for or automatically done during the install step:
rails generate rails_admin:install_admin
