### PR TITLE
Rails 3.1 Fix the issue on index name on 'rails_admin_histories' table is too long; the limit is 63 characters

### DIFF
--- a/lib/generators/rails_admin/templates/drop.rb
+++ b/lib/generators/rails_admin/templates/drop.rb
@@ -13,6 +13,6 @@ class DropAdminHistoriesTable < ActiveRecord::Migration
       t.integer :year, :limit => 5
       t.timestamps
     end
-    add_index(:rails_admin_histories, [:item, :table, :month, :year], :length => { :maximum => 63 })
+    add_index(:rails_admin_histories, [:item, :table, :month, :year], :name => 'index_rails_admin_histories' )
   end
 end

--- a/lib/generators/rails_admin/templates/migration.rb
+++ b/lib/generators/rails_admin/templates/migration.rb
@@ -9,7 +9,7 @@ class CreateRailsAdminHistoriesTable < ActiveRecord::Migration
        t.integer :year, :limit => 5
        t.timestamps
     end
-    add_index(:rails_admin_histories, [:item, :table, :month, :year], :length => { :maximum => 63 })
+    add_index(:rails_admin_histories, [:item, :table, :month, :year], :name => 'index_rails_admin_histories' )
   end
 
   def self.down


### PR DESCRIPTION
== CreateRailsAdminHistoriesTable: migrating =================================
-- create_table(:rails_admin_histories)
-> 0.0156s
-- add_index(:rails_admin_histories, [:item, :table, :month, :year])
rake aborted!
An error has occurred, this and all later migrations canceled:

Index name 'index_rails_admin_histories_on_item_and_table_and_month_and_year' on table 'rails_admin_histories' is too long; the limit is 63 characters

See issue: https://github.com/sferik/rails_admin/issues/604

Manually set the index table name as "index_rails_admin_histories".
