### PR TITLE
gemspec encoding

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_runtime_dependency 'haml', ['>= 3.1.0', '< 3.3.0']
   gem.add_runtime_dependency 'rails', '~> 3.0.9'
 
-  gem.authors = ["Erik Michaels-Ober", "Bogdan Gaza", "Petteri"]
+  gem.authors = ["Erik Michaels-Ober", "Bogdan Gaza", "Petteri Kaapa"]
   gem.description = %q{RailsAdmin is a Rails engine that provides an easy-to-use interface for managing your data}
   gem.email = ['sferik@gmail.com', 'bogdan@cadmio.org', 'petteri.kaapa@gmail.com']
   gem.files = Dir['Gemfile', 'LICENSE.md', 'README.md', 'Rakefile', 'app/**/*', 'config/**/*', 'lib/**/*', 'public/**/*']


### PR DESCRIPTION
Hi,

I was having issues deploying my app. Bundler was throwing the typical gsub encoding error. I don't know why, but I can't reproduce the error in every machine.

This push fixes that issue. Please try to keep the gemspec without non EN chars, otherwise bundle will complaint.

Thanks,
  Tiago Franco
