### PR TITLE
Fix for issue 312

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -5,7 +5,7 @@ module RailsAdmin
   class Engine < Rails::Engine
     initializer "static assets" do |app|
       if app.config.serve_static_assets
-        app.middleware.insert 0, ::ActionDispatch::Static, "#{root}/public"
+        app.middleware.insert_after ::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public"
       end
     end
     


### PR DESCRIPTION
Make rails admin static assets override everything apart from static assets in the main application. This allows applications to override static files.
