### PR TITLE
Patch handling of namespaced models like Cms::BasicPage. Fixes #352, http

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -17,7 +17,7 @@ module RailsAdmin
     end
 
     def to_model_name(param)
-      parts = param.split("::")
+      parts = param.split("~")
       parts.map{|x| x == parts.last ? x.singularize.camelize : x.camelize}.join("::")
     end
 

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -273,7 +273,7 @@ module RailsAdmin
     end
 
     def get_attributes
-      @attributes = params[@abstract_model.to_param.singularize] || {}
+      @attributes = params[@abstract_model.to_param.singularize.gsub('~','_')] || {}
       @attributes.each do |key, value|
         # Deserialize the attribute if attribute is serialized
         if @abstract_model.model.serialized_attributes.keys.include?(key) and value.is_a? String

--- a/lib/rails_admin/generic_support.rb
+++ b/lib/rails_admin/generic_support.rb
@@ -4,7 +4,7 @@ module RailsAdmin
     module GenericSupport
       def to_param
         parts = model.to_s.split("::")
-        parts.map{|x| x == parts.last ? x.underscore.pluralize : x.underscore}.join("::")
+        parts.map{|x| x == parts.last ? x.underscore.pluralize : x.underscore}.join("~")
       end
 
       def pretty_name

--- a/spec/dummy_app/app/models/cms.rb
+++ b/spec/dummy_app/app/models/cms.rb
@@ -1,0 +1,5 @@
+module Cms
+  def self.table_name_prefix
+    'cms_'
+  end
+end

--- a/spec/dummy_app/app/models/cms/basic_page.rb
+++ b/spec/dummy_app/app/models/cms/basic_page.rb
@@ -1,0 +1,5 @@
+class Cms::BasicPage < ActiveRecord::Base
+
+  validates :title, :content, :presence => true
+
+end

--- a/spec/dummy_app/db/migrate/20110328193014_create_cms_basic_pages.rb
+++ b/spec/dummy_app/db/migrate/20110328193014_create_cms_basic_pages.rb
@@ -1,0 +1,14 @@
+class CreateCmsBasicPages < ActiveRecord::Migration
+  def self.up
+    create_table :cms_basic_pages do |t|
+      t.string :title
+      t.text :content
+
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :cms_basic_pages
+  end
+end

--- a/spec/requests/basic/create/rails_admin_namespaced_model_create_spec.rb
+++ b/spec/requests/basic/create/rails_admin_namespaced_model_create_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe "RailsAdmin Namespaced Model Create" do
+
+  before(:each) do
+    get rails_admin_new_path(:model_name => "cms~basic_page")
+
+    fill_in "cms_basic_page[title]", :with => "Hello"
+    fill_in "cms_basic_page[content]", :with => "World"
+  end
+
+  it 'should be successful' do
+    @req  = click_button "Save"
+    @req.should be_successful
+  end
+
+  it 'should create object with correct attributes' do
+    expect {
+      @req  = click_button "Save"
+    }.to change(Cms::BasicPage, :count).by(1)
+  end
+
+end

--- a/spec/requests/basic/new/rails_admin_namespaced_model_new_spec.rb
+++ b/spec/requests/basic/new/rails_admin_namespaced_model_new_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe "RailsAdmin Namespaced Model New" do
+
+  describe "AbstractModel#to_param" do
+    it 'turns namespaces into prefixes with ~' do
+      RailsAdmin::AbstractModel.new("Cms::BasicPage").to_param.should == 'cms~basic_pages'
+    end
+  end
+
+  describe "ApplicationController#to_model_name" do
+    it 'turns cms~basic_pages into Cms::BasicPage' do
+      RailsAdmin::ApplicationController.new.to_model_name('cms~basic_pages').should == 'Cms::BasicPage'
+    end
+  end
+
+  describe "GET /admin/cms_basic_page/new" do
+    before(:each) do
+      get rails_admin_new_path(:model_name => "cms~basic_page")
+    end
+
+    it "should respond successfully", :only =>true do
+      response.should be_successful
+    end
+
+    it 'should have correct input field names' do
+      response.should have_selector("label[for=cms_basic_page_title]")
+      response.should have_selector("input#cms_basic_page_title[name='cms_basic_page[title]']")
+      response.should have_selector("label[for=cms_basic_page_content]")
+      response.should have_selector("textarea#cms_basic_page_content[name='cms_basic_page[content]']")
+    end
+  end
+end


### PR DESCRIPTION
Patch handling of namespaced models like Cms::BasicPage. Fixes #352, http://goo.gl/H1mLV
1. Don't generate urls with :: in them, that's not legal (see http://www.faqs.org/rfcs/rfc2396.html Section 2.2, 2.3). Use ~ instead. This is still hacky. Ideally we should treat namespaces as proper URL components, e.g. /cms/basic_page/5/edit, but that would have been a bigger change.
2. Rails will automatically change model names containing `::` into `_` when generating input field names. A recent commit started using Rails's native form helpers to generate input field names which completely broke namespaced model support. This patch fixes this by gsub'ing "~" -> "_" in incoming parameters. This is a stop gap measure pending a wider resolution of the namespace issue. This fixes #352
3. Added test support for namespaced models which was lacking and probably the reason why previous support regressed.

This is working for now, but down the road, we should probably contemplate a more permanent solution for namespaced models.
