### PR TITLE
Clean dummy application's schema

### DIFF
--- a/spec/dummy_app/app/models/league.rb
+++ b/spec/dummy_app/app/models/league.rb
@@ -3,4 +3,8 @@ class League < ActiveRecord::Base
 
   has_many(:divisions)
   has_many(:teams)
+
+  def teams
+  	Team.joins(:division).where("divisions.league_id" => id)
+  end
 end

--- a/spec/dummy_app/app/models/team.rb
+++ b/spec/dummy_app/app/models/team.rb
@@ -1,5 +1,4 @@
 class Team < ActiveRecord::Base
-  validates_numericality_of(:league_id, :only_integer => true)
   validates_numericality_of(:division_id, :only_integer => true)
   validates_presence_of(:manager)
   validates_numericality_of(:founded, :only_integer => true)
@@ -8,7 +7,6 @@ class Team < ActiveRecord::Base
   validates_numericality_of(:win_percentage)
   validates_numericality_of(:revenue, :allow_nil => true)
 
-  belongs_to(:league)
   belongs_to(:division)
   has_many(:players)
   has_and_belongs_to_many :fans

--- a/spec/dummy_app/db/migrate/20110329183136_remove_league_id_from_teams.rb
+++ b/spec/dummy_app/db/migrate/20110329183136_remove_league_id_from_teams.rb
@@ -1,0 +1,9 @@
+class RemoveLeagueIdFromTeams < ActiveRecord::Migration
+  def self.up
+    remove_column :teams, :league_id
+  end
+
+  def self.down
+    add_column :teams, :league_id, :integer
+  end
+end

--- a/spec/lib/abstract_object_spec.rb
+++ b/spec/lib/abstract_object_spec.rb
@@ -64,11 +64,10 @@ describe "AbstractObject" do
       let(:object) { RailsAdmin::AbstractObject.new league }
       let(:name) { "Awesome League" }
       let(:divisions) { [Division.create(:name => "D1", :league_id => -1), Division.create(:name => "D2", :league_id => -1)] }
-      let(:teams) { [Team.create(:name => "T1", :manager => "M1", :founded => 1, :wins => 1, :losses => 1, :win_percentage => 1, :league_id => -1, :division_id => -1), Team.create(:name => "T2", :manager => "M2", :founded => 1, :wins => 1, :losses => 1, :win_percentage => 1, :league_id => -1, :division_id => -1)] }
 
       before do
         object.attributes = { :name  => name }
-        object.associations = { :teams => teams.map(&:id), :divisions => divisions }
+        object.associations = { :divisions => divisions }
       end
 
       it "should create a League with given attributes and associations" do
@@ -76,7 +75,6 @@ describe "AbstractObject" do
         league.reload
         league.name.should == name
         league.divisions.should == divisions
-        league.teams.should == teams
       end
     end
   end
@@ -87,7 +85,7 @@ describe "AbstractObject" do
       let(:suspended) { true }
       let(:player) { Player.create(:suspended => true, :number => 42, :name => name) }
       let(:object) { RailsAdmin::AbstractObject.new player }
-      let(:new_team) { Team.create(:name => "T1", :manager => "M1", :founded => 1, :wins => 1, :losses => 1, :win_percentage => 1, :league_id => -1, :division_id => -1) }
+      let(:new_team) { Team.create(:name => "T1", :manager => "M1", :founded => 1, :wins => 1, :losses => 1, :win_percentage => 1, :division_id => -1) }
       let(:new_suspended) { false }
       let(:new_draft) { nil }
       let(:new_number) { player.number + 29 }

--- a/spec/requests/basic/create/rails_admin_basic_create_spec.rb
+++ b/spec/requests/basic/create/rails_admin_basic_create_spec.rb
@@ -95,29 +95,29 @@ describe "RailsAdmin Basic Create" do
 
   describe "create with has-many association" do
     before(:each) do
-      @teams = []
+      @divisions = []
       (1..3).each do |number|
-        @teams << RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        @divisions << RailsAdmin::AbstractModel.new("Division").create(:league_id => rand(99999), :name => "Division #{number}")
       end
 
       get rails_admin_new_path(:model_name => "league")
 
       fill_in "league[name]", :with => "National League"
 
-      select @teams[0].name, :from => "associations_teams"
+      select @divisions[0].name, :from => "associations_divisions"
       @req = click_button "Save"
 
       @league = RailsAdmin::AbstractModel.new("League").first
     end
 
     it "should create an object with correct associations" do
-      @teams[0].reload
-      @league.teams.should include(@teams[0])
+      @divisions[0].reload
+      @league.divisions.should include(@divisions[0])
     end
 
     it "should not create an object with incorrect associations" do
-      @league.teams.should_not include(@teams[1])
-      @league.teams.should_not include(@teams[2])
+      @league.divisions.should_not include(@divisions[1])
+      @league.divisions.should_not include(@divisions[2])
     end
   end
 
@@ -125,33 +125,33 @@ describe "RailsAdmin Basic Create" do
     before(:each) do
       @teams = []
       (1..3).each do |number|
-        @teams << RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        @teams << RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
 
-      get rails_admin_new_path(:model_name => "league")
+      get rails_admin_new_path(:model_name => "fan")
 
-      fill_in "league[name]", :with => "National League"
+      fill_in "fan[name]", :with => "John Doe"
 
       select @teams[0].name, :from => "associations_teams"
       @req = click_button "Save"
 
-      @league = RailsAdmin::AbstractModel.new("League").first
+      @fan = RailsAdmin::AbstractModel.new("Fan").first
     end
 
     it "should create an object with correct associations" do
       @teams[0].reload
-      @league.teams.should include(@teams[0])
+      @fan.teams.should include(@teams[0])
     end
 
     it "should not create an object with incorrect associations" do
-      @league.teams.should_not include(@teams[1])
-      @league.teams.should_not include(@teams[2])
+      @fan.teams.should_not include(@teams[1])
+      @fan.teams.should_not include(@teams[2])
     end
   end
 
   describe "create with uniqueness constraint violated", :given => "a player exists" do
     before(:each) do
-      @team =  RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team 1", :manager => "Manager 1", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+      @team =  RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team 1", :manager => "Manager 1", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       @player = RailsAdmin::AbstractModel.new("Player").create(:team_id => @team.id, :number => 1, :name => "Player 1")
 
       get rails_admin_new_path(:model_name => "player")

--- a/spec/requests/basic/delete/rails_admin_basic_delete_spec.rb
+++ b/spec/requests/basic/delete/rails_admin_basic_delete_spec.rb
@@ -30,7 +30,7 @@ describe "RailsAdmin Basic Delete" do
   describe "delete with missing label" do
     before(:each) do
       @league = RailsAdmin::AbstractModel.new("League").create(:name => "League 1")
-      @team = RailsAdmin::AbstractModel.new("Team").create(:league_id => @league.id, :division_id => rand(99999), :manager => "Manager 1", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+      @team = RailsAdmin::AbstractModel.new("Division").create(:league_id => @league.id, :name => "Division 1")
 
       get rails_admin_delete_path(:model_name => "league", :id => @league.id)
     end

--- a/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
@@ -49,7 +49,7 @@ describe "RailsAdmin Basic Edit" do
     before(:each) do
       @teams = []
       (1..3).each do |number|
-        @teams << RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        @teams << RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
       @player = RailsAdmin::AbstractModel.new("Player").create(:team_id => rand(99999), :number => 1, :name => "Player 1")
       get rails_admin_edit_path(:model_name => "player", :id => @player.id)
@@ -67,7 +67,7 @@ describe "RailsAdmin Basic Edit" do
   describe "edit with has-and-belongs-to-many association" do
     before(:each) do
       teams = (1..3).collect do |number|
-        RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
       fan = RailsAdmin::AbstractModel.new("Fan").create(:name => "Fan 1")
       fan.teams << teams[0]
@@ -103,7 +103,7 @@ describe "RailsAdmin Basic Edit" do
 
       @teams = []
       (1..3).each do |number|
-        @teams << RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        @teams << RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
 
       get rails_admin_edit_path(:model_name => "player", :id => @player.id)

--- a/spec/requests/basic/new/rails_admin_basic_new_spec.rb
+++ b/spec/requests/basic/new/rails_admin_basic_new_spec.rb
@@ -46,7 +46,7 @@ describe "RailsAdmin Basic New" do
   describe "GET /admin/player/new with has-many association" do
     before(:each) do
       (1..3).each do |number|
-        RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
 
       get rails_admin_new_path(:model_name => "player")
@@ -64,7 +64,7 @@ describe "RailsAdmin Basic New" do
   describe "GET /admin/team/:id/fans/new with has-and-belongs-to-many association" do
     before(:each) do
       (1..3).each do |number|
-        RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
 
       get rails_admin_new_path(:model_name => "fan")
@@ -82,7 +82,7 @@ describe "RailsAdmin Basic New" do
   describe "GET /admin/player/new with missing label" do
     before(:each) do
       (1..3).each do |number|
-        RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
       get rails_admin_new_path(:model_name => "player")
     end

--- a/spec/requests/basic/update/rails_admin_basic_update_spec.rb
+++ b/spec/requests/basic/update/rails_admin_basic_update_spec.rb
@@ -101,16 +101,16 @@ describe "RailsAdmin Basic Update" do
     before(:each) do
       @league = RailsAdmin::AbstractModel.new("League").create(:name => "League 1")
 
-      @teams = []
+      @divisions = []
       (1..3).each do |number|
-        @teams << RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        @divisions << RailsAdmin::AbstractModel.new("Division").create(:league_id => rand(99999), :name => "Division #{number}")
       end
 
       get rails_admin_edit_path(:model_name => "league", :id => @league.id)
 
       fill_in "league[name]", :with => "National League"
 
-      select @teams[0].name, :from => "associations_teams"
+      select @divisions[0].name, :from => "associations_divisions"
 
       response = click_button "Save"
       @league = RailsAdmin::AbstractModel.new("League").first
@@ -122,34 +122,34 @@ describe "RailsAdmin Basic Update" do
     end
 
     it "should update an object with correct associations" do
-      @teams[0].reload
-      @league.teams.should include(@teams[0])
+      @divisions[0].reload
+      @league.divisions.should include(@divisions[0])
     end
 
     it "should not update an object with incorrect associations" do
-      @league.teams.should_not include(@teams[1])
-      @league.teams.should_not include(@teams[2])
+      @league.divisions.should_not include(@divisions[1])
+      @league.divisions.should_not include(@divisions[2])
     end
 
     it "should log a history message about the update" do
-      @histories.collect(&:message).should include("Added Teams ##{@teams[0].id} associations, Changed name")
+      @histories.collect(&:message).should include("Added Divisions ##{@divisions[0].id} associations, Changed name")
     end
 
     describe "removing has-many associations" do
       before(:each) do
         get rails_admin_edit_path(:model_name => "league", :id => @league.id)
-        unselect @teams[0].name, :from => "associations_teams"
+        unselect @divisions[0].name, :from => "associations_divisions"
         response = click_button "Save"
         @league = RailsAdmin::AbstractModel.new("League").first
         @histories.reload
       end
 
       it "should have empty associations" do
-        @league.teams.should be_empty
+        @league.divisions.should be_empty
       end
 
       it "should log a message to history about removing associations" do
-        @histories.collect(&:message).should include("Removed Teams ##{@teams[0].id} associations")
+        @histories.collect(&:message).should include("Removed Divisions ##{@divisions[0].id} associations")
       end
     end
   end
@@ -157,7 +157,7 @@ describe "RailsAdmin Basic Update" do
   describe "update with has-and-belongs-to-many association" do
     before(:each) do
       @teams = (1..3).collect do |number|
-        RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+        RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team #{number}", :manager => "Manager #{number}", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       end
 
       @fan = RailsAdmin::AbstractModel.new("Fan").create(:name => "Fan 1")

--- a/spec/requests/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/requests/config/edit/rails_admin_config_edit_spec.rb
@@ -21,7 +21,6 @@ describe "RailsAdmin Config DSL Edit Section" do
       # Should not have the group header
       response.should_not have_tag("legend", :content => "Hidden Group")
       # Should not have any of the group's fields either
-      response.should_not have_tag("select#team_league_id")
       response.should_not have_tag("select#team_division_id")
       response.should_not have_tag("input#team_name")
       response.should_not have_tag("input#team_logo_url")
@@ -72,7 +71,6 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
           group :belongs_to_associations do
             label "Belong's to associations"
-            field :league_id
             field :division_id
           end
         end
@@ -83,9 +81,8 @@ describe "RailsAdmin Config DSL Edit Section" do
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("#team_name")
         elements[1].should have_tag("#team_logo_url")
-        elements[2].should have_tag("#team_league_id")
-        elements[3].should have_tag("#team_division_id")
-        elements.length.should == 4
+        elements[2].should have_tag("#team_division_id")
+        elements.length.should == 3
       end
     end
 
@@ -93,7 +90,6 @@ describe "RailsAdmin Config DSL Edit Section" do
       RailsAdmin.config Team do
         edit do
           group :default do
-            field :league_id
             field :name
             field :logo_url
           end
@@ -109,7 +105,6 @@ describe "RailsAdmin Config DSL Edit Section" do
       end
       get rails_admin_new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
-        elements.should have_tag("label", :content => "League")
         elements.should have_tag("label", :content => "Name")
         elements.should have_tag("label", :content => "Logo url")
         elements.should have_tag("label", :content => "Division")
@@ -123,7 +118,6 @@ describe "RailsAdmin Config DSL Edit Section" do
 
     it "should show all by default" do
       get rails_admin_new_path(:model_name => "team")
-      response.should have_tag("select#team_league_id")
       response.should have_tag("select#team_division_id")
       response.should have_tag("input#team_name")
       response.should have_tag("input#team_logo_url")
@@ -158,17 +152,15 @@ describe "RailsAdmin Config DSL Edit Section" do
     it "should only show the defined fields if some fields are defined" do
       RailsAdmin.config Team do
         edit do
-          field :league_id
           field :division_id
           field :name
         end
       end
       get rails_admin_new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
-        elements[0].should have_tag("#team_league_id")
-        elements[1].should have_tag("#team_division_id")
-        elements[2].should have_tag("#team_name")
-        elements.length.should == 3
+        elements[0].should have_tag("#team_division_id")
+        elements[1].should have_tag("#team_name")
+        elements.length.should == 2
       end
     end
 
@@ -215,7 +207,6 @@ describe "RailsAdmin Config DSL Edit Section" do
       end
       get rails_admin_new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
-        elements.should have_tag("label", :content => "League")
         elements.should have_tag("label", :content => "Division")
         elements.should have_tag("label", :content => "Name (STRING)")
         elements.should have_tag("label", :content => "Logo url (STRING)")
@@ -242,7 +233,6 @@ describe "RailsAdmin Config DSL Edit Section" do
       end
       get rails_admin_new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
-        elements.should have_tag("label", :content => "League")
         elements.should have_tag("label", :content => "Division")
         elements.should have_tag("label", :content => "Name (STRING)")
         elements.should have_tag("label", :content => "Logo url (STRING)")
@@ -286,7 +276,6 @@ describe "RailsAdmin Config DSL Edit Section" do
       end
       get rails_admin_new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
-        elements.should have_tag("label", :content => "League")
         elements.should have_tag("label", :content => "Division")
         elements.should_not have_tag("label", :content => "Name")
         elements.should_not have_tag("label", :content => "Logo url")
@@ -313,7 +302,6 @@ describe "RailsAdmin Config DSL Edit Section" do
       end
       get rails_admin_new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
-        elements.should have_tag("label", :content => "League")
         elements.should have_tag("label", :content => "Division")
         elements.should_not have_tag("label", :content => "Name")
         elements.should_not have_tag("label", :content => "Logo url")

--- a/spec/requests/config/list/rails_admin_config_list_spec.rb
+++ b/spec/requests/config/list/rails_admin_config_list_spec.rb
@@ -460,7 +460,7 @@ describe "RailsAdmin Config DSL List Section" do
         end
       end
 
-      team = RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Team I", :manager => "Manager I", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+      team = RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Team I", :manager => "Manager I", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
 
       RailsAdmin::AbstractModel.new("Player").create(:name => 'Player I', :number => 1, :team => team)
       RailsAdmin::AbstractModel.new("Player").create(:name => 'Player II', :number => 2, :team => team)

--- a/spec/requests/rails_admin_spec.rb
+++ b/spec/requests/rails_admin_spec.rb
@@ -46,7 +46,7 @@ describe "RailsAdmin" do
 
   describe "polymorphic associations" do
     before :each do
-      @team = RailsAdmin::AbstractModel.new("Team").create(:league_id => rand(99999), :division_id => rand(99999), :name => "Commentable Team", :manager => "Manager", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
+      @team = RailsAdmin::AbstractModel.new("Team").create(:division_id => rand(99999), :name => "Commentable Team", :manager => "Manager", :founded => 1869 + rand(130), :wins => (wins = rand(163)), :losses => 162 - wins, :win_percentage => ("%.3f" % (wins.to_f / 162)).to_f)
       @comment = RailsAdmin::AbstractModel.new("Comment").create(:content => "Comment on a team", :commentable => @team)
     end
 


### PR DESCRIPTION
I'm not sure what purpose the duplicating relation `team->league` served, but I got rid of it as, to the best of my knowledge, the existing `team->division->league` is the proper relation.

Why I'm going through all this trouble? The dummy application contained within test suite is about to be used as demo.railsadmin.org test application so I'm trying to tidy it up a bit... Next up - proper fixtures.

PS. As a by-product `create with has-and-belongs-to-many association` test is now actually testing against an HABTM association instead of a has_many association.
