### PR TITLE
Fix for the asset copy in rails_admin:install task

### DIFF
--- a/lib/rails_admin/tasks/install.rb
+++ b/lib/rails_admin/tasks/install.rb
@@ -43,8 +43,8 @@ module RailsAdmin
 
         def copy_assets_files
           print "Now copying assets files - javascripts, stylesheets and images! "
-          origin = File.join(gem_path, 'public')
-          destination = Rails.root.join('public')
+          origin = File.join(gem_path, 'app/assets')
+          destination = Rails.root.join('app/assets')
           puts copy_files(%w( stylesheets images javascripts ), origin, destination)
         end
 

--- a/spec/lib/install_spec.rb
+++ b/spec/lib/install_spec.rb
@@ -27,9 +27,9 @@ describe "Rake tasks" do
         assert_no_file destination_root + "/config/locales/devise.en.yml"
         assert_no_file destination_root + "/config/locales/rails_admin.en.yml"
 
-        assert_no_file destination_root + "/public/javascripts/rails_admin/application.js"
-        assert_no_directory destination_root + "/public/stylesheets/rails_admin"
-        assert_no_directory destination_root + "/public/images/rails_admin"
+        assert_no_file destination_root + "/app/assets/javascripts/rails_admin/application.js"
+        assert_no_directory destination_root + "/app/assets/stylesheets/rails_admin"
+        assert_no_directory destination_root + "/app/assets/images/rails_admin"
         silence_stream(STDOUT) { RailsAdmin::Tasks::Install.run }
       end
 
@@ -39,9 +39,9 @@ describe "Rake tasks" do
       end
 
       it "creates rails_admin assets" do
-        assert_file destination_root + "/public/javascripts/rails_admin/application.js"
-        assert_directory destination_root + "/public/stylesheets/rails_admin"
-        assert_directory destination_root + "/public/images/rails_admin"
+        assert_file destination_root + "/app/assets/javascripts/rails_admin/application.js"
+        assert_directory destination_root + "/app/assets/stylesheets/rails_admin"
+        assert_directory destination_root + "/app/assets/images/rails_admin"
       end
     end
   end


### PR DESCRIPTION
This updates the install task to copy from 'app/assets' rather than 'public'.   It also fixes the test in install_spec.rb.  It's not much, but I thought I'd put it out there.
