### PR TITLE
Resize dragonfly images in form

### DIFF
--- a/app/views/rails_admin/main/_dragonfly_file.html.erb
+++ b/app/views/rails_admin/main/_dragonfly_file.html.erb
@@ -4,7 +4,7 @@
    <% if field.bindings[:object].send(field.name) %>
      <div class="row">
        <% if field.bindings[:object].send(field.name).mime_type.include? 'image' %>
-         <%= image_tag(field.bindings[:object].send(field.name).url) %><br />
+         <%= image_tag(field.bindings[:object].send(field.name).thumb("450x100").url) %><br />
        <% else %>
          <%= link_to field.bindings[:object].send(field.name).url, field.bindings[:object].send(field.name).url %>
        <% end %>


### PR DESCRIPTION
Currently, RailsAdmin will show the full resolution of an image when uploaded through Dragonfly. This tiny patch resizes Dragonfly images to 450x100, which I found to be a sensible default.
