### PR TITLE
Make the config.js file path not escaped and actually loaded 

### DIFF
--- a/app/views/rails_admin/main/_form_text.html.haml
+++ b/app/views/rails_admin/main/_form_text.html.haml
@@ -9,7 +9,7 @@
     $j(document).ready(function($){
     CKEDITOR.replace('#{field.dom_id}',
     {
-    customConfig : '#{field.ckeditor_config_js}'
+    customConfig : '#{field.ckeditor_config_js.html_safe}'
     }
     );
     });


### PR DESCRIPTION
I noticed the config.js file was not loaded in rails admin since its path is escaped. By making it "HTML safe", it is not escaped anymore and the file is properly loaded.
