### PR TITLE
Removes hardcoded english in rails_admin/main/delete.html.haml

### DIFF
--- a/app/views/rails_admin/main/delete.html.haml
+++ b/app/views/rails_admin/main/delete.html.haml
@@ -4,13 +4,16 @@
   = breadcrumbs_for :delete, @object
   
   .content
-    %h2.title Delete confirmation
+    %h2.title= t("admin.delete.delete_confirmation")
     .inner
       = render(:partial => 'layouts/rails_admin/flash', :locals => {:flash => flash})
       %p
-        Are you sure you want to delete the #{@abstract_model.pretty_name.downcase} &ldquo;
+        = t("admin.delete.are_you_sure_you_want_to_delete_the_object", :model_name => @abstract_model.pretty_name.downcase)
+        &ldquo;
         %strong>= @model_config.with(:object => @object).object_label
-        \&rdquo;? All of the following related items will be deleted:
+        \&rdquo;
+        %span>
+        = t("admin.delete.all_of_the_following_related_items_will_be_deleted")
 
       %div{:style=>"padding-left:20px"}= render :partial => "delete_notice", :object => @object
 
@@ -24,4 +27,4 @@
             = t("admin.delete.confirmation")
 
           %button.button{:type => "submit", :name => "_continue"}
-            =t("admin.new.cancel")
+            = t("admin.new.cancel")

--- a/config/locales/rails_admin.bg.yml
+++ b/config/locales/rails_admin.bg.yml
@@ -49,7 +49,10 @@ bg:
       save_and_edit: "Запамети и редактирай"
       cancel: "Откажи"
     delete:
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Да, сигурен съм"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.da.yml
+++ b/config/locales/rails_admin.da.yml
@@ -46,8 +46,10 @@ da:
       save_and_edit: "Gem og rediger"
       cancel: "Fortryd"
     delete:
-      flash_confirmation: "%{name} er nu slettet"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Ja, jeg er sikker"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.de.yml
+++ b/config/locales/rails_admin.de.yml
@@ -50,8 +50,10 @@ de:
       save_and_edit: "Speichern und bearbeiten"
       cancel: "Abbrechen"
     delete:
-      flash_confirmation: "%{name} wurde erfolgreich entfernt"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Ja, ich bin sicher"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -50,8 +50,10 @@ en:
       save_and_edit: "Save and edit"
       cancel: "Cancel"
     delete:
-      flash_confirmation: "%{name} was successfully destroyed"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Yes, I'm sure"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.es.yml
+++ b/config/locales/rails_admin.es.yml
@@ -47,8 +47,10 @@ es:
       save_and_edit: "Guardar y editar"
       cancel: "Cancelar"
     delete:
-      flash_confirmation: "%{name} fue eliminado exitosamente"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Sí, estoy seguro"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Exportar a %{name}"
       select: "Selecciona los campos a exportar"

--- a/config/locales/rails_admin.fi.yml
+++ b/config/locales/rails_admin.fi.yml
@@ -48,8 +48,10 @@ fi:
       save_and_edit: "Tallenna ja muokkaa"
       cancel: "Peruuta"
     delete:
-      flash_confirmation: "%{name} poistettiin onnistuneesti"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Kyllä, olen varma"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Vie %{name} muodossa"
       select: "Valitse vietävät kentät"

--- a/config/locales/rails_admin.fr.yml
+++ b/config/locales/rails_admin.fr.yml
@@ -47,8 +47,10 @@ fr:
       cancel: "Annuler"
       add_new: "Ajouter un(e) %{name}"
     delete:
-      flash_confirmation: "%{name} a été détruit(e) avec succès"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Oui, je suis sûr(e)"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Exporter en %{name}"
       select: "Sélectionner les champs à exporter"

--- a/config/locales/rails_admin.hr.yml
+++ b/config/locales/rails_admin.hr.yml
@@ -48,8 +48,10 @@ hr:
       save_and_edit: "Spremi i uredi"
       cancel: "Odustani"
     delete:
-      flash_confirmation: "%{name} je uspješno obrisan(o)"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Da, siguran sam"
+      delete_confirmation: "Delete confirmation"
     flash:
       successful: "%{name} je uspješno %{action}"
       error: "%{name} nije uspješno %{action}"

--- a/config/locales/rails_admin.lt.yml
+++ b/config/locales/rails_admin.lt.yml
@@ -49,8 +49,10 @@ lt:
       save_and_edit: "Išsaugoti ir tęsti redagavimą"
       cancel: "Atšaukti"
     delete:
-      flash_confirmation: "%{name} ištrintas"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Taip, aš sutinku"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.lv.yml
+++ b/config/locales/rails_admin.lv.yml
@@ -47,8 +47,10 @@ lv:
       save_and_edit: "Saglabāt un labot"
       cancel: "Atcelt"
     delete:
-      flash_confirmation: "%{name} veiksmīgi izdzēsts"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Jā, esmu pārliecināts"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.mn.yml
+++ b/config/locales/rails_admin.mn.yml
@@ -50,8 +50,10 @@ mn:
       save_and_edit: "Хадгалаад засах"
       cancel: "Болих"
     delete:
-      flash_confirmation: "%{name} -г устгалаа"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Итгэлтэй байна уу"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.nl.yml
+++ b/config/locales/rails_admin.nl.yml
@@ -50,8 +50,10 @@ nl:
       save_and_edit: "Opslaan en aanpassen"
       cancel: "Annuleren"
     delete:
-      flash_confirmation: "%{name} succesvol verwijderd"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Ja, ik weet het zeker"
+      delete_confirmation: "Delete confirmation"
     flash:
       successful: "%{name} succesvol %{action}"
       error: "%{name} onsuccesvol %{action}"

--- a/config/locales/rails_admin.pl.yml
+++ b/config/locales/rails_admin.pl.yml
@@ -50,8 +50,10 @@ pl:
       save_and_edit: "Zapisz i wróć do edycji"
       cancel: "Anuluj"
     delete:
-      flash_confirmation: "%{name} zastał usunięty"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Tak, jestem pewien."
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.pt-BR.yml
+++ b/config/locales/rails_admin.pt-BR.yml
@@ -50,8 +50,10 @@ pt-BR:
       save_and_edit: "Gravar e alterar"
       cancel: "Cancelar"
     delete:
-      flash_confirmation: "%{name} foi apagado com sucesso!"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Sim, com certeza."
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Exportar para %{name}"
       select: "Selecione os campos para exportar"

--- a/config/locales/rails_admin.pt-PT.yml
+++ b/config/locales/rails_admin.pt-PT.yml
@@ -49,8 +49,10 @@ pt-PT:
       save_and_edit: "Guardar e editar"
       cancel: "Cancelar"
     delete:
-      flash_confirmation: "%{name} foi apagado com sucesso"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Sim, com certeza."
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.ru.yml
+++ b/config/locales/rails_admin.ru.yml
@@ -49,8 +49,10 @@ ru:
       save_and_edit: "Сохранить и продолжить редактирование"
       cancel: "Отмена"
     delete:
-      flash_confirmation: "%{name} удалено"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Да, я уверен"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Экспортировать как %{name}"
       select: "Выберите поля для экспорта"

--- a/config/locales/rails_admin.sv.yml
+++ b/config/locales/rails_admin.sv.yml
@@ -50,8 +50,10 @@ sv:
       save_and_edit: "Spara och redigera"
       cancel: "Avbryt"
     delete:
-      flash_confirmation: "%{name} har förstörts"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Ja, jag är säker"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.tr.yml
+++ b/config/locales/rails_admin.tr.yml
@@ -50,8 +50,10 @@ tr:
       save_and_edit: "Kaydet ve düzenle"
       cancel: "İptal et"
     delete:
-      flash_confirmation: "%{name} başarıyla silindi"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Evet, eminim"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.uk.yml
+++ b/config/locales/rails_admin.uk.yml
@@ -47,8 +47,10 @@ uk:
       save_and_edit: "Зберегти і поредагувати"
       cancel: "Скасувати"
     delete:
-      flash_confirmation: "%{name} успішно видалено"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "Так, я впевнений"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "Select fields to export"

--- a/config/locales/rails_admin.zh_cn.yml
+++ b/config/locales/rails_admin.zh_cn.yml
@@ -49,8 +49,10 @@ zh_cn:
     edit:
       add_new_associated_model_name: "添加新的%{name}"
     delete:
-      flash_confirmation: "%{name}被成功删除"
+      all_of_the_following_related_items_will_be_deleted: "? All of the following related items will be deleted:"
+      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete the %{model_name}"
       confirmation: "是的，我确定"
+      delete_confirmation: "Delete confirmation"
     export:
       confirmation: "Export to %{name}"
       select: "选择需要导出的字段"


### PR DESCRIPTION
Removes hardcoded english, but I'm not sure what the appropriate way to combine the sentences is. We need to only do html_safe on the quotes and strong html but not the objects label.

See Issue #165
