### PR TITLE
CKEditor Download script support for spaces in working folders

### DIFF
--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -12,7 +12,7 @@ namespace :admin do
     puts "Downloading CKEditor (you need to have either wget or curl installed)"
     `curl #{ckeditor_url} -o '#{ckeditor_file}' || wget #{ckeditor_url} -O #{ckeditor_file}`
     puts "Deflating to your public javascript folder"
-    `cd #{destination_folder} && tar xvfz #{ckeditor_file}`
+    `cd "#{destination_folder}" && tar xvfz #{ckeditor_file}`
     puts "Finished."
   end
 end


### PR DESCRIPTION
Hi, my working folder path had a space in it ("Heavyweight HD") and the ckeditor download script didn't support this. The fix is easy: surround the destination_folder variable with quotes.
