### PR TITLE
Strange sort on collection in multiselect

### DIFF
--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -17,7 +17,7 @@
       [o.send(config.object_label_method), o.id]
     end
   else
-    collection = field.associated_collection(@authorization_adapter).sort_by {|a| selected_ids.index(a[1]) || selected_ids.size }
+    collection = field.associated_collection(@authorization_adapter)
   end
   edit_url = authorized?(:edit, config.abstract_model) ? rails_admin_edit_path(:model_name => config.abstract_model.to_param, :id => '__ID__') : ''
   


### PR DESCRIPTION
It looks fairly deliberate, but I can't figure out what it's trying to say and it's interfering with the default ordering on my select lists.

```
.sort_by {|a| selected_ids.index(a[1]) || selected_ids.size }
```

Sort by the position of this item's id in the list of selected items or the number of total selected items? This would make sense if there was one list I guess, but there's two. I'd much prefer the lists be sorted by my default scope so items are easier to find (sorted alphabetically).

If there's something I'm missing, please let me know.
