### PR TITLE
CSFR Protection for Rails 3.0.4

### DIFF
--- a/app/views/layouts/rails_admin/dashboard.html.erb
+++ b/app/views/layouts/rails_admin/dashboard.html.erb
@@ -9,9 +9,12 @@
   <%= stylesheet_link_tag('rails_admin/dashboard') %>
 
   <%= javascript_include_tag('rails_admin/prototype.js') %>
+  <%= javascript_include_tag('rails_admin/rails.js') %>
+
   <%= javascript_include_tag('rails_admin/scriptaculous.js') %>
   <%= javascript_include_tag('rails_admin/dashboard.js') %>
 
+  <%= csrf_meta_tag %>
 </head>
 <body>
   <div id="wrapper">

--- a/app/views/layouts/rails_admin/form.html.erb
+++ b/app/views/layouts/rails_admin/form.html.erb
@@ -7,8 +7,11 @@
   <%= stylesheet_link_tag('rails_admin/create.css') %>
 
   <%= javascript_include_tag('rails_admin/prototype.js') %>
+  <%= javascript_include_tag('rails_admin/rails.js') %>
+
   <%= javascript_include_tag('rails_admin/prototype-base-extensions.js') %>
   <%= javascript_include_tag('rails_admin/prototype-date-extensions.js') %>
+
   <%= javascript_include_tag('rails_admin/datepicker.js') %>
   <%= javascript_include_tag('rails_admin/associations.js') %>
   <%= javascript_include_tag('ckeditor/ckeditor.js') if File.exists?(File.join(Rails.root, 'public/javascripts/ckeditor/ckeditor.js')) %>
@@ -48,6 +51,7 @@
 
   </script>
 
+  <%= csrf_meta_tag %>
 </head>
 
 <body>

--- a/app/views/layouts/rails_admin/list.html.erb
+++ b/app/views/layouts/rails_admin/list.html.erb
@@ -7,6 +7,7 @@
   <%= stylesheet_link_tag('rails_admin/base') %>
   <%= stylesheet_link_tag('rails_admin/list') %>
   <%= javascript_include_tag('rails_admin/prototype.js') %>
+  <%= javascript_include_tag('rails_admin/rails.js') %>
 
   <script type="text/javascript" language="javascript">
     var bindEvents = function(){
@@ -24,6 +25,8 @@
     }
     document.observe("dom:loaded", bindEvents)
   </script>
+
+  <%= csrf_meta_tag %>
 </head>
 <body>
   <div id="wrapper">

--- a/public/javascripts/rails_admin/rails.js
+++ b/public/javascripts/rails_admin/rails.js
@@ -172,4 +172,20 @@
       input.disabled = false;
     });
   });
+
+  Ajax.Responders.register({
+    onCreate: function(request) {
+      var csrf_meta_tag = $$('meta[name=csrf-token]')[0];
+
+      if (csrf_meta_tag) {
+        var header = 'X-CSRF-Token',
+            token = csrf_meta_tag.readAttribute('content');
+
+        if (!request.options.requestHeaders) {
+          request.options.requestHeaders = {};
+        }
+        request.options.requestHeaders[header] = token;
+      }
+    }
+  });
 })();


### PR DESCRIPTION
I'm not too familiar with the rails_admin code yet, but I was trying out Rails 3.0.4 and had to add the csrf_meta_tag to the layouts. I wasn't sure where would be the best place to include the new Ajax onCreate callback, so I just updated the rail.js file and included into the layouts.

See http://weblog.rubyonrails.org/2011/2/8/csrf-protection-bypass-in-ruby-on-rails
