### PR TITLE
Fixes problem when logging out through included logout button

### DIFF
--- a/app/views/layouts/rails_admin/_header.html.haml
+++ b/app/views/layouts/rails_admin/_header.html.haml
@@ -10,5 +10,5 @@
       - if (current_user rescue nil)
         %li= link_to header_icon(:account, current_user.email), (rails_admin_edit_path(:user, current_user) rescue '#')
       - if (current_user rescue nil)
-        %li= link_to header_icon(:logout, t("admin.credentials.log_out")), (destroy_session_path(current_user) rescue '#')
+        %li= link_to header_icon(:logout, t("admin.credentials.log_out")), (destroy_session_path(current_user) rescue '#'), :method => :delete
 


### PR DESCRIPTION
When trying to log out of Rails Admin through the logout button in the upper right corner, I discovered a bug. That bug was causing the user to go to /[user model]/sign_out (where [user model] is the name of your Devise model) via a GET request. This generated a missing route exception for me on Rails 3.0.9 (Mac OS X, Ruby 1.9.2). By adding the code I've included in this commit, I am forcing that link to send a DELETE request, the proper way to log out of Devise. Please note that if a root route is not defined, Devise will throw an error when trying to redirect you after logout.
