### PR TITLE
Put the History#most_recent scope back to what it was before this commit:

### DIFF
--- a/app/models/rails_admin/history.rb
+++ b/app/models/rails_admin/history.rb
@@ -4,8 +4,8 @@ module RailsAdmin
 
     IGNORED_ATTRS = Set[:id, :created_at, :created_on, :deleted_at, :updated_at, :updated_on, :deleted_on]
 
-    scope :most_recent, lambda {|table|
-      where("#{retrieve_connection.quote_column_name(:table)} = ?", table).order("updated_at")
+    scope :most_recent, lambda {|model|
+      where("#{retrieve_connection.quote_column_name(:table)} = ?", model.pretty_name).order("updated_at DESC")
     }
 
     def self.get_history_for_dates(mstart, mstop, ystart, ystop)


### PR DESCRIPTION
Put the History#most_recent scope back to what it was before this commit: https://github.com/sferik/rails_admin/commit/eb076c5bcb4895542af286875500d88aface8ce6#L0L7

A RailsAdmin::AbstractModel does not implement to_s, so we need to call #pretty_name to get a sensible string representation to query by.

This caused WEBrick to fail with 'illegal hardware instruction'.

Fixes #399
