### PR TITLE
Fix for issue 333

### DIFF
--- a/app/views/rails_admin/main/_submit_buttons.html.erb
+++ b/app/views/rails_admin/main/_submit_buttons.html.erb
@@ -3,10 +3,12 @@
     <%= submit_tag t("admin.new.save"), :class => "ra-button ui-state-highlight", :name => "_save" %>
   </li>
 
-  <li class="save add">
-    <%= submit_tag t("admin.new.save_and_add_another"), :class => "ra-button", :name => "_add_another" %>
-  </li>
-
+  <% if authorized? :new, @abstract_model %>
+    <li class="save add">
+      <%= submit_tag t("admin.new.save_and_add_another"), :class => "ra-button", :name => "_add_another" %>
+    </li>
+  <% end %>
+  
   <li class="save edit">
     <%= submit_tag t("admin.new.save_and_edit"), :class => "ra-button", :name => "_add_edit" %>
   </li>


### PR DESCRIPTION
The Save and add another button appears to be displayed on the edit screen even if the user is not authorized to create new record.
