### PR TITLE
Introduction current_rails_admin

### DIFF
--- a/app/assets/stylesheets/rails_admin/theme/activo/style.css.erb
+++ b/app/assets/stylesheets/rails_admin/theme/activo/style.css.erb
@@ -156,6 +156,7 @@ hr {
 
 #user-navigation {
   top: auto;
+  margin-top: 20px;
   right: 10px; }
 
 #user-navigation ul li a:link, #user-navigation ul li a:visited, #user-navigation ul li a:hover, #user-navigation ul li a:active {

--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -9,6 +9,7 @@ module RailsAdmin
     before_filter :set_plugin_name
 
     helper_method :_current_user
+    helper_method :current_rails_admin
 
     def get_model
       model_name = to_model_name(params[:model_name])
@@ -41,6 +42,10 @@ module RailsAdmin
 
     def _current_user
       instance_eval &RailsAdmin::Config.current_user_method
+    end
+
+    def current_rails_admin
+      send RailsAdmin::Config.current_rails_admin_method
     end
 
     def set_plugin_name

--- a/app/views/layouts/rails_admin/_header.html.haml
+++ b/app/views/layouts/rails_admin/_header.html.haml
@@ -1,12 +1,10 @@
 #header
   = render :partial => "rails_admin/main/title"
-  %h1
-
   #user-navigation
     %ul.wat-cf
       %li= link_to header_icon(:config, t('admin.dashboard.name')), dashboard_path
       - if (root_path rescue nil)
         %li= link_to header_icon(:home, t('home.name').capitalize), (root_path rescue '/')
-      - if (current_user rescue nil)
-        %li= link_to header_icon(:account, current_user.email), (edit_path(:user, current_user) rescue '#')
+      - if (current_rails_admin rescue nil)
+        %li= link_to header_icon(:account, current_rails_admin.email), (edit_path(:user, current_rails_admin) rescue '#')
         %li= link_to header_icon(:logout, t("admin.credentials.log_out")), '/users/sign_out', :method => (Devise.sign_out_via rescue :delete)

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -185,6 +185,13 @@ module RailsAdmin
         @current_user || DEFAULT_CURRENT_USER
       end
 
+      # Setup a different method to determine the current admin logged in (by default is current_user).
+      # This is run inside the controller instance and made available as a helper.
+      attr_writer :current_rails_admin_method
+      def current_rails_admin_method
+        @current_rails_admin_method ||= :current_user
+      end
+
       def default_search_operator=(operator)
         if %w{ default like starts_with ends_with is = }.include? operator
           @default_search_operator = operator


### PR DESCRIPTION
Instead of using '_current_user' or 'current_user' 
we can to introduce 'current_rails_admin' which would point to existing app methods:
current_user, current_admin, and etc
