### PR TITLE
Making bindings[:view] available in "visible do ... end" blocks in config.

### DIFF
--- a/app/views/rails_admin/main/list.html.haml
+++ b/app/views/rails_admin/main/list.html.haml
@@ -3,7 +3,8 @@
   params = request.params.except(:authenticity_token, :action, :controller, :model_name, :utf8, :bulk_export)
   sort = params[:sort]
   sort_reverse = params[:sort_reverse]
-  properties = @model_config.list.visible_fields.map{|property| property.with(:view => self)}
+  # pass self as :view to visible_fields
+  properties = @model_config.list.visible_fields(:view => self).map{|property| property.with(:view => self)}
   # columns paginate
   @filterable_fields = @model_config.list.fields.select(&:filterable?)
   @style, @other, properties = get_column_set(properties)

--- a/lib/rails_admin/config/fields/group.rb
+++ b/lib/rails_admin/config/fields/group.rb
@@ -44,8 +44,9 @@ module RailsAdmin
         end
 
         # Reader for fields that are marked as visible
-        def visible_fields
-          fields.select {|f| f.visible? }
+        # Pass in optional bindings for visible blocks.        
+        def visible_fields(bindings = {})
+          fields.select {|f| f.with(bindings).visible? }
         end
 
         # Configurable group label which by default is group's name humanized.

--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -97,9 +97,10 @@ module RailsAdmin
         selected
       end
 
-      # Get all fields defined as visible.
-      def visible_fields
-        fields.select {|f| f.visible? }
+      # Get all fields defined as visible. 
+      # Pass in optional bindings for visible blocks.
+      def visible_fields(bindings = {})
+        fields.select {|f| f.with(bindings).visible? }
       end
     end
   end

--- a/spec/requests/config/list/rails_admin_config_list_spec.rb
+++ b/spec/requests/config/list/rails_admin_config_list_spec.rb
@@ -394,6 +394,63 @@ describe "RailsAdmin Config DSL List Section" do
       should have_selector(".grid tbody tr:nth-child(2) td:nth-child(4)", :text => @fans[0].name.upcase)
     end
 
+    it "should have option to customize a field as visible" do
+      RailsAdmin.config Fan do
+        list do
+          field :id
+          field :name do
+            visible do
+              true
+            end
+          end
+          field :created_at
+          field :updated_at
+        end
+      end
+      @fans = 2.times.map { FactoryGirl.create :fan }
+      visit rails_admin_list_path(:model_name => "fan")
+      should have_selector(".grid tbody tr:nth-child(1) td:nth-child(4)", :text => @fans[1].name)
+      should have_selector(".grid tbody tr:nth-child(2) td:nth-child(4)", :text => @fans[0].name)
+    end
+    
+    it "should have option to customize a field as not visible" do
+      RailsAdmin.config Fan do
+        list do
+          field :id
+          field :name do
+            visible do
+              false
+            end
+          end
+          field :created_at
+          field :updated_at
+        end
+      end
+      @fans = 2.times.map { FactoryGirl.create :fan }
+      visit rails_admin_list_path(:model_name => "fan")
+      should_not have_selector(".grid tbody tr:nth-child(1) td:nth-child(4)", :text => @fans[1].name)
+      should_not have_selector(".grid tbody tr:nth-child(2) td:nth-child(4)", :text => @fans[0].name)
+    end
+       
+    it "should have bindings[:view] available in visible block" do
+      RailsAdmin.config Fan do
+        list do
+          field :id
+          field :name do
+            visible do
+              bindings.has_key?(:view)
+            end
+          end
+          field :created_at
+          field :updated_at
+        end
+      end
+      @fans = 2.times.map { FactoryGirl.create :fan }
+      visit rails_admin_list_path(:model_name => "fan")
+      should have_selector(".grid tbody tr:nth-child(1) td:nth-child(4)", :text => @fans[1].name)
+      should have_selector(".grid tbody tr:nth-child(2) td:nth-child(4)", :text => @fans[0].name)      
+    end
+            
     it "should have a simple option to customize output formatting of date fields" do
       RailsAdmin.config Fan do
         list do
@@ -410,6 +467,22 @@ describe "RailsAdmin Config DSL List Section" do
       should have_selector(".grid tbody tr:nth-child(1) td:nth-child(5)", :text => /\d{2} \w{3} \d{1,2}:\d{1,2}/)
     end
 
+    it "should have a simple option to customize output formatting of date fields" do
+      RailsAdmin.config Fan do
+        list do
+          field :id
+          field :name
+          field :created_at do
+            date_format :short
+          end
+          field :updated_at
+        end
+      end
+      @fans = 2.times.map { FactoryGirl.create :fan }
+      visit rails_admin_list_path(:model_name => "fan")
+      should have_selector(".grid tbody tr:nth-child(1) td:nth-child(5)", :text => /\d{2} \w{3} \d{1,2}:\d{1,2}/)
+    end
+    
     it "should have option to customize output formatting of date fields" do
       RailsAdmin.config Fan do
         list do


### PR DESCRIPTION
Currently bindings is empty in the "visible do" blocks in RailsAdmin.config.

Modified visible_fields as well as the markup for the "list page",  so :view => self is actually passed to "visible do" blocks in RailsAdmin.config.

Not sure if this is the best fix, but bindings[:view] is now available in the "visible do" blocks in the config.
