### PR TITLE
fix for hover actions on action_icon when deployed with relative root

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -74,7 +74,7 @@ module RailsAdmin
     # the icon shown beside every entry in the list view
     def action_icon link, icon, text
       icon_path = "/stylesheets/rails_admin/theme/activo/images/icons/24/%s.png"
-      icon_change = "this.src='#{icon_path}'"
+      icon_change = "this.src='#{image_path(icon_path)}'"
       link_to link do
         image_tag (icon_path % icon),
           :alt => text, :title => text,


### PR DESCRIPTION
fix for hover actions on action_icon when deployed with relative root (by using image_path)
No longer an issue in 3.1 however.
