### PR TITLE
Truncate history messages longer than 255 chars. Fixes sferik/rails_admin

### DIFF
--- a/app/models/rails_admin/history.rb
+++ b/app/models/rails_admin/history.rb
@@ -7,6 +7,14 @@ module RailsAdmin
     scope :most_recent, lambda {|model|
       where("#{retrieve_connection.quote_column_name(:table)} = ?", model.pretty_name).order("updated_at DESC")
     }
+    
+    before_save :truncate_message
+    
+    def truncate_message
+      if message.present? && message.size > 255
+        self.message = message.truncate(255)
+      end
+    end
 
     def self.get_history_for_dates(mstart, mstop, ystart, ystop)
       if mstart > mstop && mstart < 12

--- a/spec/models/rails_admin/history_spec.rb
+++ b/spec/models/rails_admin/history_spec.rb
@@ -10,4 +10,18 @@ describe RailsAdmin::History do
       @results.count.should == 5
     end
   end
+  
+  describe "creating a new history entry" do
+    it "saves up to 255 chars without modification" do
+      history = RailsAdmin::History.create(:message => "#"*255).reload
+      
+      history.message.should == "#"*255
+    end
+    
+    it "messages longer than 255 chars are truncated" do
+      history = RailsAdmin::History.create(:message => "#"*280).reload
+      
+      history.message.should == ("#"*(255-3))+"..."
+    end
+  end
 end


### PR DESCRIPTION
Truncate history messages longer than 255 chars. Fixes sferik/rails_admin#536.
