### PR TITLE
Use object ids instead of objects in path helper so that objects with overridden #to_param can be linked

### DIFF
--- a/app/views/rails_admin/main/edit.html.haml
+++ b/app/views/rails_admin/main/edit.html.haml
@@ -11,12 +11,12 @@
       = action_button rails_admin_history_object_path(:id => params[:id]), t("admin.history.name")
 
       - if authorized? :delete, @abstract_model, @object
-        = action_button rails_admin_delete_path(@abstract_model, @object), t("admin.list.delete_action"), :cross
+        = action_button rails_admin_delete_path(@abstract_model, @object.id), t("admin.list.delete_action"), :cross
 
     %h2.title= @page_name
     .inner
       = render(:partial => 'layouts/rails_admin/flash', :locals => {:flash => flash})
-      = send(@model_config.update.form_builder, @object, :url => rails_admin_update_path(@abstract_model, @object), :html => { :method => "put", :multipart => true, :class => "form" }) do |form|
+      = send(@model_config.update.form_builder, @object, :url => rails_admin_update_path(@abstract_model, @object.id), :html => { :method => "put", :multipart => true, :class => "form" }) do |form|
         - @model_config.edit.with(:object => @object).visible_groups.each do |fieldset|
           = render :partial => 'form_fieldset', :locals => { :fieldset => fieldset, :form => form, :object => @object }
         = render :partial => 'submit_buttons'

--- a/app/views/rails_admin/main/list.html.haml
+++ b/app/views/rails_admin/main/list.html.haml
@@ -129,11 +129,11 @@
                 - other_right = rails_admin_list_path(params.except("set").merge(:model_name => @abstract_model.to_param, :set => params[:set].to_i + 1))
                 %td.other.right{ :style => "#{'display: none' if @other.include?("right")}" }= link_to "...", other_right, :remote => true
                 %td.last
-                  = action_icon(rails_admin_show_path(@abstract_model, object), :show, "Show")
+                  = action_icon(rails_admin_show_path(@abstract_model, object.id), :show, "Show")
                   - if can_edit
                     = action_icon(edit_path, :edit, t("admin.list.edit_action"))
                   - if authorized? :delete, @abstract_model, object
-                    = action_icon(rails_admin_delete_path(@abstract_model, object), :cross, t("admin.list.delete_action"))
+                    = action_icon(rails_admin_delete_path(@abstract_model, object.id), :cross, t("admin.list.delete_action"))
 
         .pagination
           - if @page_count.to_i > 1

--- a/app/views/rails_admin/main/show.html.haml
+++ b/app/views/rails_admin/main/show.html.haml
@@ -10,9 +10,9 @@
       - if show_url = url_for(@object) rescue nil
         = action_button show_url, t("admin.show.show_in_app")
       - if authorized? :edit, @abstract_model, @object
-        = action_button rails_admin_edit_path(@abstract_model, @object), t("admin.list.edit_action")
+        = action_button rails_admin_edit_path(@abstract_model, @object.id), t("admin.list.edit_action")
       - if authorized? :delete, @abstract_model, @object
-        = action_button rails_admin_delete_path(@abstract_model, @object), t("admin.list.delete_action"), :cross
+        = action_button rails_admin_delete_path(@abstract_model, @object.id), t("admin.list.delete_action"), :cross
 
     %h2.title= @page_name
     .inner

--- a/spec/dummy_app/app/models/ball.rb
+++ b/spec/dummy_app/app/models/ball.rb
@@ -1,0 +1,8 @@
+class Ball < ActiveRecord::Base
+
+  validates_presence_of :color
+
+  def to_param
+    color.present? ? color.downcase.gsub(" ", "-") : id
+  end
+end

--- a/spec/dummy_app/db/migrate/20110714095433_create_balls.rb
+++ b/spec/dummy_app/db/migrate/20110714095433_create_balls.rb
@@ -1,0 +1,12 @@
+class CreateBalls < ActiveRecord::Migration
+  def self.up
+    create_table :balls, :force => true do |t|
+      t.string :color
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :balls
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -56,4 +56,8 @@ FactoryGirl.define do
       EOF
     end
   end
+
+  factory :ball do
+    color(%W(red blue green yellow purple brown black white).sample)
+  end
 end

--- a/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
@@ -83,4 +83,16 @@ describe "RailsAdmin Basic Edit" do
       visit rails_admin_edit_path(:model_name => "player", :id => @player.id)
     end
   end
+
+  describe "edit object with overridden to_param" do
+    before(:each) do
+      @ball = FactoryGirl.create :ball
+      visit rails_admin_edit_path(:model_name => "ball", :id => @ball.id)
+    end
+
+    it "should display a link to the delete page" do
+      should have_selector "a[href='/admin/balls/#{@ball.id}/delete']"
+    end
+
+  end
 end

--- a/spec/requests/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/requests/basic/list/rails_admin_basic_list_spec.rb
@@ -365,4 +365,17 @@ describe "RailsAdmin Basic List" do
     end
   end
 
+  describe "list for objects with overridden to_param" do
+    before(:each) do
+      @ball = FactoryGirl.create :ball
+      visit rails_admin_list_path(:model_name => "ball")
+    end
+
+    it "shows the show and delete links with valid url" do
+      should have_selector("td a[href='/admin/balls/#{@ball.id}'] img[alt='Show']")
+      should have_selector("td a[href='/admin/balls/#{@ball.id}/delete'] img[alt='Delete']")
+    end
+
+  end
+
 end

--- a/spec/requests/basic/update/rails_admin_basic_update_spec.rb
+++ b/spec/requests/basic/update/rails_admin_basic_update_spec.rb
@@ -215,4 +215,21 @@ describe "RailsAdmin Basic Update" do
     end
   end
 
+  describe "update with overridden to_param" do
+    before(:each) do
+      @ball = FactoryGirl.create :ball
+
+      visit rails_admin_edit_path(:model_name => "ball", :id => @ball.id)
+
+      fill_in "ball[color]", :with => "gray"
+      click_button "Save and edit"
+
+      @ball.reload
+    end
+
+    it "should update an object with correct attributes" do
+      @ball.color.should eql("gray")
+    end
+  end
+
 end

--- a/spec/requests/config/navigation/rails_admin_config_navigation_spec.rb
+++ b/spec/requests/config/navigation/rails_admin_config_navigation_spec.rb
@@ -8,7 +8,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
 
     it "should be alphabetical by default" do
       visit rails_admin_dashboard_path
-      ["Cms/Basic Pages", "Comments", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users"].each_with_index do |content, i|
+      ["Balls", "Cms/Basic Pages", "Comments", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]/a").should have_content(content)
       end
     end
@@ -20,7 +20,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit rails_admin_dashboard_path
-      ["Teams", "Cms/Basic Pages", "Comments", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Users"].each_with_index do |content, i|
+      ["Teams", "Balls", "Cms/Basic Pages", "Comments", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]/a").should have_content(content)
       end
     end
@@ -32,7 +32,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit rails_admin_dashboard_path
-      ["Cms/Basic Pages", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users"].each_with_index do |content, i|
+      ["Balls", "Cms/Basic Pages", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]/a").should have_content(content)
       end
       ["Cms/Basic Pages", "Comments"].each_with_index do |content, i|
@@ -50,7 +50,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit rails_admin_dashboard_path
-      ["CMS related", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users"].each_with_index do |content, i|
+      ["Balls", "CMS related", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]/a").should have_content(content)
       end
       ["Cms/Basic Pages", "Comments"].each_with_index do |content, i|
@@ -69,7 +69,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit rails_admin_dashboard_path
-      ["Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users", "CMS related"].each_with_index do |content, i|
+      ["Balls", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Users", "CMS related"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]/a").should have_content(content)
       end
     end


### PR DESCRIPTION
Here is my tested patch. I only tested in places I added ".id". I don't know if it would make sens to test every generated url.

PS: It is my first OSS contribution. I'll improve the patch if necessary.
