### PR TITLE
it should use "=" operator for enums

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -439,7 +439,7 @@ module RailsAdmin
         end
         ["(#{column} BETWEEN ? AND ?)", *values]
       when :enum
-        ["(#{column} #{@like_operator} ?)", value]
+        ["(#{column} = ?)", value]
       end
     end
 


### PR DESCRIPTION
it's temporary workaround, querying mechanism should be reworked to use also type of column/field not only parameter's type
