### PR TITLE
Fix instance of "rails_admin_edit_path"

### DIFF
--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -10,8 +10,8 @@
   else
     collection = field.associated_collection(@authorization_adapter).sort_by {|a| selected_ids.index(a[1]) || selected_ids.size }
   end
-  edit_url = authorized?(:edit, config.abstract_model) ? rails_admin_edit_path(:model_name => config.abstract_model.to_param, :id => '__ID__') : ''
-  
+  edit_url = authorized?(:edit, config.abstract_model) ? edit_path(:model_name => config.abstract_model.to_param, :id => '__ID__') : ''
+
 = field_wrapper_for(form, field) do
   %input{:name => field.dom_name, :type => "hidden", :value => ""}
   = form.select field.method_name, collection, { :selected => selected_ids, :object => @object }, field.html_attributes.merge({:'data-edit-url' => edit_url})
@@ -37,7 +37,7 @@
   up: "#{t("admin.new.up")}",
   down: "#{t("admin.new.down")}"
   }
-  
+
   });
   if($("div.createAssociatedRecordDialog").length == 0) {
   $(".#{"#{field.dom_id}"} .createAssociatedRecord").remoteForm({ dialogClass: "createAssociatedRecordDialog" });

--- a/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/requests/basic/edit/rails_admin_basic_edit_spec.rb
@@ -87,7 +87,7 @@ describe "RailsAdmin Basic Edit" do
   describe "edit object with overridden to_param" do
     before(:each) do
       @ball = FactoryGirl.create :ball
-      visit rails_admin_edit_path(:model_name => "ball", :id => @ball.id)
+      visit edit_path(:model_name => "ball", :id => @ball.id)
     end
 
     it "should display a link to the delete page" do

--- a/spec/requests/basic/update/rails_admin_basic_update_spec.rb
+++ b/spec/requests/basic/update/rails_admin_basic_update_spec.rb
@@ -219,7 +219,7 @@ describe "RailsAdmin Basic Update" do
     before(:each) do
       @ball = FactoryGirl.create :ball
 
-      visit rails_admin_edit_path(:model_name => "ball", :id => @ball.id)
+      visit edit_path(:model_name => "ball", :id => @ball.id)
 
       fill_in "ball[color]", :with => "gray"
       click_button "Save and edit"


### PR DESCRIPTION
Fixes issue where an "undefined method" error would be raised.

Seems there was a left-over "rails_admin_edit_path".  Also tweaked two other instances of this path in tests.
