### PR TITLE
Force version lock of Rake to 0.8.7 to avoid 0.9.0 issues

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'http://rubygems.org'
 # put test-only gems in this group so their generators
 # and rake tasks are available in development mode:
 group :development, :test do
+  gem 'rake', '~> 0.8.7'
   gem 'rails', '~> 3.0.7'
 
   platforms :jruby do


### PR DESCRIPTION
Out of the box rails_admin installs Rake 0.9.0 when `bundle install` is run because of improper version locking in other dependencies.
