### PR TITLE
Deprecation warnings with Rails 3.0.4 if Errors.on is used

### DIFF
--- a/app/views/rails_admin/main/_field.html.erb
+++ b/app/views/rails_admin/main/_field.html.erb
@@ -1,7 +1,7 @@
   <div class="field">
     <%= field.render %>
-    <% if @object.errors.on(field.name) %>
-        <span class="errorMessage"><%= "#{field.label } #{@object.errors.on(field.name)}" %></span>
+    <% if @object.errors[field.name].size > 0 %>
+        <span class="errorMessage"><%= "#{field.label } #{@object.errors[field.name]}" %></span>
     <% end %>
     <p class="help"><%= field.help %></p>
   </div>

--- a/app/views/rails_admin/main/edit.html.erb
+++ b/app/views/rails_admin/main/edit.html.erb
@@ -1,7 +1,7 @@
 <div id="contentHeader">
   <h2><%= @page_name %></h2>
-  <% if @object.errors.on :base %>
-    <%= @object.errors.on :base %>
+  <% if @object.errors[:base].size > 0 %>
+    <%= @object.errors[:base] %>
   <% end %>
   <div id="quickAccess">
     <ul id="quick">


### PR DESCRIPTION
With Rails 3.0.4, running the rails_admin tests produces the following deprecation warnings:

`DEPRECATION WARNING: Errors#on have been deprecated, use Errors#[] instead.
Also note that the behavior of Errors#[] has changed. Errors#[] now always returns an Array. An empty Array is returned when there are no errors on the specified attribute.`

This patch suppresses the warnings by using Errors[] instead of Errors.on

All tests are still working after the patch
