### PR TITLE
Stylesheet didn't exist in production app

### DIFF
--- a/app/assets/stylesheets/rails_admin/rails_admin.css
+++ b/app/assets/stylesheets/rails_admin/rails_admin.css
@@ -2,7 +2,7 @@
  * This is a manifest file that'll automatically include all the stylesheets available in this directory
  * and any sub-directories. You're free to add application-wide styles to this file and they'll appear at
  * the top of the compiled file, but it's generally better to create a new file per style scope.
- *
+ *= require_self
  *= require ./theme/base.css
  *= require ./theme/jquery.tipsy.css
  *= require ./theme/activo/style.css


### PR DESCRIPTION
need to require_self in manifest file to call all stylesheets in production

Simple one line change, added require_self to rails_admin.css manifest file. It's necessary for the compiled file to show up in production as the layout currently calls for it.
