### PR TITLE
DRYed up the file copying tasks

### DIFF
--- a/lib/rails_admin/tasks/install.rb
+++ b/lib/rails_admin/tasks/install.rb
@@ -45,30 +45,20 @@ module RailsAdmin
           print "Now copying assets files - javascripts, stylesheets and images! "
           origin = File.join(gem_path, 'public')
           destination = Rails.root.join('public')
-
-          puts
-          %w( stylesheets images javascripts ).each do |directory|
-            Dir[File.join(origin, directory, 'rails_admin', '**/*')].each do |file|
-              relative  = file.gsub(/^#{origin}\//, '')
-              dest_file = File.join(destination, relative)
-              dest_dir  = File.dirname(dest_file)
-
-              if !File.exist?(dest_dir)
-                FileUtils.mkdir_p(dest_dir)
-              end
-
-              copier.copy_file(file, dest_file) unless File.directory?(file)
-            end
-          end
+          puts copy_files(%w( stylesheets images javascripts ), origin, destination)
         end
 
         def copy_view_files
           print "Now copying view files "
           origin = File.join(gem_path, 'app/views')
           destination = Rails.root.join('app/views')
+          puts copy_files(%w( layouts . ), origin, destination)
+        end
 
-          puts
-          %w( layouts . ).each do |directory|
+        private
+
+        def copy_files(directories, origin, destination)
+          directories.each do |directory|
             Dir[File.join(origin, directory, 'rails_admin', '**/*')].each do |file|
               relative  = file.gsub(/^#{origin}\//, '')
               dest_file = File.join(destination, relative)
@@ -82,8 +72,6 @@ module RailsAdmin
             end
           end
         end
-
-        private
 
         def check_for_devise_models
           devise_path = Rails.root.join("config/initializers/devise.rb")


### PR DESCRIPTION
I should have noticed this for my previous commit but the copy_asset_files and copy_view_files methods are basically the same. The directory iterator is a good candidate to be DRYed up.
