### PR TITLE
Issue #390 revisited: Edge case when start month is 12 (December) -- get_history_for_dates 

### DIFF
--- a/app/controllers/rails_admin/history_controller.rb
+++ b/app/controllers/rails_admin/history_controller.rb
@@ -15,7 +15,7 @@ module RailsAdmin
     end
 
     def slider
-      if params[:from].nil? or params[:to].nil?
+      if params[:from].blank? or params[:to].blank?
         not_found
       else
         render :json => AbstractHistory.history_summaries(params[:from], params[:to])

--- a/app/models/rails_admin/history.rb
+++ b/app/models/rails_admin/history.rb
@@ -9,26 +9,22 @@ module RailsAdmin
     }
 
     def self.get_history_for_dates(mstart, mstop, ystart, ystop)
-      sql_in = ""
-      if mstart > mstop
-        # fix by Dan Choi
-        #sql_in = (mstart + 1..12).to_a.join(", ") <== possible culprit May month bug
-        sql_in = (mstart..12).to_a.join(", ")
+      if mstart > mstop && mstart < 12
+        sql_in = ((mstart + 1)..12).to_a.join(", ")
         sql_in_two = (1..mstop).to_a.join(", ")
 
-        results = History.find_by_sql("select count(*) as number, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystart} group by year, month")
-        results_two = History.find_by_sql("select count(*) as number, year, month from rails_admin_histories where month IN (#{sql_in_two}) and year = #{ystop} group by year, month")
+        results = History.find_by_sql("select count(*) as record_count, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystart} group by year, month")
+        results_two = History.find_by_sql("select count(*) as record_count, year, month from rails_admin_histories where month IN (#{sql_in_two}) and year = #{ystop} group by year, month")
 
         results.concat(results_two)
       else
-        #sql_in =  (mstart + 1..mstop).to_a.join(", ")  <=== may be defective too
-        sql_in =  (mstart..mstop).to_a.join(", ")
+        sql_in = ((mstart == 12 ? 1 : mstart + 1)..mstop).to_a.join(", ")
 
-        results = History.find_by_sql("select count(*) as number, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystart} group by year, month")
+        results = History.find_by_sql("select count(*) as record_count, year, month from rails_admin_histories where month IN (#{sql_in}) and year = #{ystop} group by year, month")
       end
 
       results.each do |result|
-        result.number = result.number.to_i
+        result.record_count = result.record_count.to_i
       end
 
       add_blank_results(results, mstart, ystart)

--- a/spec/requests/history/rails_admin_history_spec.rb
+++ b/spec/requests/history/rails_admin_history_spec.rb
@@ -13,6 +13,13 @@ describe "RailsAdmin History" do
     end
   end
 
+  describe "when range starts in December" do
+    it "does not produce SQL with empty IN () range" do
+      RailsAdmin::History.should_receive(:find_by_sql).with("select count(*) as number, year, month from rails_admin_histories where month IN (1, 2, 3, 4) and year = 2011 group by year, month").and_return([])
+      RailsAdmin::History.get_history_for_dates(12, 4, 2010, 2011)
+    end
+  end
+
   describe "history blank results single year" do
     before(:each) do
       @months = RailsAdmin::History.add_blank_results([RailsAdmin::BlankHistory.new(7, 2010), RailsAdmin::BlankHistory.new(9, 2011)], 5, 2010)


### PR DESCRIPTION
Fix edge case when start month is 12 (December) -- get_history_for_dates was using incorrect branch, resulting in a SQL query with: "...WHERE month IN ()..." which caused an exception.

This patch fixes an intermittent issue that we've seen and I finally tracked down to be caused by a bug in `History.get_history_for_dates` when the start month is December (12).

The algorithm incorrectly added 1 to 12, and produced a month range 13..12 which would be empty and throw this database exception:

ActiveRecord::StatementInvalid: Please run the generator "rails generate rails_admin:install_admin" then migrate your database. Mysql2::Error: You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near ') and year = 2010 group by year, month' at line 1: select count(_) as number, year, month from rails_admin_histories *_where month IN ()*\* and year = 2010 group by year, month

This fixes #390, again, but also addresses subtle issues introduced by the previous patch.
For details, see: https://github.com/sferik/rails_admin/issues/390#issuecomment-1091788
