### PR TITLE
Fix ApplicationController#to_model_name

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -20,7 +20,8 @@ module RailsAdmin
 
     def to_model_name(param)
       parts = param.split("~")
-      parts.map{|x| x == parts.last ? x.singularize.camelize : x.camelize}.join("::")
+      parts[-1] = parts.last.singularize
+      parts.map(&:camelize).join("::")
     end
 
     def get_object

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe RailsAdmin::ApplicationController do
+  describe "#to_model_name" do
+    it "handles classes nested in modules of the same name" do
+      controller.to_model_name("conversations~conversations").should eq("Conversations::Conversation")
+    end
+  end
+end


### PR DESCRIPTION
When passed a plural class contained in a module of the same name, both the
module name and the class were singularized. This patch ensures that only the
class name is singularized.
