### PR TITLE
Simple field name change

### DIFF
--- a/app/models/rails_admin/blank_history.rb
+++ b/app/models/rails_admin/blank_history.rb
@@ -2,14 +2,14 @@ module RailsAdmin
   class BlankHistory
     attr_accessor :number, :month, :year
     def initialize(month, year)
-      @number = 0
+      @record_count = 0
       @month = month
       @year = year
     end
 
     # Make BlankHistory look like History when it gets JSON-serialized.
     def to_hash(*a)
-      {"history" => {"number" => @number, "month" => @month, "year" => @year}}
+      {"history" => {"record_count" => @record_count, "month" => @month, "year" => @year}}
     end
 
   end

--- a/app/models/rails_admin/history.rb
+++ b/app/models/rails_admin/history.rb
@@ -14,18 +14,18 @@ module RailsAdmin
         sql_in = (mstart + 1..12).to_a.join(", ")
         sql_in_two = (1..mstop).to_a.join(", ")
 
-        results = History.find_by_sql("select count(*) as number, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystart} group by year, month")
-        results_two = History.find_by_sql("select count(*) as number, year, month from rails_admin_histories where month IN (#{sql_in_two}) and year = #{ystop} group by year, month")
+        results = History.find_by_sql("select count(*) as record_count, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystart} group by year, month")
+        results_two = History.find_by_sql("select count(*) as record_count, year, month from rails_admin_histories where month IN (#{sql_in_two}) and year = #{ystop} group by year, month")
 
         results.concat(results_two)
       else
         sql_in =  (mstart + 1..mstop).to_a.join(", ")
 
-        results = History.find_by_sql("select count(*) as number, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystart} group by year, month")
+        results = History.find_by_sql("select count(*) as record_count, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystart} group by year, month")
       end
 
       results.each do |result|
-        result.number = result.number.to_i
+        result.record_count = result.record_count.to_i
       end
 
       add_blank_results(results, mstart, ystart)


### PR DESCRIPTION
Hi All,

I tried to get rails_admin running with an Oracle back-end and quickly realized that the histories model was using 'number' as the label for the record count field.  This breaks on Oracle because number is a reserved word.  I didn't feel the next the update docs or specs simply because it's a label change that won't effect either.  If you disagree, or would rather wording I used, just let me know and I'll fix it and re-submit the pull request.

Thanks,

Curtis

P.S.  I'm not using Oracle by choice :)
