### PR TITLE
Additional navigation proposal

### DIFF
--- a/app/views/rails_admin/main/_navigation.html.haml
+++ b/app/views/rails_admin/main/_navigation.html.haml
@@ -7,6 +7,9 @@
 %ul#nav.navigation
   %li{:class => ("active" if @page_type == "dashboard")}
     = link_to(t("admin.dashboard.name"), rails_admin_dashboard_path)
+  - RailsAdmin::Config.nav_before_model.each do |page,link|
+    %li{:class => ("active" if @page_type == page)}
+      %a{:href => "#{link['url']}"}= link['label']
   - root_models.each do |model|
     - children = [model] + models.select { |m| m.parent.to_s == model.abstract_model.model.to_s }
     - tab_titles = children.map { |child| child.abstract_model.pretty_name.downcase }
@@ -19,3 +22,7 @@
           - children.each_with_index do |child, index|
             %li{:class => ("active" if @page_type == tab_titles[index])}
               = link_to(child.label.pluralize, rails_admin_list_path(:model_name => child.abstract_model.to_param))
+  - RailsAdmin::Config.nav_after_model.each do |page,link|
+    %li{:class => ("active" if @page_type == page)}
+      %a{:href => "#{link['url']}"}= link['label']
+

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -71,6 +71,11 @@ module RailsAdmin
       # to be used as a label for object records. This defaults to [:name, :title]
       attr_accessor :label_methods
 
+      # TODO: document these options properly
+      # Allow to insert additional navigation links into the navigation sidebar
+      attr_accessor :nav_before_model
+      attr_accessor :nav_after_model
+
       # Stores model configuration objects in a hash identified by model's class
       # name.
       #


### PR DESCRIPTION
In a couple of my projects, I used rails_admin as my application framework. It covers 80% of what I needed and I only had to implement a few home made controllers to handle the 20% left.

Note that to accomplish this I used the following technique: https://gist.github.com/1086055 which allows to reuse the awesome Activo theme of Rails Admin for my whole application.

Now, I needed to insert some additional links to my home made controllers into the Rails Admin navigation.

Another use case would be if I wanted to have a permanent link always in the navigation: for instance, let's say I have a customer model, and I want to always see a link to "Add new customer" in my navigation (from every admin pages). I could use the feature as well.

This pull request is a first stab at it, which I think is not ideal:
1) I don't like the configuration syntax that much
2) It's missing tests and docs (to be fixed of course)

The syntax currently looks like this

``` ruby
RailsAdmin.config do |config|
    config.nav_before_models = {
        'foo' => {
            'label' => 'Foo',
            'url' => 'foo/foo',
        },
        'bar' => {
            'label' => 'Bar',
            'url' => 'bar/bar'
        }
    }
    config.nav_after_models = {
        'stuff' => {
            'label' => 'More stuff',
            'url' => 'more/stuff'
        }
    }
end
```

Ideally, I wanted to use the RailsAdmin::Config::Navigation class, but it's being deprecated. The syntax could have looked like this:

``` ruby
RailsAdmin.config do |config|
    config.navigation.before_models do
        link :foo do
            label 'Foo'
            url 'foo/foo'
        end
        link :bar do
            label 'Bar'
            url 'bar/bar'
        end
    end
    config.navigation.after_models do end
        link :stuff do
            label 'More stuff'
            url 'more/stuff'
        end
    end
end
```

What do you think? Any suggestion on what would be the best approach?
