### PR TITLE
Tracking 20110816

### DIFF
--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -80,9 +80,9 @@ module RailsAdmin
           association[:inverse_of]
         end
         
-        # Reader for validation errors of the bound object
+        # Reader for the bound object's validation errors relating to this association
         def errors
-          bindings[:object].errors[child_key]
+          bindings[:object].errors[name]
         end
 
         # Reader whether the bound object has validation errors


### PR DESCRIPTION
Look again.  RailsAdmin now understands errors of associated models!  This was a simple bug.  The old way, association_field.errors returned the bound object's errors relating to... an association... to another object with its own class... if such an association existed... which, in any case, bore no relation to the field in question.  (That is, if parent habtm :children, and field.name == :children, field.errors used to return parent.errors[:parent_id].  Probably not what you were looking for.)
