### PR TITLE
Bump ckeditor version

### DIFF
--- a/lib/tasks/download.rake
+++ b/lib/tasks/download.rake
@@ -2,12 +2,16 @@ namespace :rails_admin do
   desc "Download CKEditor to your public javascript folder"
   task :ckeditor_download do
     require 'fileutils'
-    ckeditor_url = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%203.5/ckeditor_3.5.tar.gz"
-    ckeditor_file = "/tmp/ckeditor_3.5.tar.gz"
-    destination_folder = File.join(FileUtils.pwd, 'public', 'javascripts')
+    require 'tempfile'
+    ckeditor_url = "http://download.cksource.com/CKEditor/CKEditor/CKEditor%203.5.3/ckeditor_3.5.3.tar.gz"
+    ckeditor_file = Tempfile.new('ckeditor').path
+    destination_folder = Rails.root.join('public', 'javascripts')
 
-    raise "CKEditor is already installed in your public." if File.exists? File.join(destination_folder, 'ckeditor', 'LICENSE.html')
-    raise "Missing public/javascripts folder. Create it." unless File.exists?(destination_folder)
+    if File.exists? File.join(destination_folder, 'ckeditor', 'LICENSE.html')
+      puts "CKEditor is already installed."
+      exit 0
+    end
+    FileUtils.mkdir_p(destination_folder) unless File.directory? destination_folder
 
     puts "Downloading CKEditor (you need to have either wget or curl installed)"
     `curl #{ckeditor_url} -o '#{ckeditor_file}' || wget #{ckeditor_url} -O #{ckeditor_file}`


### PR DESCRIPTION
Current version of ckeditor that we're using(3.5) was released on 21-Dec-2010.

And there is another version 3.5.3 released on 07-Apr-2011 which has lots of bug fixes and is backward compatible with the older version.

http://ckeditor.com/blog/CKEditor_3.5.3_released
