### PR TITLE
I´ve added 2 missing German translations and also refactored a little.

### DIFF
--- a/app/views/rails_admin/history/show.html.erb
+++ b/app/views/rails_admin/history/show.html.erb
@@ -15,7 +15,7 @@
           <form action="" method="get">
             <fieldset>
               <input type="text" id="searchBar" name="query" value="<%= query %>"/>
-              <input type="submit" id="searchbar_btn" value="<%= t("admin.list.search_btn").upcase %>" />
+              <input type="submit" id="searchbar_btn" value="<%= t("admin.list.search").upcase %>" />
             </fieldset>
           </form>
         </div>

--- a/app/views/rails_admin/main/list.html.erb
+++ b/app/views/rails_admin/main/list.html.erb
@@ -41,7 +41,7 @@
           <form action="" method="get">
             <fieldset>
               <input type="text" id="searchBar" name="query" value="<%= query %>"/>
-              <input type="submit" id="searchbar_btn" value="<%= t("admin.list.search_btn").upcase %>" />
+              <input type="submit" id="searchbar_btn" value="<%= t("admin.list.search").upcase %>" />
             </fieldset>
           </form>
         </div>

--- a/config/locales/rails_admin.bg.yml
+++ b/config/locales/rails_admin.bg.yml
@@ -25,7 +25,7 @@ bg:
       edit_action: "Редактирай"
       delete_action: "Изтрий"
       add_new: "Добави"
-      search_btn: "ТЪРСИ"
+      search: "ТЪРСИ"
       select: "Избор на %{name} за редакция"
       show_all: "Покажи всички"
     new:

--- a/config/locales/rails_admin.da.yml
+++ b/config/locales/rails_admin.da.yml
@@ -22,7 +22,7 @@ da:
       edit_action: "Rediger"
       delete_action: "Slet"
       add_new: "Tilføj ny"
-      search_btn: "SØG"
+      search: "SØG"
       select: "Vælg %{name} der skal redigeres"
       show_all: "Vis alle"
     new:

--- a/config/locales/rails_admin.de.yml
+++ b/config/locales/rails_admin.de.yml
@@ -27,7 +27,7 @@ de:
       select_action: "Auswählen"
       delete_selected: "Auswahl löschen"
       add_new: "Neu hinzufügen"
-      search_btn: "Suchen"
+      search: "Suchen"
       select: "Auswählen %{name} zum Bearbeiten"
       show_all: "Alle anzeigen"
     new:

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -27,7 +27,7 @@ en:
       select_action: "Select"
       delete_selected: "Delete selected"
       add_new: "Add new"
-      search_btn: "Search"
+      search: "Search"
       select: "Select %{name} to edit"
       show_all: "Show all"
     new:

--- a/config/locales/rails_admin.es.yml
+++ b/config/locales/rails_admin.es.yml
@@ -22,7 +22,7 @@ es:
       edit_action: "Editar"
       delete_action: "Eliminar"
       add_new: "Agregar"
-      search_btn: "BUSCAR"
+      search: "BUSCAR"
       select: "Seleccione %{name} para editar"
       show_all: "Mostrar todos"
     new:

--- a/config/locales/rails_admin.fi.yml
+++ b/config/locales/rails_admin.fi.yml
@@ -25,7 +25,7 @@ fi:
       select_action: "Valitse"
       delete_selected: "Poista valitut"
       add_new: "Lisää uusi"
-      search_btn: "HAKU"
+      search: "HAKU"
       select: "Valitse muokattava %{name}"
       show_all: "Näytä kaikki"
     new:

--- a/config/locales/rails_admin.fr.yml
+++ b/config/locales/rails_admin.fr.yml
@@ -22,7 +22,7 @@ fr:
       edit_action: "Éditer"
       delete_action: "Effacer"
       add_new: "Nouv"
-      search_btn: "RECHERCHE"
+      search: "RECHERCHE"
       select: "Sélectionner %{name} pour modifier"
       show_all: "Afficher tous"
     new:

--- a/config/locales/rails_admin.lt.yml
+++ b/config/locales/rails_admin.lt.yml
@@ -26,7 +26,7 @@ lt:
       select_action: "Pasirinkti"
       delete_selected: "Pašalinti pasirinktus"
       add_new: "Pridėti"
-      search_btn: "IEŠKOTI"
+      search: "IEŠKOTI"
       select: "Pasirinkti %{name} redagavimui"
       show_all: "Rodyti visus įrašus"
     new:

--- a/config/locales/rails_admin.lv.yml
+++ b/config/locales/rails_admin.lv.yml
@@ -22,7 +22,7 @@ lv:
       edit_action: "Labot"
       delete_action: "Dzēst"
       add_new: "Pievienot jaunu"
-      search_btn: "MEKLĒT"
+      search: "MEKLĒT"
       select: "Izvēlieties %{name}, lai labotu"
       show_all: "Parādīt visu"
     new:

--- a/config/locales/rails_admin.pl.yml
+++ b/config/locales/rails_admin.pl.yml
@@ -25,7 +25,7 @@ pl:
       edit_action: "Edytuj"
       delete_action: "Usuń"
       add_new: "Dodaj"
-      search_btn: "SZUKAJ"
+      search: "SZUKAJ"
       select: "Wybierz %{name} do edycji"
       show_all: "Wybierz wszystkie"
     new:

--- a/config/locales/rails_admin.pt-BR.yml
+++ b/config/locales/rails_admin.pt-BR.yml
@@ -25,7 +25,7 @@ pt-BR:
       edit_action: "Alterar"
       delete_action: "Excluir"
       add_new: "Adicionar"
-      search_btn: "BUSCAR"
+      search: "BUSCAR"
       select: "Selecione %{name} para alterar"
       show_all: "Exibir todos"
       select_action: "Selecionar"

--- a/config/locales/rails_admin.pt-PT.yml
+++ b/config/locales/rails_admin.pt-PT.yml
@@ -24,7 +24,7 @@ pt-PT:
       edit_action: "Editar"
       delete_action: "Remover"
       add_new: "Adicionar"
-      search_btn: "PROCURAR"
+      search: "PROCURAR"
       select: "Selecione %{name} para editar"
       show_all: "Exibir todos"
     new:

--- a/config/locales/rails_admin.ru.yml
+++ b/config/locales/rails_admin.ru.yml
@@ -26,7 +26,7 @@ ru:
       select_action: "Выбрать"
       delete_selected: "Удалить выбранные"
       add_new: "Добавить"
-      search_btn: "ПОИСК"
+      search: "ПОИСК"
       select: "Выберите %{name} для редактирования"
       show_all: "Показать все"
     new:

--- a/config/locales/rails_admin.sv.yml
+++ b/config/locales/rails_admin.sv.yml
@@ -27,7 +27,7 @@ sv:
       select_action: "Marker"
       delete_selected: "Ta bort markerade"
       add_new: "Lägg till ny"
-      search_btn: "SÖK"
+      search: "SÖK"
       select: "Markera %{name} för att redigera"
       show_all: "Visa alla"
     new:

--- a/config/locales/rails_admin.tr.yml
+++ b/config/locales/rails_admin.tr.yml
@@ -25,7 +25,7 @@ tr:
       edit_action: "Düzenle"
       delete_action: "Sil"
       add_new: "Yeni ekle"
-      search_btn: "ARA"
+      search: "ARA"
       select: "Düzenlemek için seçin: %{name}"
       show_all: "Hepsini göster"
     new:

--- a/config/locales/rails_admin.uk.yml
+++ b/config/locales/rails_admin.uk.yml
@@ -22,7 +22,7 @@ uk:
       edit_action: "Редагувати"
       delete_action: "Видалити"
       add_new: "Створити"
-      search_btn: "ПОШУК"
+      search: "ПОШУК"
       select: "Оберіть %{name} для редагування"
       show_all: "Показати все"
     new:


### PR DESCRIPTION
Instead of having an upcase translated string in a yml file (admin.list.search_btn: "SEARCH") that string should be upcased in the view, just like the other cases where translations are e.g. downcased.

The other change i made is renaming the key admin.list.search_btn to admin.list.search because the name implies it is used in a button. But this must not be the case.
