### PR TITLE
Test failure depending on test order

### DIFF
--- a/spec/requests/history/rails_admin_history_spec.rb
+++ b/spec/requests/history/rails_admin_history_spec.rb
@@ -56,7 +56,7 @@ describe "RailsAdmin History" do
   end
 
   describe "model history fetch" do
-    before :all do
+    before :each do
       @model = RailsAdmin::AbstractModel.new("Player")
       player = FactoryGirl.create :player
       30.times do |i|
@@ -92,7 +92,7 @@ describe "RailsAdmin History" do
       end
 
       context "with a lot of histories" do
-        before :all do
+        before :each do
           player = @model.create(:team_id => -1, :number => -1, :name => "Player 1")
           1000.times do |i|
             player.number = i

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -62,6 +62,7 @@ RSpec.configure do |config|
     RailsAdmin::AbstractModel.new("Player").destroy_all!
     RailsAdmin::AbstractModel.new("Team").destroy_all!
     RailsAdmin::AbstractModel.new("User").destroy_all!
+    RailsAdmin::History.destroy_all
 
     user = RailsAdmin::AbstractModel.new("User").create(
       :email => "username@example.com",


### PR DESCRIPTION
Hello,

I ran into this problem where one test in sferik:master fails depending in the order in which it is executed in the test suite. 

rspec ./spec/requests/history/rails_admin_history_spec.rb:74
 1) RailsAdmin History model history fetch should respect RailsAdmin::Config.default_items_per_page
     Failure/Error: histories[0].should == 2
       expected: 2
            got: 3 (using ==)

I looked into this (it does not happen on all machines we tried on, but a few consistently exhibit the behavior), and I realized that history items are not cleaned up between tests. After this change, things worked fine. Please take a look and let me know if this sounds reasonable.

Cheers!
Iannis
