### PR TITLE
Bring back copy_assets and add copy_locales rake tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -982,6 +982,34 @@ with [CanCan](https://github.com/ryanb/cancan), pass it like this.
 
 See the [wiki](https://github.com/sferik/rails_admin/wiki) for more on authorization.
 
+Static Assets & Locales
+-----------------------
+
+When running `rake rails_admin:install` the locale files (`config/locales/...`) and the static asset files
+(javascript files, images, stylesheets) are copied to your local application tree.
+
+Should you update the gem to a new version that perhaps includes updated locale or asset files, then you won't automatically
+be able to take advantage of these. In fact, you may choose for this reason, to not commit locale files and asset
+files to your local repository and instead have them loaded from the gem.
+
+You can choose to commit locale files to your local application tree, if you want to modify them from what the gem
+supplies; then you also need to manage updates by hand. Locale files will be automatically loaded from the gem
+unless overrides exist.
+
+For asset files, the following applies: When running in development mode, the rails_admin engine will inject a middleware
+to serve static assets (javascript files, images, stylesheets) from the gem's location. This generally isn't a good
+setup for high-traffic production environments. Depending on your web server configuration is may also just plain fail.
+You may need to serve the asset files from the local application tree (public/...). You can choose to have the assets
+served from the gem in development mode but from the local application tree in production mode. In that case, you
+need to copy the assets during deployment (e.g. via a capistrano hook).
+
+Two rake tasks have been provided to copy locale and asset files to the local application tree:
+
+    rake rails_admin:copy_locales
+    rake rails_admin:copy_assets
+
+These tasks run automatically during installation, but are provided separately, e.g. for updates or deployments.
+
 Contributing
 ------------
 In the spirit of [free software](http://www.fsf.org/licensing/essays/free-sw.html), **everyone** is encouraged to help improve this project.

--- a/lib/rails_admin/tasks/install.rb
+++ b/lib/rails_admin/tasks/install.rb
@@ -25,6 +25,43 @@ module RailsAdmin
           puts "Done."
         end
 
+        def copy_locales_files
+          print "Now copying locales files! "
+          locales_path = gem_path + "/config/locales/*.yml"
+
+          app_path = Rails.root.join("config/locales")
+
+          unless File.directory?(app_path)
+            app_path.mkdir
+          end
+
+          puts
+          Dir.glob(locales_path).each do |file|
+            copier.copy_file file, File.join(app_path, File.basename(file))
+          end
+        end
+
+        def copy_assets_files
+          print "Now copying assets files - javascripts, stylesheets and images! "
+          origin = File.join(gem_path, 'public')
+          destination = Rails.root.join('public')
+
+          puts
+          %w( stylesheets images javascripts ).each do |directory|
+            Dir[File.join(origin, directory, 'rails_admin', '**/*')].each do |file|
+              relative  = file.gsub(/^#{origin}\//, '')
+              dest_file = File.join(destination, relative)
+              dest_dir  = File.dirname(dest_file)
+
+              if !File.exist?(dest_dir)
+                FileUtils.mkdir_p(dest_dir)
+              end
+
+              copier.copy_file(file, dest_file) unless File.directory?(file)
+            end
+          end
+        end
+
         private
 
         def check_for_devise_models
@@ -59,44 +96,6 @@ module RailsAdmin
           puts "Setting up devise for you!
     ======================================================"
           `rails g devise #{@@model_name}`
-        end
-
-        def copy_locales_files
-          print "Now copying locales files! "
-          locales_path = gem_path + "/config/locales/*.yml"
-
-          app_path = Rails.root.join("config/locales")
-
-          unless File.directory?(app_path)
-            app_path.mkdir
-          end
-
-          puts
-          Dir.glob(locales_path).each do |file|
-            copier.copy_file file, File.join(app_path, File.basename(file))
-          end
-
-        end
-
-        def copy_assets_files
-          print "Now copying assets files - javascripts, stylesheets and images! "
-          origin = File.join(gem_path, 'public')
-          destination = Rails.root.join('public')
-
-          puts
-          %w( stylesheets images javascripts ).each do |directory|
-            Dir[File.join(origin, directory, 'rails_admin', '**/*')].each do |file|
-              relative  = file.gsub(/^#{origin}\//, '')
-              dest_file = File.join(destination, relative)
-              dest_dir  = File.dirname(dest_file)
-
-              if !File.exist?(dest_dir)
-                FileUtils.mkdir_p(dest_dir)
-              end
-
-              copier.copy_file(file, dest_file) unless File.directory?(file)
-            end
-          end
         end
 
         def gem_path

--- a/lib/tasks/install.rake
+++ b/lib/tasks/install.rake
@@ -5,5 +5,16 @@ namespace :rails_admin do
   task :install do
     RailsAdmin::Tasks::Install.run(ENV['model_name'] || 'user')
   end
+
+  desc "Copy only locale files (part of install, but useful for deployments when only assets are needed)"
+  task :copy_locales do
+    RailsAdmin::Tasks::Install.copy_locales_files
+  end
+
+  desc "Copy only assets files (part of install, useful for deployments when only assets are needed)"
+  task :copy_assets do
+    RailsAdmin::Tasks::Install.copy_assets_files
+  end
+
 end
 


### PR DESCRIPTION
I think for standard operation it's best to _not_ copy the assets and locales into the local application, because:
1. the locale files will load from the gem automatically.
2. the asset files for development will be served from their gem location via middleware.
3. it's easy to forget to update the static asset files & locale files, and up til now there wasn't even a rake task to do this.
4. the only reason to copy locale files is if you want to modify them. So, it's best to do this on an as needed basis, with the understanding that you need to maintain them yourself now.
5. the only reason to copy locale files is for production servers and then it can be done during deployment, e.g. with the re-introduced copy_assets rake task.

I'm even inclined to say that probably the install rake task should not copy locales and assets, because of the silent maintenance issue brought on by that. But that's better left for another commit.
