### PR TITLE
Refer to group associations by association name

### DIFF
--- a/lib/rails_admin/config/fields/group.rb
+++ b/lib/rails_admin/config/fields/group.rb
@@ -12,7 +12,7 @@ module RailsAdmin
 
         def initialize(parent, name)
           super(parent)
-          @name = name
+          @name = name.to_s.gsub(' ', '_').downcase.to_sym
         end
 
         # Defines a configuration for a field by proxying parent's field method

--- a/spec/requests/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/requests/config/edit/rails_admin_config_edit_spec.rb
@@ -35,6 +35,21 @@ describe "RailsAdmin Config DSL Edit Section" do
       response.should_not have_tag("input#team_revenue")
     end
 
+    it "should hide association groupings by the name of the association" do
+      RailsAdmin.config Team do
+        edit do
+          group :players do
+            hide
+          end
+        end
+      end
+      get rails_admin_new_path(:model_name => "team")
+      # Should not have the group header
+      response.should_not have_tag("legend", :content => "Players")
+      # Should not have any of the group's fields either
+      response.should_not have_tag("select#associations_players")
+    end
+
     it "should be renameable" do
       RailsAdmin.config Team do
         edit do


### PR DESCRIPTION
Hello there,

First off, I'd just like to thank you all for all the hard work done to make rails_admin so great. While I was using it I was trying to get an association group to hide in the edit view. The documentation states that you should be able to do the following:

```
config.model Team do
  edit do
    group :players do
      hide
    end
  end
end
```

However, I wasn't able to get this to work unless I used :Players instead of :players. This isn't a huge deal but it gets pretty inconsistent with rails naming conventions when you start to have, for example, model names like SomeFans. Ideally this would work like following:  
    group :some_fans
However, you have to do the following in order to achieve the desired functionality:  
    group :"Some Fans"

I've included a really small patch with a test that exposes the issue. However, it's probably a bit of a hack seeing as I don't know the architecture as well as I'm sure you all do. This is my first pull request on an open source project and I really appreciate you reading this.

Thanks,  
Tony Schneider  
twitter: @tonywok
