### PR TITLE
Context aware instance option

### DIFF
--- a/app/views/rails_admin/main/_show_has_many_association.html.haml
+++ b/app/views/rails_admin/main/_show_has_many_association.html.haml
@@ -1,8 +1,0 @@
-- model_name   = field.association[:name]
-- associations = [field.bindings[:object].send(model_name)].flatten.compact
-
-%div.label= field.label
-%div.value
-  %ul
-    - associations.each do |association|
-      %li= link_to "#{association.class.name} #{association.id}", rails_admin_show_path(:model_name => model_name, :id => association.id)

--- a/lib/rails_admin/config/base.rb
+++ b/lib/rails_admin/config/base.rb
@@ -35,11 +35,6 @@ module RailsAdmin
         self.class.register_instance_option(option_name, scope, &default)
       end
 
-      def register_action_aware_instance_option(option_name)
-        scope = class << self; self; end;
-        self.class.register_action_aware_instance_option(option_name, scope)
-      end
-
       def register_deprecated_instance_option(option_name, replacement_option_name)
         scope = class << self; self; end;
         self.class.register_deprecated_instance_option(option_name, replacement_option_name, scope)
@@ -94,13 +89,6 @@ module RailsAdmin
             end
             value
           end
-        end
-      end
-
-      def self.register_action_aware_instance_option(option_name, scope = self)
-        scope.send(:define_method, option_name) do |*args, &block|
-          action = self.parent.class.to_s.demodulize.downcase
-          send("#{action}_#{option_name}", *args, &block)
         end
       end
 

--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -94,14 +94,6 @@ module RailsAdmin
         def value
           bindings[:object].send(association[:name])
         end
-
-        register_instance_option(:partial) do
-          if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-            :form_field
-          else
-            :show_association
-          end
-        end
       end
     end
   end

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -151,11 +151,7 @@ module RailsAdmin
         end
 
         register_instance_option(:partial) do
-          if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-            :form_field
-          else
-            :show_base
-          end
+          :form_field
         end
 
         register_deprecated_instance_option(:show_partial, :partial) # deprecated on 2011-07-15
@@ -164,7 +160,6 @@ module RailsAdmin
         register_deprecated_instance_option(:update_partial, :partial) # deprecated on 2011-07-15
 
         register_instance_option(:render) do
-          action = self.parent.class.to_s.demodulize.downcase
           bindings[:view].render :partial => partial.to_s, :locals => {:field => self, :form => bindings[:form] }
         end
 

--- a/lib/rails_admin/config/fields/types/belongs_to_association.rb
+++ b/lib/rails_admin/config/fields/types/belongs_to_association.rb
@@ -34,11 +34,7 @@ module RailsAdmin
           end
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_filtering_select
-            else
-              :show_association
-            end
+            :form_filtering_select
           end
 
           def associated_model_config

--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -155,11 +155,7 @@ module RailsAdmin
           end
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_datetime
-            else
-              :show_base
-            end
+            :form_datetime
           end
 
           register_instance_option(:strftime_format) do

--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -8,11 +8,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types::register(self)
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_enumeration
-            else
-              :show_base
-            end
+            :form_enumeration
           end
 
           register_instance_option(:html_attributes) do

--- a/lib/rails_admin/config/fields/types/has_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_many_association.rb
@@ -14,11 +14,7 @@ module RailsAdmin
           end
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_filtering_multiselect
-            else
-              :show_has_many_association
-            end
+            :form_filtering_multiselect
           end
 
           register_instance_option(:html_attributes) do

--- a/lib/rails_admin/config/fields/types/has_one_association.rb
+++ b/lib/rails_admin/config/fields/types/has_one_association.rb
@@ -9,11 +9,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types::register(self)
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_filtering_select
-            else
-              :show_association
-            end
+            :form_filtering_select
           end
 
           # Accessor for field's formatted value

--- a/lib/rails_admin/config/fields/types/paperclip_file.rb
+++ b/lib/rails_admin/config/fields/types/paperclip_file.rb
@@ -10,11 +10,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(self)
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_paperclip_file
-            else
-              :show_paperclip_file
-            end
+            :form_paperclip_file
           end
 
           register_instance_option(:delete_method) do

--- a/lib/rails_admin/config/fields/types/polymorphic_association.rb
+++ b/lib/rails_admin/config/fields/types/polymorphic_association.rb
@@ -15,11 +15,7 @@ module RailsAdmin
           end
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_polymorphic_association
-            else
-              :show_polymorphic_association
-            end
+            :form_polymorphic_association
           end
 
           # Accessor whether association is visible or not. By default

--- a/lib/rails_admin/config/fields/types/string.rb
+++ b/lib/rails_admin/config/fields/types/string.rb
@@ -38,11 +38,7 @@ module RailsAdmin
            end
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              color? ? :form_colorpicker : :form_field
-            else
-              :show_base
-            end
+            color? ? :form_colorpicker : :form_field
           end
         end
       end

--- a/lib/rails_admin/config/fields/types/text.rb
+++ b/lib/rails_admin/config/fields/types/text.rb
@@ -31,11 +31,7 @@ module RailsAdmin
           end
 
           register_instance_option(:partial) do
-            if parent.kind_of?(RailsAdmin::Config::Sections::Update)
-              :form_text
-            else
-              :show_base
-            end
+            :form_text
           end
         end
       end


### PR DESCRIPTION
As discussed towards the end of the [show page pull request](https://github.com/sferik/rails_admin/pull/527), it would be nice to have a context-aware option which does the right thing based on where it's used in the config. Here's an attempt at this.

All the specs pass and it's working for me in some limited testing.

At the top of `RailsAdmin::Config::Base.register_instance_option` is this code snippet:

``` ruby
    unless options = scope.instance_variable_get("@config_options")
      options = scope.instance_variable_set("@config_options", {})
    end

    option_name = option_name.to_s

    options[option_name] = nil
```

Nothing like this is happening for the action-aware instance option though. Does it need to? Anything else I'm missing or didn't consider?

Also, I refactored the deprecated method logic in 999259f.
