### PR TITLE
Rails 3.1 support - Make RailsAdmin mountable and isolated

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -152,7 +152,7 @@ module RailsAdmin
 
       AbstractHistory.create_history_item("Destroyed #{@model_config.with(:object => @object).object_label}", @object, @abstract_model, _current_user)
 
-      redirect_to rails_admin_list_path(:model_name => @abstract_model.to_param)
+      redirect_to list_path(:model_name => @abstract_model.to_param)
     end
 
     def bulk_delete
@@ -175,7 +175,7 @@ module RailsAdmin
         AbstractHistory.create_history_item(message, object, @abstract_model, _current_user)
       end
 
-      redirect_to rails_admin_list_path(:model_name => @abstract_model.to_param)
+      redirect_to list_path(:model_name => @abstract_model.to_param)
     end
 
     def handle_error(e)
@@ -290,13 +290,13 @@ module RailsAdmin
 
       if params[:_add_another]
         flash[:notice] = t("admin.flash.successful", :name => pretty_name, :action => t("admin.actions.#{action}d"))
-        redirect_to rails_admin_new_path(:model_name => param)
+        redirect_to new_path(:model_name => param)
       elsif params[:_add_edit]
         flash[:notice] = t("admin.flash.successful", :name => pretty_name, :action => t("admin.actions.#{action}d"))
-        redirect_to rails_admin_edit_path(:model_name => param, :id => @object.id)
+        redirect_to edit_path(:model_name => param, :id => @object.id)
       else
         flash[:notice] = t("admin.flash.successful", :name => pretty_name, :action => t("admin.actions.#{action}d"))
-        redirect_to rails_admin_list_path(:model_name => param)
+        redirect_to list_path(:model_name => param)
       end
     end
 
@@ -315,7 +315,7 @@ module RailsAdmin
     def check_for_cancel
       if params[:_continue]
         flash[:notice] = t("admin.flash.noaction")
-        redirect_to rails_admin_list_path(:model_name => @abstract_model.to_param)
+        redirect_to list_path(:model_name => @abstract_model.to_param)
       end
     end
 

--- a/app/views/layouts/rails_admin/_header.html.erb
+++ b/app/views/layouts/rails_admin/_header.html.erb
@@ -12,7 +12,7 @@
 
     <div id="header2">
       <h1 id="logo">
-      <%= link_to rails_admin_dashboard_path do %>
+      <%= link_to dashboard_path do %>
         <span class="image_replacement"><%= @plugin_name %></span>
       <% end -%>
       </h1>

--- a/app/views/layouts/rails_admin/delete.html.erb
+++ b/app/views/layouts/rails_admin/delete.html.erb
@@ -3,8 +3,8 @@
 <% end %>
 <% content_for :breadcrumb do %>
   <li><%= home_link %></li>
-  <li>&rsaquo; <%= link_to(t('admin.dashboard.name'), rails_admin_dashboard_path) %></li>
-  <li>&rsaquo; <%= link_to(@model_config.label, rails_admin_list_path(:model_name => @abstract_model.to_param)) %></li>
+  <li>&rsaquo; <%= link_to(t('admin.dashboard.name'), dashboard_path) %></li>
+  <li>&rsaquo; <%= link_to(@model_config.label, list_path(:model_name => @abstract_model.to_param)) %></li>
   <li>&rsaquo; <span><%= @page_name %></span></li>
 <% end %>
 

--- a/app/views/layouts/rails_admin/form.html.erb
+++ b/app/views/layouts/rails_admin/form.html.erb
@@ -3,8 +3,8 @@
 <% end %>
 <% content_for :breadcrumb do %>
   <li><%= home_link %></li>
-  <li>&rsaquo; <%= link_to(t('admin.dashboard.name'), rails_admin_dashboard_path) %></li>
-  <li>&rsaquo; <%= link_to(@model_config.label, rails_admin_list_path(:model_name => @abstract_model.to_param)) %></li>
+  <li>&rsaquo; <%= link_to(t('admin.dashboard.name'), dashboard_path) %></li>
+  <li>&rsaquo; <%= link_to(@model_config.label, list_path(:model_name => @abstract_model.to_param)) %></li>
   <li>&rsaquo; <span><%= @page_name %></span></li>
 <% end %>
 

--- a/app/views/layouts/rails_admin/list.html.erb
+++ b/app/views/layouts/rails_admin/list.html.erb
@@ -3,9 +3,9 @@
 <% end %>
 <% content_for :breadcrumb do %>
   <li><%= home_link %></li>
-  <li>&rsaquo; <%= link_to(t('admin.dashboard.name'), rails_admin_dashboard_path) %></li>
+  <li>&rsaquo; <%= link_to(t('admin.dashboard.name'), dashboard_path) %></li>
   <% if @history %>
-    <li>&rsaquo; <%= link_to(@model_config.label, rails_admin_list_path(:model_name => @abstract_model.to_param)) %></li>
+    <li>&rsaquo; <%= link_to(@model_config.label, list_path(:model_name => @abstract_model.to_param)) %></li>
     <li>&rsaquo; <span>History</span></li>
   <% else %>
     <li>&rsaquo; <span><%= @model_config.label %></span></li>

--- a/app/views/rails_admin/history/show.html.erb
+++ b/app/views/rails_admin/history/show.html.erb
@@ -29,14 +29,14 @@
                 <% selected = sort == property_name.to_s %>
                 <% sort_direction = selected ? (sort_reverse ? "ascending" : "descending") : nil %>
                 <th class="dateTime <%= sort == property_name.to_s ? "selected" : nil %>" >
-                  <% sort_location = rails_admin_history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => :created_at).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
+                  <% sort_location = history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => :created_at).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
                   <%= link_to("DATE/TIME", sort_location, :class => sort_direction) %>
                 </th>
                 <% property_name = "username"%>
                 <% selected = sort == property_name.to_s %>
                 <% sort_direction = selected ? (sort_reverse ? "ascending" : "descending") : nil %>
                 <th class="smallString <%= sort == property_name.to_s ? "selected" : nil %>" >
-                  <% sort_location = rails_admin_history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
+                  <% sort_location = history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
                   <%= link_to("USER", sort_location, :class => sort_direction) %>
                 </th>
                 <% if @general %>
@@ -44,7 +44,7 @@
                 <% selected = sort == property_name.to_s %>
                 <% sort_direction = selected ? (sort_reverse ? "ascending" : "descending") : nil %>
                 <th class="int <%= sort == property_name.to_s ? "selected" : nil %>" >
-                  <% sort_location = rails_admin_history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
+                  <% sort_location = history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
                   <%= link_to("ITEM", sort_location, :class => sort_direction) %>
                 </th>
                 <% end %>
@@ -52,7 +52,7 @@
                 <% selected = sort == property_name.to_s %>
                 <% sort_direction = selected ? (sort_reverse ? "ascending" : "descending") : nil %>
                 <th class="smallString <%= sort == property_name.to_s ? "selected" : nil %>" >
-                  <% sort_location = rails_admin_history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
+                  <% sort_location = history_model_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
                   <%= link_to("ACTION", sort_location, :class => sort_direction) %>
                 </th>
               </tr>
@@ -66,7 +66,7 @@
                       <%= paginate(@current_page, @page_count, :url => params.reject{|t| t == "page" || t=="all"}).html_safe %>
                     <% end %>
                     <% if @page_count.to_i == 2 %>
-                      <%= link_to(t("admin.list.show_all"), rails_admin_history_model_path(params.reject{|t| t == "page"}.merge(:model_name => @abstract_model.to_param, :all => true, :class => "showall"))) %>
+                      <%= link_to(t("admin.list.show_all"), history_model_path(params.reject{|t| t == "page"}.merge(:model_name => @abstract_model.to_param, :all => true, :class => "showall"))) %>
                     <% end %>
                   </div>
                 </td>
@@ -87,7 +87,7 @@
                 <% if @general %>
                 <td class="int">
                   <% unless object.message.match("Destroy") %>
-                  <%= link_to object.item, rails_admin_history_object_path(:id => object.item), :class => "historyLink"%>
+                  <%= link_to object.item, history_object_path(:id => object.item), :class => "historyLink"%>
                   <% else %>
                   <%= object.item %>
                   <% end %>

--- a/app/views/rails_admin/main/_delete_notice.html.erb
+++ b/app/views/rails_admin/main/_delete_notice.html.erb
@@ -5,12 +5,12 @@
 %>
 <ul class="items">
   <li>
-    <%= @abstract_model.pretty_name %>: <%= link_to(model_config.with(:object => object).object_label, rails_admin_edit_path(:model_name => @abstract_model.to_param, :id => object.id)) %>
+    <%= @abstract_model.pretty_name %>: <%= link_to(model_config.with(:object => object).object_label, edit_path(:model_name => @abstract_model.to_param, :id => object.id)) %>
     <ul>
       <% @abstract_model.has_many_associations.each do |association| %>
       <% object.send(association[:name]).reject{|child| child.nil?}.each do |child| %>
       <li>
-        One or more <%= @abstract_model.pretty_name.pluralize.downcase %> in <%= association[:pretty_name].downcase %>: <%= link_to(RailsAdmin.config(child).with(:object => child).object_label, rails_admin_edit_path(:model_name => association[:name].to_s.singularize.to_sym, :id => child.id)) %>
+        One or more <%= @abstract_model.pretty_name.pluralize.downcase %> in <%= association[:pretty_name].downcase %>: <%= link_to(RailsAdmin.config(child).with(:object => child).object_label, edit_path(:model_name => association[:name].to_s.singularize.to_sym, :id => child.id)) %>
       </li>
       <% end %>
       <% end %>
@@ -18,7 +18,7 @@
       <% child = object.send(association[:name]) %>
       <% next if child.nil? %>
       <li>
-        A <%= @abstract_model.pretty_name.downcase %> in <%= association[:pretty_name].downcase %>: <%= link_to(RailsAdmin.config(child).with(:object => child).object_label, rails_admin_edit_path(:model_name => association[:name], :id => child.id)) %>
+        A <%= @abstract_model.pretty_name.downcase %> in <%= association[:pretty_name].downcase %>: <%= link_to(RailsAdmin.config(child).with(:object => child).object_label, edit_path(:model_name => association[:name], :id => child.id)) %>
       </li>
       <% end %>
     </ul>

--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.erb
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.erb
@@ -30,7 +30,7 @@
                         createQuery: function(query) {
                           return { query: query }
                         },
-                        source: "<%= rails_admin_list_path(config.abstract_model.to_param, :compact => true) %>",
+                        source: "<%= list_path(config.abstract_model.to_param, :compact => true) %>",
                       <% end %>
                         sortable: <%= field.orderable ? 'true' : 'false' %>,
                       regional: {

--- a/app/views/rails_admin/main/_form_filtering_select.html
+++ b/app/views/rails_admin/main/_form_filtering_select.html
@@ -14,7 +14,7 @@
                 <%= form.label field.method_name, field.label %>
                 <%= form.select field.method_name, collection, { :selected => selected_id, :include_blank => true }, field.html_attributes %>
                 <% if authorized? :new, config.abstract_model %>
-                  <%= link_to "Add new #{config.abstract_model.to_param}", rails_admin_new_path(:model_name => config.abstract_model.to_param), :class => "createAssociatedRecord" %>
+                  <%= link_to "Add new #{config.abstract_model.to_param}", new_path(:model_name => config.abstract_model.to_param), :class => "createAssociatedRecord" %>
                 <% end %>
                 <% if field.has_errors? %>
                 <span class="errorMessage"><%= "#{field.label } #{field.errors.first}" %></span>
@@ -30,7 +30,7 @@
                         createQuery: function(query) {
                           return { query: query }
                         },
-                        source: "<%= rails_admin_list_path(config.abstract_model.to_param, :compact => true) %>"
+                        source: "<%= list_path(config.abstract_model.to_param, :compact => true) %>"
                       <% end %>
                     });
                   });

--- a/app/views/rails_admin/main/_navigation.html.erb
+++ b/app/views/rails_admin/main/_navigation.html.erb
@@ -5,7 +5,7 @@
 %>
       <ul id="nav">
         <li class="<%= "active" if @page_type == "dashboard" %>">
-          <%= link_to(t("admin.dashboard.name"), rails_admin_dashboard_path) %>
+          <%= link_to(t("admin.dashboard.name"), dashboard_path) %>
         </li>
         <% root_models[0..max_visible_tabs-1].each do |model| %>
           <%
@@ -14,13 +14,13 @@
           %>
           <li class="<%= "active" if tab_titles.include? @page_type %> <%= "more" unless children.empty? %>">
             <% if children.size == 1 %>
-              <%= link_to(model.label, rails_admin_list_path(:model_name => model.abstract_model.to_param)) %>
+              <%= link_to(model.label, list_path(:model_name => model.abstract_model.to_param)) %>
             <% else %>
               <a href="#"><%= model.dropdown ? t(model.dropdown, :default => model.dropdown) : model.label %></a>
               <ul>
                 <% children.each_with_index do |child, index| %>
                   <li class="<%= "active" if @page_type == tab_titles[index] %>">
-                    <%= link_to(child.label, rails_admin_list_path(:model_name => child.abstract_model.to_param)) %>
+                    <%= link_to(child.label, list_path(:model_name => child.abstract_model.to_param)) %>
                   </li>
                 <% end %>
               </ul>
@@ -33,7 +33,7 @@
             <ul>
             <% models[max_visible_tabs..root_models.size].each do |model| %>
               <li <%if @page_type == model.abstract_model.pretty_name.downcase %>class="active"<% end %>>
-                <%= link_to(model.label, rails_admin_list_path(:model_name => model.abstract_model.to_param)) %>
+                <%= link_to(model.label, list_path(:model_name => model.abstract_model.to_param)) %>
               </li>
             <% end %>
             </ul>

--- a/app/views/rails_admin/main/_user_info.html.erb
+++ b/app/views/rails_admin/main/_user_info.html.erb
@@ -6,7 +6,7 @@
       <strong><a href="#"><%= current_user.email %></a></strong>
     </li>
     <li class="desc">
-      <a href="<%= destroy_session_path(current_user) %>"><%= t("admin.credentials.log_out")%></a>
+      <a href="<%# FIXME destroy_session_path(current_user) %>"><%= t("admin.credentials.log_out")%></a>
     </li>
   </ul>
 </div>

--- a/app/views/rails_admin/main/bulk_delete.html.erb
+++ b/app/views/rails_admin/main/bulk_delete.html.erb
@@ -7,7 +7,7 @@
         <div class="ra-block-content">
           <p>Are you sure you want to delete the following object along with all of the following related items will be deleted:</p>
           <%= render :partial => "delete_notice", :collection => @bulk_objects %>
-          <%= form_tag rails_admin_bulk_destroy_path(:model_name => @abstract_model.to_param, :bulk_ids => @bulk_ids) do %>
+          <%= form_tag bulk_destroy_path(:model_name => @abstract_model.to_param, :bulk_ids => @bulk_ids) do %>
             <ul class="submit clearfix">
               <li>
                 <%= submit_tag t("admin.delete.confirmation"), :class => "ra-button ui-state-highlight" %>

--- a/app/views/rails_admin/main/delete.html.erb
+++ b/app/views/rails_admin/main/delete.html.erb
@@ -7,7 +7,7 @@
 <%= render(:partial => 'layouts/rails_admin/flash', :locals => {:flash => flash}) -%>
           <p>Are you sure you want to delete the <%= @abstract_model.pretty_name.downcase %> &ldquo;<strong><%= @model_config.with(:object => @object).object_label %></strong>&rdquo;? All of the following related items will be deleted:</p>
           <%= render :partial => "delete_notice", :object => @object %>
-          <%= form_for(@object, :url => rails_admin_destroy_path(:model_name => @abstract_model.to_param, :id => @object.id), :html => {:method => "delete"}) do %>
+          <%= form_for(@object, :url => destroy_path(:model_name => @abstract_model.to_param, :id => @object.id), :html => {:method => "delete"}) do %>
             <ul class="submit clearfix">
               <li>
                 <%= submit_tag t("admin.delete.confirmation"), :class => "ra-button ui-state-highlight" %>

--- a/app/views/rails_admin/main/edit.html.erb
+++ b/app/views/rails_admin/main/edit.html.erb
@@ -9,17 +9,17 @@
           <div class="ra-block-toolbar ui-state-highlight clearfix">
             <ul>
               <li>
-               <%= link_to t("admin.history.name"), rails_admin_history_object_path(:id => params[:id]), :class => 'ra-button' %>
+               <%= link_to t("admin.history.name"), history_object_path(:id => params[:id]), :class => 'ra-button' %>
               </li>
               <% if authorized? :delete, @abstract_model, @object %>
               <li>
-               <%= link_to t("admin.list.delete_action"), rails_admin_delete_path(:model_name => @abstract_model.to_param, :id => params[:id]), :class => 'ra-button' %>
+               <%= link_to t("admin.list.delete_action"), delete_path(:model_name => @abstract_model.to_param, :id => params[:id]), :class => 'ra-button' %>
               </li>
               <% end %>
             </ul>
           </div>
           <%= render(:partial => 'layouts/rails_admin/flash', :locals => {:flash => flash}) -%>
-          <%= send(@model_config.update.form_builder, @object, :url => rails_admin_update_path(:model_name => @abstract_model.to_param, :id => @object.id), :html => { :method => "put", :multipart => true }) do |form| %>
+          <%= send(@model_config.update.form_builder, @object, :url => update_path(:model_name => @abstract_model.to_param, :id => @object.id), :html => { :method => "put", :multipart => true }) do |form| %>
             <% @model_config.edit.with(:object => @object).visible_groups.each do |fieldset| %>
               <%= render :partial => 'form_fieldset', :locals => { :fieldset => fieldset, :form => form, :object => @object } -%>
             <% end %>

--- a/app/views/rails_admin/main/index.html.erb
+++ b/app/views/rails_admin/main/index.html.erb
@@ -23,7 +23,7 @@
                   <% if authorized? :list, abstract_model %>
                     <tr class="<%= cycle 'odd', 'even' %>">
                       <td class="modelNameRow">
-                        <%= link_to(RailsAdmin.config(abstract_model).label, rails_admin_list_path(:model_name => abstract_model.to_param), :class => "show") %>
+                        <%= link_to(RailsAdmin.config(abstract_model).label, list_path(:model_name => abstract_model.to_param), :class => "show") %>
                       </td>
                       <td>
                       <% if (last_used = @most_recent_changes[abstract_model.pretty_name]) %>
@@ -39,7 +39,7 @@
                       </td>
                       <td>
                         <% if authorized? :new, abstract_model %>
-                          <%= link_to(t("admin.dashboard.add_new"), rails_admin_new_path(:model_name => abstract_model.to_param), :class => "add") %>|<%= link_to(t("admin.dashboard.show"), rails_admin_list_path(:model_name => abstract_model.to_param), :class => "show") %>
+                          <%= link_to(t("admin.dashboard.add_new"), new_path(:model_name => abstract_model.to_param), :class => "add") %>|<%= link_to(t("admin.dashboard.show"), list_path(:model_name => abstract_model.to_param), :class => "show") %>
                         <% end %>
                       </td>
                     </tr>
@@ -62,13 +62,13 @@
               $j(document).ready(function($) {
                 var cache = {};
                  $("#timeline").timeline({
-                   url: "<%= rails_admin_history_slider_path %>",
+                   url: "<%= history_slider_path %>",
                    monthChanged: function(month, year) {
                      if (cache[year] && cache[year][month]) {
                        $("#listingHistory").html(cache[year][month]);
                      } else {
                        $j("#listingHistory").load(
-                         "<%= rails_admin_history_list_path %>",
+                         "<%= history_list_path %>",
                          { month: month, year: year },
                          function(response, status, xhr) {
                            if (!cache[year]) { cache[year] = {}; }

--- a/app/views/rails_admin/main/list.html.erb
+++ b/app/views/rails_admin/main/list.html.erb
@@ -37,22 +37,22 @@
           <div class="ra-block-toolbar ui-state-highlight">
             <ul>
               <li>
-               <%= link_to(t("admin.history.name"), rails_admin_history_model_path, :class => "ra-button") %>
+               <%= link_to(t("admin.history.name"), history_model_path, :class => "ra-button") %>
               </li>
               <% if authorized? :new, @abstract_model %>
                 <li>
-                 <%= link_to(t("admin.list.add_new"), rails_admin_new_path(:model_name => @abstract_model.to_param), :class => "ra-button") %>
+                 <%= link_to(t("admin.list.add_new"), new_path(:model_name => @abstract_model.to_param), :class => "ra-button") %>
                 </li>
               <% end %>
             </ul>
-            <%= form_tag(rails_admin_list_path(params.merge(:model_name => @abstract_model.to_param).reject{|key, value| key.to_sym == :page}), :method => "get", :remote => true) do %>
+            <%= form_tag(list_path(params.merge(:model_name => @abstract_model.to_param).reject{|key, value| key.to_sym == :page}), :method => "get", :remote => true) do %>
               <fieldset>
                 <input type="text" name="query" value="<%= query %>" size="32" />
                 <input type="submit" class="ra-button" value="<%= t("admin.list.search").upcase %>" />
               </fieldset>
             <% end %>
           </div>
-          <%= form_tag rails_admin_bulk_delete_path(:model_name => @abstract_model.to_param), :method => :get do %>
+          <%= form_tag bulk_delete_path(:model_name => @abstract_model.to_param), :method => :get do %>
             <table class="grid">
               <thead>
                 <tr>
@@ -63,7 +63,7 @@
                   <% selected = sort == property_name.to_s %>
                   <th class="<%= "#{property.css_class}" %> <%= selected ? "selected" : nil %>">
                     <% if property.sortable? %>
-                    <% sort_location = rails_admin_list_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
+                    <% sort_location = list_path(params.merge(:model_name => @abstract_model.to_param, :sort => property_name).reject{|key, value| key.to_sym == :sort_reverse}.merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})) %>
                     <% sort_direction = selected ? (sort_reverse ? "ascending" : "descending") : nil %>
                     <%= link_to(property_pretty_name.upcase, sort_location, :class => sort_direction, :remote => true) %>
                     <% else %>
@@ -92,7 +92,7 @@
                       <%= @record_count %>
                       <%= @model_config.abstract_model.model.model_name.human(:count => @record_count, :default => @record_count != 1 ? @model_config.label.downcase.pluralize : @model_config.label.downcase) %>
                       <% if @page_count.to_i == 2 %>
-                        <%= link_to(t("admin.list.show_all"), rails_admin_list_path(params.merge(:model_name => @abstract_model.to_param, :all => true, :remote => true, :class => "showall"))) %>
+                        <%= link_to(t("admin.list.show_all"), list_path(params.merge(:model_name => @abstract_model.to_param, :all => true, :remote => true, :class => "showall"))) %>
                       <% end %>
                     </div>
                   </td>
@@ -101,23 +101,23 @@
               <tbody>
                 <% @objects.each_with_index do |object, index| %>
                 <tr class="<%= index % 2 == 0 ? " odd" : " even" %>">
-                  <% other_left = rails_admin_list_path(params.merge(:model_name => @abstract_model.to_param).reject{|key, value| key == "set"}.merge(:set => params[:set].to_i - 1)) %>
+                  <% other_left = list_path(params.merge(:model_name => @abstract_model.to_param).reject{|key, value| key == "set"}.merge(:set => params[:set].to_i - 1)) %>
                   <td class="other left" <% if @other.include? "left" %>style="display: none"<% end %>>
                     <%= link_to("...", other_left, :remote => true) %>
                   </td>
                   <% properties.map{|property| property.bind(:object, object)}.each do |property| %>
                     <td class="<%= "#{property.css_class}" %>"><%= [:text, :string].include?(property.type) ? property.formatted_value[0..40] : property.formatted_value %></td>
                   <% end %>
-                  <% other_right = rails_admin_list_path(params.merge(:model_name => @abstract_model.to_param).reject{|key, value| key == "set"}.merge(:set => params[:set].to_i + 1)) %>
+                  <% other_right = list_path(params.merge(:model_name => @abstract_model.to_param).reject{|key, value| key == "set"}.merge(:set => params[:set].to_i + 1)) %>
                   <td class="other right" <% if @other.include? "right" %>style="display: none"<% end %>>
                     <%= link_to("...", other_right, :remote => true)%>
                   </td>
                   <td class="action edit">
-                    <%= link_to(t("admin.list.edit_action"), rails_admin_edit_path(:model_name => @abstract_model.to_param, :id => object.id)) if authorized? :edit, @abstract_model, object %>
+                    <%= link_to(t("admin.list.edit_action"), edit_path(:model_name => @abstract_model.to_param, :id => object.id)) if authorized? :edit, @abstract_model, object %>
                   </td>
                   <% if authorized? :delete, @abstract_model %>
                   <td class="action delete">
-                    <%= link_to(t("admin.list.delete_action"), rails_admin_delete_path(:model_name => @abstract_model.to_param, :id => object.id)) if authorized? :delete, @abstract_model, object %>
+                    <%= link_to(t("admin.list.delete_action"), delete_path(:model_name => @abstract_model.to_param, :id => object.id)) if authorized? :delete, @abstract_model, object %>
                   </td>
                   <td class="action select"><%= check_box_tag "bulk_ids[]", object.id, false, :id => "bulk_destroy_#{object.id}" if authorized? :delete, @abstract_model, object %></td>
                   <% end %>

--- a/app/views/rails_admin/main/new.html.erb
+++ b/app/views/rails_admin/main/new.html.erb
@@ -7,7 +7,7 @@
         </div>
         <div class="ra-block-content">
           <%= render(:partial => 'layouts/rails_admin/flash', :locals => {:flash => flash}) -%>
-          <%= send(@model_config.create.form_builder, @object, :url => rails_admin_create_path(:model_name => @abstract_model.to_param, :id => @object.id), :html => { :multipart => true }) do |form| %>
+          <%= send(@model_config.create.form_builder, @object, :url => create_path(:model_name => @abstract_model.to_param, :id => @object.id), :html => { :multipart => true }) do |form| %>
             <% @model_config.create.with(:object => @object).visible_groups.each do |fieldset| %>
               <%= render :partial => 'form_fieldset', :locals => { :fieldset => fieldset, :form => form, :object => @object } -%>
             <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,29 +1,25 @@
-Rails.application.routes.draw do
+RailsAdmin::Engine.routes.draw do
 
-  # Prefix route urls with "admin" and route names with "rails_admin_"
-  scope "admin", :module => :rails_admin, :as => "rails_admin" do
-    # Routes for rails_admin controller
-    controller "main" do
-      match "/", :to => :index, :as => "dashboard"
-      get "/:model_name", :to => :list, :as => "list"
-      get "/:model_name/new", :to => :new, :as => "new"
-      match "/:model_name/get_pages", :to => :get_pages, :as => "get_pages"
-      post "/:model_name", :to => :create, :as => "create"
-      get "/:model_name/:id/edit", :to => :edit, :as => "edit"
-      put "/:model_name/:id", :to => :update, :as => "update"
-      get "/:model_name/:id/delete", :to => :delete, :as => "delete"
-      delete "/:model_name/:id", :to => :destroy, :as => "destroy"
-      get "/:model_name/bulk_delete", :to => :bulk_delete, :as => "bulk_delete"
-      post "/:model_name/bulk_destroy", :to => :bulk_destroy, :as => "bulk_destroy"
-    end
-    scope "history", :as => "history" do
-      controller "history" do
-        match "/list", :to => :list, :as => "list"
-        match "/slider", :to => :slider, :as => "slider"
-        match "/:model_name", :to => :for_model, :as => "model"
-        match "/:model_name/:id", :to => :for_object, :as => "object"
-      end
+  # Routes for rails_admin controller
+  controller "main" do
+    match "/", :to => :index, :as => "dashboard"
+    get "/:model_name", :to => :list, :as => "list"
+    get "/:model_name/new", :to => :new, :as => "new"
+    match "/:model_name/get_pages", :to => :get_pages, :as => "get_pages"
+    post "/:model_name", :to => :create, :as => "create"
+    get "/:model_name/:id/edit", :to => :edit, :as => "edit"
+    put "/:model_name/:id", :to => :update, :as => "update"
+    get "/:model_name/:id/delete", :to => :delete, :as => "delete"
+    delete "/:model_name/:id", :to => :destroy, :as => "destroy"
+    get "/:model_name/bulk_delete", :to => :bulk_delete, :as => "bulk_delete"
+    post "/:model_name/bulk_destroy", :to => :bulk_destroy, :as => "bulk_destroy"
+  end
+  scope "history", :as => "history" do
+    controller "history" do
+      match "/list", :to => :list, :as => "list"
+      match "/slider", :to => :slider, :as => "slider"
+      match "/:model_name", :to => :for_model, :as => "model"
+      match "/:model_name/:id", :to => :for_object, :as => "object"
     end
   end
-
 end

--- a/lib/rails_admin/config/fields/types/polymorphic_association.rb
+++ b/lib/rails_admin/config/fields/types/polymorphic_association.rb
@@ -45,7 +45,7 @@ module RailsAdmin
             end
 
             Hash[*types.collect { |v|
-                  [v[0], bindings[:view].rails_admin_list_path(v[1])]
+                  [v[0], bindings[:view].list_path(v[1])]
                 }.flatten]
           end
 

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -3,6 +3,7 @@ require 'rails'
 
 module RailsAdmin
   class Engine < Rails::Engine
+    isolate_namespace RailsAdmin
     initializer "static assets" do |app|
       if app.config.serve_static_assets
         app.middleware.insert_after ::ActionDispatch::Static, ::ActionDispatch::Static, "#{root}/public"

--- a/spec/dummy_app/config/routes.rb
+++ b/spec/dummy_app/config/routes.rb
@@ -1,5 +1,6 @@
 DummyApp::Application.routes.draw do
 
+  mount RailsAdmin::Engine => '/admin', :as => 'rails_admin'
   devise_for :users
   root :to => "rails_admin::Main#index"
 

--- a/spec/requests/authorization/cancan_spec.rb
+++ b/spec/requests/authorization/cancan_spec.rb
@@ -31,13 +31,13 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
 
       it "GET /admin should raise CanCan::AccessDenied" do
         lambda {
-          get rails_admin_dashboard_path
+          get dashboard_path
         }.should raise_error(CanCan::AccessDenied)
       end
 
       it "GET /admin/player should raise CanCan::AccessDenied" do
         lambda {
-          get rails_admin_list_path(:model_name => "player")
+          get list_path(:model_name => "player")
         }.should raise_error(CanCan::AccessDenied)
       end
 
@@ -49,7 +49,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
       end
 
       it "GET /admin should show Player but not League" do
-        get rails_admin_dashboard_path
+        get dashboard_path
         response.should be_successful
         response.body.should contain("Player")
         response.body.should_not contain("League")
@@ -62,7 +62,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
           Factory.create(:player, :retired => true),
         ]
 
-        get rails_admin_list_path(:model_name => "player", :set => 1)
+        get list_path(:model_name => "player", :set => 1)
 
         response.should be_successful
         response.body.should contain(@players[0].name)
@@ -76,13 +76,13 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
 
       it "GET /admin/team should raise CanCan::AccessDenied" do
         lambda {
-          get rails_admin_list_path(:model_name => "team")
+          get list_path(:model_name => "team")
         }.should raise_error(CanCan::AccessDenied)
       end
 
       it "GET /admin/player/new should raise CanCan::AccessDenied" do
         lambda {
-          get rails_admin_new_path(:model_name => "player")
+          get new_path(:model_name => "player")
         }.should raise_error(CanCan::AccessDenied)
       end
 
@@ -94,7 +94,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
       end
 
       it "GET /admin/player/new should render and create record upon submission" do
-        get rails_admin_new_path(:model_name => "player")
+        get new_path(:model_name => "player")
         response.body.should_not contain("edit")
         fill_in "player[name]", :with => "Jackie Robinson"
         fill_in "player[number]", :with => "42"
@@ -111,7 +111,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
       it "GET /admin/player/1/edit should raise access denied" do
         @player = Factory.create :player
         lambda {
-          get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+          get edit_path(:model_name => "player", :id => @player.id)
         }.should raise_error(CanCan::AccessDenied)
       end
 
@@ -124,7 +124,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
 
       it "GET /admin/player/1/edit should render and update record upon submission" do
         @player = Factory.create :player
-        get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+        get edit_path(:model_name => "player", :id => @player.id)
         response.body.should_not contain("Delete")
         fill_in "player[name]", :with => "Jackie Robinson"
         click_button "Save"
@@ -136,14 +136,14 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
       it "GET /admin/player/1/edit with retired player should raise access denied" do
         @player = Factory.create :player, :retired => true
         lambda {
-          get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+          get edit_path(:model_name => "player", :id => @player.id)
         }.should raise_error(CanCan::AccessDenied)
       end
 
       it "GET /admin/player/1/delete should raise access denied" do
         @player = Factory.create :player
         lambda {
-          get rails_admin_delete_path(:model_name => "player", :id => @player.id)
+          get delete_path(:model_name => "player", :id => @player.id)
         }.should raise_error(CanCan::AccessDenied)
       end
 
@@ -157,7 +157,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
       it "GET /admin/player/1/delete should render and destroy record upon submission" do
         @player = Factory.create :player
         player_id = @player.id
-        get rails_admin_delete_path(:model_name => "player", :id => player_id)
+        get delete_path(:model_name => "player", :id => player_id)
 
         click_button "Yes, I'm sure"
         response.should be_successful
@@ -167,7 +167,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
       it "GET /admin/player/1/delete with retired player should raise access denied" do
         @player = Factory.create :player, :retired => true
         lambda {
-          get rails_admin_delete_path(:model_name => "player", :id => @player.id)
+          get delete_path(:model_name => "player", :id => @player.id)
         }.should raise_error(CanCan::AccessDenied)
       end
 
@@ -176,7 +176,7 @@ if ENV["AUTHORIZATION_ADAPTER"] == "cancan"
         retired_player = Factory.create :player, :retired => true
 
         @delete_ids = [active_player, retired_player].map(&:id)
-        get rails_admin_bulk_delete_path(:model_name => "player", :bulk_ids => @delete_ids)
+        get bulk_delete_path(:model_name => "player", :bulk_ids => @delete_ids)
 
         response.body.should contain(active_player.name)
         response.body.should_not contain(retired_player.name)

--- a/spec/requests/basic/bulk_delete/rails_admin_basic_bulk_delete_spec.rb
+++ b/spec/requests/basic/bulk_delete/rails_admin_basic_bulk_delete_spec.rb
@@ -4,7 +4,7 @@ describe "RailsAdmin Basic Bulk Delete" do
   describe "bulk_delete" do
     before(:each) do
       @players = 2.times.map { Factory.create :player }
-      get rails_admin_bulk_delete_path(:model_name => "player", :bulk_ids => @players.map(&:id))
+      get bulk_delete_path(:model_name => "player", :bulk_ids => @players.map(&:id))
     end
 
     it "should respond successfully" do

--- a/spec/requests/basic/bulk_destroy/rails_admin_basic_bulk_destroy_spec.rb
+++ b/spec/requests/basic/bulk_destroy/rails_admin_basic_bulk_destroy_spec.rb
@@ -6,7 +6,7 @@ describe "RailsAdmin Basic Bulk Destroy" do
       RailsAdmin::History.destroy_all
       @players = 3.times.map { Factory.create(:player) }
       @delete_ids = @players[0..1].map(&:id)
-      get rails_admin_bulk_delete_path(:model_name => "player", :bulk_ids => @delete_ids)
+      get bulk_delete_path(:model_name => "player", :bulk_ids => @delete_ids)
       click_button "Yes, I'm sure"
     end
 
@@ -40,7 +40,7 @@ describe "RailsAdmin Basic Bulk Destroy" do
       RailsAdmin::History.destroy_all
       @players = 3.times.map { Factory.create(:player) }
       @delete_ids = @players[0..1].map(&:id)
-      get rails_admin_bulk_delete_path(:model_name => "player", :bulk_ids => @delete_ids)
+      get bulk_delete_path(:model_name => "player", :bulk_ids => @delete_ids)
       click_button "Cancel"
     end
 

--- a/spec/requests/basic/create/rails_admin_basic_create_spec.rb
+++ b/spec/requests/basic/create/rails_admin_basic_create_spec.rb
@@ -4,7 +4,7 @@ describe "RailsAdmin Basic Create" do
 
   describe "create" do
     before(:each) do
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
@@ -29,7 +29,7 @@ describe "RailsAdmin Basic Create" do
 
   describe "create and edit" do
     before(:each) do
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
@@ -54,7 +54,7 @@ describe "RailsAdmin Basic Create" do
 
   describe "create and add another" do
     before(:each) do
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
@@ -81,7 +81,7 @@ describe "RailsAdmin Basic Create" do
     before(:each) do
       @draft = Factory.create :draft
 
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => 42
@@ -103,7 +103,7 @@ describe "RailsAdmin Basic Create" do
     before(:each) do
       @divisions = 3.times.map { Factory.create :division }
 
-      get rails_admin_new_path(:model_name => "league")
+      get new_path(:model_name => "league")
 
       fill_in "league[name]", :with => "National League"
       select @divisions[0].name, :from => "league_division_ids"
@@ -128,7 +128,7 @@ describe "RailsAdmin Basic Create" do
     before(:each) do
       @teams = 3.times.map { Factory.create :team }
 
-      get rails_admin_new_path(:model_name => "fan")
+      get new_path(:model_name => "fan")
 
       fill_in "fan[name]", :with => "John Doe"
       select @teams[0].name, :from => "fan_team_ids"
@@ -153,7 +153,7 @@ describe "RailsAdmin Basic Create" do
       @team = Factory.create :team
       @player = Factory.create :player, :team => @team
 
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
 
       fill_in "player[name]", :with => @player.name
       fill_in "player[number]", :with => @player.number.to_s
@@ -169,7 +169,7 @@ describe "RailsAdmin Basic Create" do
 
   describe "create with invalid object" do
     before(:each) do
-      visit(rails_admin_create_path(:model_name => "player"), :post, :params => {:player => {}})
+      visit(create_path(:model_name => "player"), :post, :params => {:player => {}})
     end
 
     it "should show an error message" do
@@ -180,7 +180,7 @@ describe "RailsAdmin Basic Create" do
   
   describe "create with object with errors on base" do
     before(:each) do
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
       fill_in "player[name]", :with => "Jackie Robinson on steroids"
       click_button "Save and add another"
     end

--- a/spec/requests/basic/create/rails_admin_namespaced_model_create_spec.rb
+++ b/spec/requests/basic/create/rails_admin_namespaced_model_create_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "RailsAdmin Namespaced Model Create" do
 
   before(:each) do
-    get rails_admin_new_path(:model_name => "cms~basic_page")
+    get new_path(:model_name => "cms~basic_page")
 
     fill_in "cms_basic_page[title]", :with => "Hello"
     fill_in "cms_basic_page[content]", :with => "World"

--- a/spec/requests/basic/delete/rails_admin_basic_delete_spec.rb
+++ b/spec/requests/basic/delete/rails_admin_basic_delete_spec.rb
@@ -5,7 +5,7 @@ describe "RailsAdmin Basic Delete" do
   describe "delete" do
     before(:each) do
       @player = Factory.create :player
-      get rails_admin_delete_path(:model_name => "player", :id => @player.id)
+      get delete_path(:model_name => "player", :id => @player.id)
     end
 
     it "should respond successfully" do
@@ -19,7 +19,7 @@ describe "RailsAdmin Basic Delete" do
 
   describe "delete with missing object" do
     before(:each) do
-      get rails_admin_delete_path(:model_name => "player", :id => 1)
+      get delete_path(:model_name => "player", :id => 1)
     end
 
     it "should raise NotFound" do
@@ -31,7 +31,7 @@ describe "RailsAdmin Basic Delete" do
     before(:each) do
       @division = Factory.create :division
       @team = Factory.create :team, :name => "", :division => @division
-      get rails_admin_delete_path(:model_name => "division", :id => @division.id)
+      get delete_path(:model_name => "division", :id => @division.id)
     end
 
     it "should respond successfully" do

--- a/spec/requests/basic/destroy/rails_admin_basic_destroy_spec.rb
+++ b/spec/requests/basic/destroy/rails_admin_basic_destroy_spec.rb
@@ -5,7 +5,7 @@ describe "RailsAdmin Basic Destroy" do
   describe "destroy" do
     before(:each) do
       @player = Factory.create :player
-      get rails_admin_delete_path(:model_name => "player", :id => @player.id)
+      get delete_path(:model_name => "player", :id => @player.id)
       click_button "Yes, I'm sure"
       @player = RailsAdmin::AbstractModel.new("Player").first
     end
@@ -22,7 +22,7 @@ describe "RailsAdmin Basic Destroy" do
   describe "destroy" do
     before(:each) do
       @player = Factory.create :player
-      get rails_admin_delete_path(:model_name => "player", :id => @player.id)
+      get delete_path(:model_name => "player", :id => @player.id)
       click_button "Cancel"
       @player = RailsAdmin::AbstractModel.new("Player").first
     end
@@ -38,7 +38,7 @@ describe "RailsAdmin Basic Destroy" do
 
   describe "destroy with missing object" do
     before(:each) do
-      response = visit(rails_admin_destroy_path(:model_name => "player", :id => 1), :delete)
+      response = visit(destroy_path(:model_name => "player", :id => 1), :delete)
     end
 
     it "should raise NotFound" do

--- a/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
@@ -5,7 +5,7 @@ describe "RailsAdmin Basic Edit" do
   describe "edit" do
     before(:each) do
       @player = Factory.create :player
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
     end
 
     it "should respond successfully" do
@@ -32,7 +32,7 @@ describe "RailsAdmin Basic Edit" do
     before(:each) do
       @player = Factory.create :player
       @draft = Factory.create :draft
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
     end
 
     it "should respond successfully" do
@@ -48,7 +48,7 @@ describe "RailsAdmin Basic Edit" do
     before(:each) do
       @teams = 3.times.map { Factory.create :team }
       @player = Factory.create :player
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
     end
 
     it "should respond successfully" do
@@ -64,7 +64,7 @@ describe "RailsAdmin Basic Edit" do
     before(:each) do
       @teams = 3.times.map { Factory.create :team }
       @fan = Factory.create :fan, :teams => [@teams[0]]
-      get rails_admin_edit_path(:model_name => "fan", :id => @fan.id)
+      get edit_path(:model_name => "fan", :id => @fan.id)
     end
 
     it "should respond successfully" do
@@ -82,7 +82,7 @@ describe "RailsAdmin Basic Edit" do
 
   describe "edit with missing object" do
     before(:each) do
-      get rails_admin_edit_path(:model_name => "player", :id => 1)
+      get edit_path(:model_name => "player", :id => 1)
     end
 
     it "should raise NotFound" do
@@ -94,7 +94,7 @@ describe "RailsAdmin Basic Edit" do
     before(:each) do
       @player = Factory.create :player
       @teams = 3.times.map { Factory.create :team, :name => "" }
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
     end
 
     it "should respond successfully" do

--- a/spec/requests/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/requests/basic/list/rails_admin_basic_list_spec.rb
@@ -4,7 +4,7 @@ describe "RailsAdmin Basic List" do
 
   describe "GET /admin" do
     before(:each) do
-      get rails_admin_dashboard_path
+      get dashboard_path
     end
 
     it "should respond successfully" do
@@ -15,7 +15,7 @@ describe "RailsAdmin Basic List" do
   describe "GET /admin/player as list" do
     before(:each) do
       21.times { Factory.create :player } # two pages of players
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
     end
 
     it "should respond successfully" do
@@ -46,7 +46,7 @@ describe "RailsAdmin Basic List" do
   describe "GET /admin/player with sort" do
     before(:each) do
       @players = 2.times.map { Factory.create :player }
-      get rails_admin_list_path(:model_name => "player", :sort => "name", :set => 1)
+      get list_path(:model_name => "player", :sort => "name", :set => 1)
     end
 
     it "should respond successfully" do
@@ -62,7 +62,7 @@ describe "RailsAdmin Basic List" do
 
     before(:each) do
       @players = 2.times.map { Factory.create :player }
-      get rails_admin_list_path(:model_name => "player", :sort => "name", :sort_reverse => "true", :set => 1)
+      get list_path(:model_name => "player", :sort => "name", :sort_reverse => "true", :set => 1)
     end
 
     it "should respond successfully" do
@@ -77,7 +77,7 @@ describe "RailsAdmin Basic List" do
   describe "GET /admin/player with field search" do
     before(:each) do
       @players = 2.times.map { Factory.create :player }
-      get rails_admin_list_path(:model_name => "player", :query => "number:#{@players[0].number}", :set => 1)
+      get list_path(:model_name => "player", :query => "number:#{@players[0].number}", :set => 1)
     end
 
     it "should respond successfully" do
@@ -96,7 +96,7 @@ describe "RailsAdmin Basic List" do
   describe "GET /admin/player with query" do
     before(:each) do
       @players = 2.times.map { Factory.create :player }
-      get rails_admin_list_path(:model_name => "player", :query => @players[0].name, :set => 1)
+      get list_path(:model_name => "player", :query => @players[0].name, :set => 1)
     end
 
     it "should respond successfully" do
@@ -120,7 +120,7 @@ describe "RailsAdmin Basic List" do
         Factory.create(:player, :injured => true),
         Factory.create(:player, :injured => false),
       ]
-      get rails_admin_list_path(:model_name => "player", :query => @players[0].name, :filter => {:injured => "true"}, :set => 1)
+      get list_path(:model_name => "player", :query => @players[0].name, :filter => {:injured => "true"}, :set => 1)
     end
 
     it "should respond successfully" do
@@ -144,7 +144,7 @@ describe "RailsAdmin Basic List" do
         Factory.create(:player, :injured => true),
         Factory.create(:player, :injured => false),
       ]
-      get rails_admin_list_path(:model_name => "player", :filter => {:injured => "true"}, :set => 1)
+      get list_path(:model_name => "player", :filter => {:injured => "true"}, :set => 1)
     end
 
     it "should respond successfully" do
@@ -168,7 +168,7 @@ describe "RailsAdmin Basic List" do
         Factory.create(:player, :retired => false, :injured => true),
         Factory.create(:player, :retired => false, :injured => false),
       ]
-      get rails_admin_list_path(:model_name => "player", :filter => {:retired => "true", :injured => "true"}, :set => 1)
+      get list_path(:model_name => "player", :filter => {:retired => "true", :injured => "true"}, :set => 1)
     end
 
     it "should respond successfully" do
@@ -189,7 +189,7 @@ describe "RailsAdmin Basic List" do
   describe "GET /admin/player with 2 objects" do
     before(:each) do
       @players = 2.times.map { Factory.create :player }
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
     end
 
     it "should respond successfully" do
@@ -204,7 +204,7 @@ describe "RailsAdmin Basic List" do
   describe "GET /admin/player with 20 objects" do
     before(:each) do
       @players = 20.times.map { Factory.create :player }
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
     end
 
     it "should respond successfully" do
@@ -220,7 +220,7 @@ describe "RailsAdmin Basic List" do
     before(:each) do
       items_per_page = RailsAdmin::Config::Sections::List.default_items_per_page
       (items_per_page * 20).times { Factory.create(:player) }
-      get rails_admin_list_path(:model_name => "player", :page => 8)
+      get list_path(:model_name => "player", :page => 8)
     end
 
     it "should respond successfully" do
@@ -236,7 +236,7 @@ describe "RailsAdmin Basic List" do
     before(:each) do
       items_per_page = RailsAdmin::Config::Sections::List.default_items_per_page
       (items_per_page * 20).times { Factory.create(:player) }
-      get rails_admin_list_path(:model_name => "player", :page => 18)
+      get list_path(:model_name => "player", :page => 18)
     end
 
     it "should respond successfully" do
@@ -251,7 +251,7 @@ describe "RailsAdmin Basic List" do
   describe "GET /admin/player show all" do
     before(:each) do
       2.times.map { Factory.create :player }
-      get rails_admin_list_path(:model_name => "player", :all => true)
+      get list_path(:model_name => "player", :all => true)
     end
 
     it "should respond successfully" do

--- a/spec/requests/basic/new/rails_admin_basic_new_spec.rb
+++ b/spec/requests/basic/new/rails_admin_basic_new_spec.rb
@@ -4,7 +4,7 @@ describe "RailsAdmin Basic New" do
 
   describe "GET /admin/player/new" do
     before(:each) do
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
     end
 
     it "should respond successfully" do
@@ -37,7 +37,7 @@ describe "RailsAdmin Basic New" do
   describe "GET /admin/player/new with has-one association" do
     before(:each) do
       Factory.create :draft
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
     end
 
     it "should respond successfully" do
@@ -52,7 +52,7 @@ describe "RailsAdmin Basic New" do
   describe "GET /admin/player/new with has-many association" do
     before(:each) do
       @teams = 3.times.map { Factory.create :team }
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
     end
 
     it "should respond successfully" do
@@ -69,7 +69,7 @@ describe "RailsAdmin Basic New" do
   describe "GET /admin/team/:id/fans/new with has-and-belongs-to-many association" do
     before(:each) do
       @teams = 3.times.map { Factory.create :team }
-      get rails_admin_new_path(:model_name => "fan")
+      get new_path(:model_name => "fan")
     end
 
     it "should respond successfully" do
@@ -86,7 +86,7 @@ describe "RailsAdmin Basic New" do
   describe "GET /admin/player/new with missing label" do
     before(:each) do
       Factory.create :team, :name => ""
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
     end
 
     it "should respond successfully" do

--- a/spec/requests/basic/new/rails_admin_namespaced_model_new_spec.rb
+++ b/spec/requests/basic/new/rails_admin_namespaced_model_new_spec.rb
@@ -16,7 +16,7 @@ describe "RailsAdmin Namespaced Model New" do
 
   describe "GET /admin/cms_basic_page/new" do
     before(:each) do
-      get rails_admin_new_path(:model_name => "cms~basic_page")
+      get new_path(:model_name => "cms~basic_page")
     end
 
     it "should respond successfully", :only =>true do

--- a/spec/requests/basic/update/rails_admin_basic_update_spec.rb
+++ b/spec/requests/basic/update/rails_admin_basic_update_spec.rb
@@ -5,7 +5,7 @@ describe "RailsAdmin Basic Update" do
   describe "update with errors" do
     before(:each) do
       @player = Factory.create :player
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
     end
 
     it "should return to edit page" do
@@ -20,7 +20,7 @@ describe "RailsAdmin Basic Update" do
     before(:each) do
       @player = Factory.create :player
 
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
@@ -47,7 +47,7 @@ describe "RailsAdmin Basic Update" do
     before(:each) do
       @player = Factory.create :player
 
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
@@ -75,7 +75,7 @@ describe "RailsAdmin Basic Update" do
       @player = Factory.create :player
       @draft = Factory.create :draft
 
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
@@ -103,7 +103,7 @@ describe "RailsAdmin Basic Update" do
       @league = Factory.create :league
       @divisions = 3.times.map { Factory.create :division }
 
-      get rails_admin_edit_path(:model_name => "league", :id => @league.id)
+      get edit_path(:model_name => "league", :id => @league.id)
 
       fill_in "league[name]", :with => "National League"
       select @divisions[0].name, :from => "league_division_ids"
@@ -133,7 +133,7 @@ describe "RailsAdmin Basic Update" do
 
     describe "removing has-many associations" do
       before(:each) do
-        get rails_admin_edit_path(:model_name => "league", :id => @league.id)
+        get edit_path(:model_name => "league", :id => @league.id)
 
         unselect @divisions[0].name, :from => "league_division_ids"
         click_button "Save"
@@ -157,7 +157,7 @@ describe "RailsAdmin Basic Update" do
       @teams = 3.times.map { Factory.create :team }
       @fan = Factory.create :fan, :teams => [@teams[0]]
 
-      get rails_admin_edit_path(:model_name => "fan", :id => @fan.id)
+      get edit_path(:model_name => "fan", :id => @fan.id)
 
       select @teams[1].name, :from => "fan_team_ids"
       click_button "Save"
@@ -177,7 +177,7 @@ describe "RailsAdmin Basic Update" do
 
   describe "update with missing object" do
     before(:each) do
-      visit(rails_admin_update_path(:model_name => "player", :id => 1), :put, {:player => {:name => "Jackie Robinson", :number => 42, :position => "Second baseman"}})
+      visit(update_path(:model_name => "player", :id => 1), :put, {:player => {:name => "Jackie Robinson", :number => 42, :position => "Second baseman"}})
     end
 
     it "should raise NotFound" do
@@ -189,7 +189,7 @@ describe "RailsAdmin Basic Update" do
     before(:each) do
       @player = Factory.create :player
 
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
 
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "a"
@@ -208,7 +208,7 @@ describe "RailsAdmin Basic Update" do
     before(:each) do
       @user = Factory.create :user
 
-      get rails_admin_edit_path(:model_name => "user", :id => @user.id)
+      get edit_path(:model_name => "user", :id => @user.id)
 
       fill_in "user[roles]", :with => "[\"admin\", \"user\"]"
       click_button "Save"

--- a/spec/requests/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/requests/config/edit/rails_admin_config_edit_spec.rb
@@ -13,7 +13,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       # Should not have the group header
       response.should_not have_tag("legend", :content => "Hidden Group")
       # Should not have any of the group's fields either
@@ -38,7 +38,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       # Should not have the group header
       response.should_not have_tag("legend", :content => "Players")
       # Should not have any of the group's fields either
@@ -53,7 +53,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
 
       response.should have_tag("legend", :content => "Renamed group")
     end
@@ -71,7 +71,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag("legend", :content => "Basic info")
       response.should have_tag("legend", :content => "Belong's to associations")
       response.should have_tag(".field") do |elements|
@@ -99,7 +99,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements.should have_tag("label", :content => "Name")
         elements.should have_tag("label", :content => "Logo url")
@@ -113,7 +113,7 @@ describe "RailsAdmin Config DSL Edit Section" do
   describe "items' fields" do
 
     it "should show all by default" do
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag("select#team_division_id")
       response.should have_tag("input#team_name")
       response.should have_tag("input#team_logo_url")
@@ -137,7 +137,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           field :name
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("#team_manager")
         elements[1].should have_tag("#team_division_id")
@@ -152,7 +152,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           field :name
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("#team_division_id")
         elements[1].should have_tag("#team_name")
@@ -168,7 +168,7 @@ describe "RailsAdmin Config DSL Edit Section" do
         end
       end
 
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("label", :content => "Team Manager")
         elements[1].should have_tag("label", :content => "Some Fans")
@@ -185,7 +185,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           field :name
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("label", :content => "Renamed field")
         elements[1].should have_tag("label", :content => "Division")
@@ -201,7 +201,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements.should have_tag("label", :content => "Division")
         elements.should have_tag("label", :content => "Name (STRING)")
@@ -227,7 +227,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements.should have_tag("label", :content => "Division")
         elements.should have_tag("label", :content => "Name (STRING)")
@@ -255,7 +255,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           field :name
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("#team_division_id")
         elements[1].should have_tag("#team_name")
@@ -270,7 +270,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements.should have_tag("label", :content => "Division")
         elements.should_not have_tag("label", :content => "Name")
@@ -296,7 +296,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements.should have_tag("label", :content => "Division")
         elements.should_not have_tag("label", :content => "Name")
@@ -324,7 +324,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           field :name
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("p.help", :content => "Required 100 characters or fewer. Additional help text for manager field.")
         elements[1].should have_tag("p.help", :content => "Required")
@@ -346,7 +346,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag(".field") do |elements|
         elements[0].should have_tag("p.help", :content => "Optional 100 characters or fewer.")
         elements[1].should have_tag("p.help", :content => "Optional")
@@ -365,7 +365,7 @@ describe "RailsAdmin Config DSL Edit Section" do
     describe "a datetime field" do
 
       it "should default to %B %d, %Y %H:%M" do
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[datetime_field]", :with => @time.strftime("%B %d, %Y %H:%M")
         click_button "Save"
@@ -384,7 +384,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
 
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[datetime_field]", :with => @time.strftime("%a, %d %b %Y %H:%M:%S")
         click_button "Save"
@@ -403,7 +403,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
 
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[datetime_field]", :with => @time.strftime("%Y-%m-%d %H:%M:%S")
         click_button "Save"
@@ -417,7 +417,7 @@ describe "RailsAdmin Config DSL Edit Section" do
     describe "a timestamp field" do
 
       it "should default to %B %d, %Y %H:%M" do
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[timestamp_field]", :with => @time.strftime("%B %d, %Y %H:%M")
         click_button "Save"
@@ -436,7 +436,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
 
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[timestamp_field]", :with => @time.strftime("%a, %d %b %Y %H:%M:%S")
         click_button "Save"
@@ -455,7 +455,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
 
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[timestamp_field]", :with => @time.strftime("%Y-%m-%d %H:%M:%S")
         click_button "Save"
@@ -469,7 +469,7 @@ describe "RailsAdmin Config DSL Edit Section" do
     describe "a time field" do
 
       it "should default to %H:%M" do
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[time_field]", :with => @time.strftime("%H:%M")
         click_button "Save"
@@ -488,7 +488,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
 
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[time_field]", :with => @time.strftime("%I:%M %p")
         click_button "Save"
@@ -502,7 +502,7 @@ describe "RailsAdmin Config DSL Edit Section" do
     describe "a date field" do
 
       it "should default to %B %d, %Y" do
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[date_field]", :with => @time.strftime("%B %d, %Y")
         click_button "Save"
@@ -522,7 +522,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
 
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[date_field]", :with => @time.strftime("%Y-%m-%d")
         click_button "Save"
@@ -541,7 +541,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
 
-        get rails_admin_new_path(:model_name => "field_test")
+        get new_path(:model_name => "field_test")
 
         fill_in "field_test[date_field]", :with => @time.strftime("%Y-%m-%d")
         click_button "Save"
@@ -595,7 +595,7 @@ describe "RailsAdmin Config DSL Edit Section" do
         end
       end
 
-      get rails_admin_new_path(:model_name => "draft")
+      get new_path(:model_name => "draft")
       response.should contain(/CKEDITOR\.replace.*?draft_notes/)
     end
   end
@@ -608,7 +608,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           field :avatar
         end
       end
-      get rails_admin_new_path(:model_name => "user")
+      get new_path(:model_name => "user")
       response.should have_tag("input#user_avatar")
     end
 
@@ -627,7 +627,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           field :color
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag("select.enum")
       
       #Reset
@@ -645,7 +645,7 @@ describe "RailsAdmin Config DSL Edit Section" do
           end
         end
       end
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should have_tag("input.color")
     end
   end
@@ -771,29 +771,29 @@ describe "RailsAdmin Config DSL Edit Section" do
         end
       end
 
-      get rails_admin_new_path(:model_name => "player")
+      get new_path(:model_name => "player")
       response.should have_tag("input#player_name")
       response.should_not contain(TF_CREATE_OUTPUT)
       response.should_not contain(TF_UPDATE_OUTPUT)
       @player = Factory.create :player
-      get rails_admin_edit_path(:model_name => "player", :id => @player.id)
+      get edit_path(:model_name => "player", :id => @player.id)
       response.should have_tag("input#player_name")
       response.should_not contain(TF_CREATE_OUTPUT)
       response.should_not contain(TF_UPDATE_OUTPUT)
 
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should contain(TF_CREATE_OUTPUT)
       response.should_not contain(TF_UPDATE_OUTPUT)
       @team = Factory.create :team
-      get rails_admin_edit_path(:model_name => "team", :id => @team.id)
+      get edit_path(:model_name => "team", :id => @team.id)
       response.should contain(TF_CREATE_OUTPUT)
       response.should_not contain(TF_UPDATE_OUTPUT)
 
-      get rails_admin_new_path(:model_name => "league")
+      get new_path(:model_name => "league")
       response.should contain(TF_CREATE_OUTPUT)
       response.should_not contain(TF_UPDATE_OUTPUT)
       @league = Factory.create :league
-      get rails_admin_edit_path(:model_name => "league", :id => @league.id)
+      get edit_path(:model_name => "league", :id => @league.id)
       response.should_not contain(TF_CREATE_OUTPUT)
       response.should contain(TF_UPDATE_OUTPUT)
     end

--- a/spec/requests/config/list/rails_admin_config_list_spec.rb
+++ b/spec/requests/config/list/rails_admin_config_list_spec.rb
@@ -17,11 +17,11 @@ describe "RailsAdmin Config DSL List Section" do
           items_per_page 1
         end
       end
-      get rails_admin_list_path(:model_name => "league")
+      get list_path(:model_name => "league")
       response.should have_tag(".grid tbody tr") do |elements|
         elements.should have_at_most(1).items
       end
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
       response.should have_tag(".grid tbody tr") do |elements|
         elements.should have_at_most(1).items
       end
@@ -33,11 +33,11 @@ describe "RailsAdmin Config DSL List Section" do
           items_per_page 1
         end
       end
-      get rails_admin_list_path(:model_name => "league")
+      get list_path(:model_name => "league")
       response.should have_tag(".grid tbody tr") do |elements|
         elements.should have_at_most(1).items
       end
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
       response.should have_tag(".grid tbody tr") do |elements|
         elements.should have_at_most(2).items
       end
@@ -54,11 +54,11 @@ describe "RailsAdmin Config DSL List Section" do
           items_per_page 1
         end
       end
-      get rails_admin_list_path(:model_name => "league")
+      get list_path(:model_name => "league")
       response.should have_tag(".grid tbody tr") do |elements|
         elements.should have_at_most(1).items
       end
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
       response.should have_tag(".grid tbody tr") do |elements|
         elements.should have_at_most(2).items
       end
@@ -68,7 +68,7 @@ describe "RailsAdmin Config DSL List Section" do
   describe "items' fields" do
 
     it "should show all by default" do
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should contain("ID")
         elements[2].should contain("CREATED AT")
@@ -86,7 +86,7 @@ describe "RailsAdmin Config DSL List Section" do
           field :created_at
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should contain("UPDATED AT")
         elements[2].should contain("NAME")
@@ -102,7 +102,7 @@ describe "RailsAdmin Config DSL List Section" do
           field :name
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements.should contain("ID")
         elements.should contain("NAME")
@@ -117,7 +117,7 @@ describe "RailsAdmin Config DSL List Section" do
           field :name
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should contain("HIS NAME")
       end
@@ -132,7 +132,7 @@ describe "RailsAdmin Config DSL List Section" do
           field :name
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should contain("IDENTIFIER")
         elements[2].should contain("NAME")
@@ -147,7 +147,7 @@ describe "RailsAdmin Config DSL List Section" do
           end
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should contain("ID")
         elements[2].should contain("CREATED AT (DATETIME)")
@@ -164,7 +164,7 @@ describe "RailsAdmin Config DSL List Section" do
           end
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should contain("ID")
         elements[2].should contain("CREATED AT (DATETIME)")
@@ -174,7 +174,7 @@ describe "RailsAdmin Config DSL List Section" do
     end
 
     it "should be sortable by default" do
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should have_tag("a")
         elements[2].should have_tag("a")
@@ -192,7 +192,7 @@ describe "RailsAdmin Config DSL List Section" do
           field :name
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should_not have_tag("a")
         elements[2].should have_tag("a")
@@ -211,7 +211,7 @@ describe "RailsAdmin Config DSL List Section" do
           field :updated_at
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should have_tag("a")
         elements[2].should have_tag("a")
@@ -232,7 +232,7 @@ describe "RailsAdmin Config DSL List Section" do
           field :updated_at
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements[1].should have_tag("a")
         elements[2].should have_tag("a")
@@ -249,7 +249,7 @@ describe "RailsAdmin Config DSL List Section" do
           end
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements.should contain("ID")
         elements.should contain("NAME")
@@ -266,7 +266,7 @@ describe "RailsAdmin Config DSL List Section" do
           end
         end
       end
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.should have_tag(".grid thead th") do |elements|
         elements.should contain("ID")
         elements.should contain("NAME")
@@ -287,7 +287,7 @@ describe "RailsAdmin Config DSL List Section" do
 
       @fans = 2.times.map { Factory.create :fan }
 
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
 
       response.should have_tag(".grid") do |table|
         table.should have_tag("thead th:nth-child(2).customClass")
@@ -310,7 +310,7 @@ describe "RailsAdmin Config DSL List Section" do
 
       @fans = 2.times.map { Factory.create :fan }
 
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
 
       response.should have_tag(".grid") do |table|
         table.should have_tag("thead th:nth-child(3).customClass")
@@ -335,7 +335,7 @@ describe "RailsAdmin Config DSL List Section" do
 
       @fans = 2.times.map { Factory.create :fan }
 
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
 
       response.should have_tag(".grid") do |table|
         table.should have_tag("thead th:nth-child(3).customClass")
@@ -363,7 +363,7 @@ describe "RailsAdmin Config DSL List Section" do
 
       @fans = 2.times.map { Factory.create :fan }
 
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
 
       response.should have_tag("style") {|css| css.should contain(/\.grid thead \.id[^{]*\{[^a-z]*width:[^\d]*2\d{2}px;[^{]*\}/) }
     end
@@ -384,7 +384,7 @@ describe "RailsAdmin Config DSL List Section" do
 
       @fans = 2.times.map { Factory.create :fan }
 
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
 
       response.should have_tag(".grid tbody tr") do |elements|
         elements[0].should have_tag("td:nth-child(3)") {|li| li.should contain(@fans[1].name.upcase) }
@@ -406,7 +406,7 @@ describe "RailsAdmin Config DSL List Section" do
 
       @fans = 2.times.map { Factory.create :fan }
 
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
 
       response.should have_tag(".grid tbody tr") do |elements|
         elements[0].should have_tag("td:nth-child(4)") do |li|
@@ -429,7 +429,7 @@ describe "RailsAdmin Config DSL List Section" do
 
       @fans = 2.times.map { Factory.create :fan }
 
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
 
       response.should have_tag(".grid tbody tr") do |elements|
         elements[0].should have_tag("td:nth-child(4)") do |li|
@@ -450,7 +450,7 @@ describe "RailsAdmin Config DSL List Section" do
       @team = Factory.create :team
       @players = 2.times.map { Factory.create :player, :team => @team }
 
-      get rails_admin_list_path(:model_name => "team")
+      get list_path(:model_name => "team")
 
       response.should have_tag(".grid tbody tr") do |elements|
         elements[0].should have_tag("td:nth-child(4)") {|li| li.should contain(@players.collect(&:name).join(", ")) }
@@ -491,7 +491,7 @@ describe "RailsAdmin Config DSL List Section" do
           end
         end
 
-        get rails_admin_list_path(:model_name => "player")
+        get list_path(:model_name => "player")
         response.should have_tag(".grid tbody tr") do |elements|
           player_names_by_date.reverse.each_with_index do |name, i|
             elements[i].should contain(name)
@@ -507,7 +507,7 @@ describe "RailsAdmin Config DSL List Section" do
           end
         end
 
-        get rails_admin_list_path(:model_name => "player")
+        get list_path(:model_name => "player")
         response.should have_tag(".grid tbody tr") do |elements|
           player_names_by_date.reverse.each_with_index do |name, i|
             elements[i].should contain(name)
@@ -532,14 +532,14 @@ describe "RailsAdmin Config DSL List Section" do
           end
         end
 
-        get rails_admin_list_path(:model_name => "league")
+        get list_path(:model_name => "league")
         response.should have_tag(".grid tbody tr") do |elements|
           league_names_by_date.reverse.each_with_index do |name, i|
             elements[i].should contain(name)
           end
         end
 
-        get rails_admin_list_path(:model_name => "player")
+        get list_path(:model_name => "player")
         response.should have_tag(".grid tbody tr") do |elements|
           @players.sort_by{|p| p[:id]}.map{|p| p[:name]}.reverse.each_with_index do |name, i|
             elements[i].should contain(name)
@@ -555,7 +555,7 @@ describe "RailsAdmin Config DSL List Section" do
         end
       end
 
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
       response.should have_tag(".grid tbody tr") do |elements|
         player_names_by_date.reverse.each_with_index do |name, i|
           elements[i].should contain(name)
@@ -571,7 +571,7 @@ describe "RailsAdmin Config DSL List Section" do
         end
       end
 
-      get rails_admin_list_path(:model_name => "player")
+      get list_path(:model_name => "player")
       response.should have_tag(".grid tbody tr") do |elements|
         player_names_by_date.each_with_index do |name, i|
           elements[i].should contain(name)

--- a/spec/requests/config/navigation/rails_admin_config_navigation_spec.rb
+++ b/spec/requests/config/navigation/rails_admin_config_navigation_spec.rb
@@ -13,7 +13,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
       RailsAdmin.config do |config|
         config.navigation.max_visible_tabs 2
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav > li") do |elements|
         elements.should have_at_most(4).items
       end
@@ -41,7 +41,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
       RailsAdmin.config do |config|
         config.navigation.max_visible_tabs 20
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav>li>a") do |as|
         as.map(&:content)[1..-1].should == ["Cms/Basic Page", "Comment", "Division", "Draft", "Fan", "League", "Player", "Team", "User"]
       end
@@ -54,7 +54,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
           weight -1
         end
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav>li>a") do |as|
         as.map(&:content)[1..-1].should == ["Team", "Cms/Basic Page", "Comment", "Division", "Draft", "Fan", "League", "Player", "User"]
       end
@@ -67,7 +67,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
           parent Cms::BasicPage
         end
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav>li>a") do |as|
         as.map(&:content)[1..-1].should == ["Cms/Basic Page", "Division", "Draft", "Fan", "League", "Player", "Team", "User"]
       end
@@ -85,7 +85,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
           dropdown "CMS related"
         end
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav>li>a") do |as|
         as.map(&:content)[1..-1].should == ["CMS related", "Division", "Draft", "Fan", "League", "Player", "Team", "User"]
       end
@@ -104,7 +104,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
           weight 1
         end
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav>li>a") do |as|
         as.map(&:content)[1..-1].should == ["Division", "Draft", "Fan", "League", "Player", "Team", "User", "CMS related"]
       end
@@ -114,7 +114,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
   describe "label for a model" do
 
     it "should be visible and sane by default" do
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav") do |navigation|
         navigation.should have_tag("li a", :content => "Fan")
       end
@@ -124,7 +124,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
       RailsAdmin.config Fan do
         label "Fan test 1"
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav") do |navigation|
         navigation.should have_tag("li a", :content => "Fan test 1")
       end
@@ -134,7 +134,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
       RailsAdmin.config Fan do
         hide
       end
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should have_tag("#nav") do |navigation|
         navigation.should_not have_tag("li a", :content => "Fan")
       end

--- a/spec/requests/config/rails_admin_config_spec.rb
+++ b/spec/requests/config/rails_admin_config_spec.rb
@@ -12,7 +12,7 @@ describe "RailsAdmin Config DSL" do
     it "should be hidden from navigation" do
       # Make query in team's edit view to make sure loading
       # the related division model config will not mess the navigation
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       excluded_models.each do |model|
         response.should have_tag("#nav") do |navigation|
           navigation.should_not have_tag("li a", :content => model.to_s)
@@ -21,17 +21,17 @@ describe "RailsAdmin Config DSL" do
     end
 
     it "should raise NotFound for the list view" do
-      get rails_admin_list_path(:model_name => "fan")
+      get list_path(:model_name => "fan")
       response.status.should equal(404)
     end
 
     it "should raise NotFound for the create view" do
-      get rails_admin_new_path(:model_name => "fan")
+      get new_path(:model_name => "fan")
       response.status.should equal(404)
     end
 
     it "should be hidden from other models relations in the edit view" do
-      get rails_admin_new_path(:model_name => "team")
+      get new_path(:model_name => "team")
       response.should_not have_tag("#team_division_id")
       response.should_not have_tag("input#team_fans")
     end

--- a/spec/requests/history/rails_admin_history_spec.rb
+++ b/spec/requests/history/rails_admin_history_spec.rb
@@ -50,7 +50,7 @@ describe "RailsAdmin History" do
 
   describe "history ajax update" do
     it "shouldn't use the application layout" do
-      post rails_admin_history_list_path, :ref => 0, :section => 4
+      post history_list_path, :ref => 0, :section => 4
       response.should_not have_tag "h1#app_layout_warning"
     end
   end
@@ -81,7 +81,7 @@ describe "RailsAdmin History" do
 
     context "GET admin/history/@model" do
       before :each do
-        get rails_admin_history_model_path(@model)
+        get history_model_path(@model)
       end
 
       it "should render successfully" do
@@ -110,7 +110,7 @@ describe "RailsAdmin History" do
         end
 
         it "should render a XHR request successfully" do
-          xhr :get, rails_admin_history_model_path(@model, :page => 2)
+          xhr :get, history_model_path(@model, :page => 2)
           response.should be_successful
         end
       end

--- a/spec/requests/rails_admin_spec.rb
+++ b/spec/requests/rails_admin_spec.rb
@@ -6,7 +6,7 @@ describe "RailsAdmin" do
     it "should be disableable" do
       logout
       RailsAdmin.authenticate_with {}
-      get rails_admin_dashboard_path
+      get dashboard_path
       response.should be_successful
     end
   end
@@ -16,7 +16,7 @@ describe "RailsAdmin" do
   # file as template for a new translation).
   describe "localization" do
     it "should default to English" do
-      get rails_admin_dashboard_path
+      get dashboard_path
 
       response.should contain("Site administration")
       response.should contain("Dashboard")
@@ -24,7 +24,7 @@ describe "RailsAdmin" do
   end
 
   describe "html head" do
-    before { get rails_admin_dashboard_path }
+    before { get dashboard_path }
     subject { response }
 
     # Note: the [href^="/sty... syntax matches the start of a value. The reason
@@ -51,13 +51,13 @@ describe "RailsAdmin" do
     end
 
     it "should work like belongs to associations in the list view" do
-      get rails_admin_list_path(:model_name => "comment")
+      get list_path(:model_name => "comment")
 
       response.body.should contain(@team.name)
     end
 
     it "should be editable" do
-      get rails_admin_edit_path(:model_name => "comment", :id => @comment.id)
+      get edit_path(:model_name => "comment", :id => @comment.id)
 
       response.should have_tag("legend", :content => "Commentable")
       response.should have_tag("select#comment_commentable_type")
@@ -65,7 +65,7 @@ describe "RailsAdmin" do
     end
 
     it "should be hidden in the owning end" do
-      get rails_admin_edit_path(:model_name => "team", :id => @team.id)
+      get edit_path(:model_name => "team", :id => @team.id)
 
       response.should_not have_tag("legend", :content => "Comments")
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,7 @@ RSpec.configure do |config|
   config.include Webrat::HaveTagMatcher
   config.include DatabaseHelpers
   config.include GeneratorHelpers
+  config.include RailsAdmin::Engine.routes.url_helpers
 
   # == Mock Framework
   config.mock_with :rr


### PR DESCRIPTION
This addresses #69 - making RailsAdmin mountable to a custom endpoint which Rails 3.1 supports.

This request has one issue I wasn't able to fix - see [user_info partial's line 10](https://github.com/kaapa/rails_admin/pull/new#L11R10). I don't know whether it's a Devise or RailsAdmin issue, but for some reason all the Devise paths don't seem to be available for our engine.

Also this does not improve the situation with test failures (#456). Many valid urls produce the page not found response for Rspec/Webrat although same urls work perfectly when browsing the DummyApp with browser.
