### PR TITLE
Added optional support for models that have a state machine.

### DIFF
--- a/app/views/rails_admin/main/edit.html.haml
+++ b/app/views/rails_admin/main/edit.html.haml
@@ -5,14 +5,20 @@
 
 #block-tables.block
   = breadcrumbs_for :edit, @object
-  
+
   .content
     .control
       = action_button rails_admin_history_object_path(:id => params[:id]), t("admin.history.name")
-      
+
       - if authorized? :delete, @abstract_model, @object
         = action_button rails_admin_delete_path(@abstract_model, @object), t("admin.list.delete_action"), :cross
-        
+
+    - model_events ||= ( @abstract_model.model.respond_to?(:state_machine) && @abstract_model.model.state_machine.events )
+    - if model_events.count > 0
+      .control
+        - model_events.collect { |a| a.name }.each do |event_name|
+          = action_button rails_admin_send_event_path(:event_name => event_name, :model_name => @abstract_model.to_param, :id => params[:id]), I18n.t("state_machine.#{@abstract_model.model.name.underscore}.#{ event_name }")
+
     %h2.title= @page_name
     .inner
       = render(:partial => 'layouts/rails_admin/flash', :locals => {:flash => flash})

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
       delete "/:model_name/:id", :to => :destroy, :as => "destroy"
       post "/:model_name/bulk_action", :to => :bulk_action, :as => "bulk_action"
       post "/:model_name/bulk_destroy", :to => :bulk_destroy, :as => "bulk_destroy"
+      get '/:model_name/:id/event/:event_name', :to => :send_event, :as => "send_event"
     end
   end
 end


### PR DESCRIPTION
The point is that if a model has a state field, we don't want to
set the state directly, rather we want to send an event to trigger
a transition which, in turn, has callbacks to do stuff.

All this would not happen if the state is set directly.

This change adds (not ideal) the event buttons next to the existing
history and delete buttons at the top of an edit page for a model.
