### PR TITLE
Ignore field when property type is nil

### DIFF
--- a/lib/rails_admin/config/fields.rb
+++ b/lib/rails_admin/config/fields.rb
@@ -22,7 +22,7 @@ module RailsAdmin
           fields << RailsAdmin::Config::Fields::Types.load("#{properties[:type]}_association").new(parent, properties[:name], properties)
         # If it's a concrete column
         elsif !properties.has_key?(:parent_model)
-          fields << RailsAdmin::Config::Fields::Types.load(properties[:type]).new(parent, properties[:name], properties)
+          fields << RailsAdmin::Config::Fields::Types.load(properties[:type]).new(parent, properties[:name], properties) unless properties[:type].blank?
         end
       end
 


### PR DESCRIPTION
I encountered this in Postgres project that is using search vectors. The property type was coming in as nil for this field and subsequently blows up Rails Admin. I've set it to ignore this column entirely if the property type is nil.
