### PR TITLE
Whitelist model config for enhanced security

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -108,6 +108,29 @@ You can exclude models from RailsAdmin by appending those models to `excluded_mo
       config.excluded_models << ClassName
     end
 
+**Whitelist Approach**
+
+By default, RailsAdmin automatically discovers all the models in the system and adds them to its list of models to
+be accessible through RailsAdmin. The `excluded_models` configuration above permits the blacklisting of individual model classes.
+
+If you prefer a whitelist approach, then you can use the `included_models` configuration option instead:
+
+    RailsAdmin.config do |config|
+      config.included_models = [Class1, Class2, Class3]
+    end
+
+Only the models explicitly listed will be put under RailsAdmin access, and the auto-discovery of models is skipped.
+
+The blacklist is effective on top of that, still, so that if you also have:
+
+    RailsAdmin.config do |config|
+      config.excluded_models = [Class1]
+    end
+
+then only `Class2` and `Class3` would be made available to RailsAdmin.
+
+The whitelist approach may be useful if RailsAdmin is used only for a part of the application and you want to make
+sure that new models are not automatically added to RailsAdmin, e.g. because of security concerns. 
 
 ### Model Class and Instance Labels ###
 

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -15,6 +15,14 @@ module RailsAdmin
     @@excluded_models = []
     mattr_accessor :excluded_models
 
+    # Configuration option to specify a whitelist of models you want to RailsAdmin to work with.
+    # The excluded_models list applies against the whitelist as well and further reduces the models
+    # RailsAdmin will use.
+    # If included_models is left empty ([]), then RailsAdmin will automatically use all the models
+    # in your application (less any excluded_models you may have specified).
+    @@included_models = []
+    mattr_accessor :included_models
+
     # Configuration option to specify which method names will be searched for
     # to be used as a label for object records. This defaults to [:name, :title]
     mattr_accessor :label_methods

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -25,7 +25,8 @@ module RailsAdmin
       end
 
       def excluded?
-        @excluded ||= !RailsAdmin::Config.excluded_models.find {|klass| klass.to_s == abstract_model.model.name }.nil?
+        return @excluded unless @excluded.nil?
+        @excluded = !RailsAdmin::AbstractModel.all.map(&:model).include?(abstract_model.model)
       end
 
       # Configure create and update views as a bulk operation with given block

--- a/spec/requests/rails_admin_spec.rb
+++ b/spec/requests/rails_admin_spec.rb
@@ -65,4 +65,52 @@ describe "RailsAdmin" do
     end
   end
 
+  describe "model whitelist:" do
+
+    before do
+      RailsAdmin::AbstractModel.instance_variable_get("@models").clear
+      RailsAdmin::Config.excluded_models = []
+      RailsAdmin::Config.included_models = []
+      RailsAdmin::Config.reset
+    end
+
+    after :all do
+      RailsAdmin::AbstractModel.instance_variable_get("@models").clear
+      RailsAdmin::Config.excluded_models = []
+      RailsAdmin::Config.included_models = []
+      RailsAdmin::Config.reset
+    end
+
+    it 'should only use included models' do
+      RailsAdmin::Config.included_models = [Team, League]
+      RailsAdmin::AbstractModel.all.map(&:model).should == [League, Team] #it gets sorted
+    end
+
+    it 'should not restrict models if included_models is left empty' do
+      RailsAdmin::Config.included_models = []
+      RailsAdmin::AbstractModel.all.map(&:model).should include(Team, League)
+    end
+
+    it 'should further remove excluded models (whitelist - blacklist)' do
+      RailsAdmin::Config.excluded_models = [Team]
+      RailsAdmin::Config.included_models = [Team, League]
+      RailsAdmin::AbstractModel.all.map(&:model).should == [League]
+    end
+
+    it 'should always exclude history' do
+      RailsAdmin::AbstractModel.all.map(&:model).should_not include(RailsAdmin::History)
+    end
+
+    it 'excluded? returns true for any model not on the list' do
+      RailsAdmin::Config.included_models = [Team, League]
+
+      team_config = RailsAdmin.config(RailsAdmin::AbstractModel.new('Team'))
+      fan_config = RailsAdmin.config(RailsAdmin::AbstractModel.new('Fan'))
+
+      fan_config.should be_excluded
+      team_config.should_not be_excluded
+    end
+    
+  end
+
 end


### PR DESCRIPTION
The current mechanism for RailsAdmin to auto-discover all the models in the system causes security concerns for us. We don't want all the possible models accessible via RailsAdmin. The `excluded_models` config option helps, but amounts to a black list approach where developers would have to remember to update this list whenever new models are added to the application. That was unsatisfactory for us.

We added a config option, `included_models` as a whitelist approach for listing models to be accessible by RailsAdmin.

The default is still auto_discovery + excluded models. The whitelist approach takes effect only when a non-empty array is assigned to `included_models`. In that case, the auto-discovery of models is skipped. The `excluded_models` list is honored on top of the `included_models` list.

Note: This patch passes specs when used with Ruby 1.9.2. For 1.8.7 (tested with REE only), it needs the other pull request I just submitted: https://github.com/sferik/rails_admin/pull/347

Otherwise, I see the following error when running `rake spec`:
    Failures:

```
1) RailsAdmin polymorphic associations should be editable
   Failure/Error: get rails_admin_edit_path(:model_name => "comment", :id => @comment.id)
   ActionView::Template::Error:
     stack level too deep
   # ./lib/rails_admin/config/fields/types/polymorphic_association.rb:38:in `label'
```
