### PR TITLE
Field partial to support Dragonfly file attachments

### DIFF
--- a/app/views/rails_admin/main/_dragonfly_file.html.erb
+++ b/app/views/rails_admin/main/_dragonfly_file.html.erb
@@ -1,0 +1,17 @@
+<%= label_tag("#{field.abstract_model.to_param}_#{field.name}", field.label) %>
+<div class="input">
+  <% if field.bindings[:object].send(field.name) %>
+    <div class="row">
+      <% if field.bindings[:object].send(field.name).mime_type.include? 'image' %>
+        <%= image_tag(field.bindings[:object].send(field.name).url) %><br />
+      <% else %>
+        <%= link_to field.bindings[:object].send(field.name).url, field.bindings[:object].send(field.name).url %> 
+      <% end %>
+    </div>
+  <% end %>
+  <div class="row">
+    <%= file_field(field.abstract_model.to_param, field.name, :class => "fileUploadField #{field.has_errors? ? "errorField" : nil}") %>
+  </div>
+</div>
+
+


### PR DESCRIPTION
I based this on the Paperclip partial. It will either display an image or a link depending on the type of attachment.
