### PR TITLE
If there are no properties, don't crash, just set the per_property to 0, seems safe enough. 

### DIFF
--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -71,7 +71,7 @@ module RailsAdmin
       max_sets = sets.size-2
       total = current_set.between?(1, max_sets) ?  704 : total
       column_offset = total-sets[current_set][:size]
-      per_property = column_offset/properties.size
+      per_property = properties.size != 0 ? column_offset / properties.size : 0
       offset = column_offset - per_property * properties.size
 
       properties.each do |property|


### PR DESCRIPTION
I needed this change when viewing records that where blank (like, Post.create({})), otherwise I would get this stack trace:

```
vendor/bundle/ruby/1.9.1/bundler/gems/rails_admin-e71eafaafd20/app/helpers/rails_admin/main_helper.rb:74:in `/'
vendor/bundle/ruby/1.9.1/bundler/gems/rails_admin-e71eafaafd20/app/helpers/rails_admin/main_helper.rb:74:in `justify_properties'
vendor/bundle/ruby/1.9.1/bundler/gems/rails_admin-e71eafaafd20/app/helpers/rails_admin/main_helper.rb:19:in `get_column_set'
vendor/bundle/ruby/1.9.1/bundler/gems/rails_admin-e71eafaafd20/app/views/rails_admin/main/list.html.haml:8:in `_vendor_bundle_ruby_______bundler_gems_rails_admin_e__eafaafd___app_views_rails_admin_main_list_html_haml___3286296796567017720_47981000'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/template.rb:144:in `block in render'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/notifications.rb:55:in `instrument'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/template.rb:142:in `render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/template_renderer.rb:40:in `block (2 levels) in render_template'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/abstract_renderer.rb:33:in `block in instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/notifications.rb:53:in `block in instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/notifications.rb:53:in `instrument'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/abstract_renderer.rb:33:in `instrument'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/template_renderer.rb:39:in `block in render_template'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/template_renderer.rb:47:in `render_with_layout'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/template_renderer.rb:38:in `render_template'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/template_renderer.rb:12:in `block in render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/abstract_renderer.rb:22:in `wrap_formats'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/template_renderer.rb:9:in `render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/renderer.rb:36:in `render_template'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_view/renderer/renderer.rb:17:in `render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/rendering.rb:120:in `_render_template'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/streaming.rb:250:in `_render_template'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/rendering.rb:114:in `render_to_body'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/renderers.rb:30:in `render_to_body'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/compatibility.rb:43:in `render_to_body'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/rendering.rb:99:in `render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/rendering.rb:16:in `render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/instrumentation.rb:40:in `block (2 levels) in render'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/core_ext/benchmark.rb:5:in `block in ms'
/usr/local/lib/ruby/1.9.1/benchmark.rb:309:in `realtime'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/core_ext/benchmark.rb:5:in `ms'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/instrumentation.rb:40:in `block in render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/instrumentation.rb:78:in `cleanup_view_runtime'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.1.0.rc8/lib/active_record/railties/controller_runtime.rb:24:in `cleanup_view_runtime'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/instrumentation.rb:39:in `render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/implicit_render.rb:10:in `default_render'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/mime_responds.rb:268:in `block in retrieve_response_from_mimes'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/mime_responds.rb:195:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/mime_responds.rb:195:in `respond_to'
vendor/bundle/ruby/1.9.1/bundler/gems/rails_admin-e71eafaafd20/app/controllers/rails_admin/main_controller.rb:47:in `list'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/implicit_render.rb:4:in `send_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/base.rb:167:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/rendering.rb:10:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/callbacks.rb:18:in `block in process_action'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/callbacks.rb:452:in `_run__4272108910333196408__process_action__2472896746071419083__callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/callbacks.rb:386:in `_run_process_action_callbacks'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/callbacks.rb:81:in `run_callbacks'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/callbacks.rb:17:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/rescue.rb:17:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/instrumentation.rb:30:in `block in process_action'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/notifications.rb:53:in `block in instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/notifications/instrumenter.rb:21:in `instrument'
vendor/bundle/ruby/1.9.1/gems/activesupport-3.1.0.rc8/lib/active_support/notifications.rb:53:in `instrument'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/instrumentation.rb:29:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/params_wrapper.rb:201:in `process_action'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.1.0.rc8/lib/active_record/railties/controller_runtime.rb:18:in `process_action'
vendor/bundle/ruby/1.9.1/gems/newrelic_rpm-3.1.1/lib/new_relic/agent/instrumentation/rails3/action_controller.rb:34:in `block in process_action'
vendor/bundle/ruby/1.9.1/gems/newrelic_rpm-3.1.1/lib/new_relic/agent/instrumentation/controller_instrumentation.rb:253:in `block in perform_action_with_newrelic_trace'
vendor/bundle/ruby/1.9.1/gems/newrelic_rpm-3.1.1/lib/new_relic/agent/method_tracer.rb:242:in `trace_execution_scoped'
vendor/bundle/ruby/1.9.1/gems/newrelic_rpm-3.1.1/lib/new_relic/agent/instrumentation/controller_instrumentation.rb:248:in `perform_action_with_newrelic_trace'
vendor/bundle/ruby/1.9.1/gems/newrelic_rpm-3.1.1/lib/new_relic/agent/instrumentation/rails3/action_controller.rb:33:in `process_action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/base.rb:121:in `process'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/abstract_controller/rendering.rb:45:in `process'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal.rb:193:in `dispatch'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal/rack_delegation.rb:14:in `dispatch'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_controller/metal.rb:236:in `block in action'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/routing/route_set.rb:65:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/routing/route_set.rb:65:in `dispatch'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/routing/route_set.rb:29:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/route_set.rb:152:in `block in call'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/code_generation.rb:96:in `block in recognize'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/code_generation.rb:68:in `optimized_each'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/code_generation.rb:95:in `recognize'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/route_set.rb:141:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/routing/route_set.rb:531:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.1.0.rc8/lib/rails/engine.rb:455:in `call'
vendor/bundle/ruby/1.9.1/gems/railties-3.1.0.rc8/lib/rails/railtie/configurable.rb:30:in `method_missing'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/prefix.rb:26:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/route_set.rb:152:in `block in call'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/code_generation.rb:96:in `block in recognize'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/code_generation.rb:75:in `optimized_each'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/code_generation.rb:95:in `recognize'
vendor/bundle/ruby/1.9.1/gems/rack-mount-0.8.2/lib/rack/mount/route_set.rb:141:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/routing/route_set.rb:531:in `call'
vendor/bundle/ruby/1.9.1/gems/newrelic_rpm-3.1.1/lib/new_relic/rack/browser_monitoring.rb:18:in `call'
vendor/bundle/ruby/1.9.1/gems/warden-1.0.5/lib/warden/manager.rb:35:in `block in call'
vendor/bundle/ruby/1.9.1/gems/warden-1.0.5/lib/warden/manager.rb:34:in `catch'
vendor/bundle/ruby/1.9.1/gems/warden-1.0.5/lib/warden/manager.rb:34:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/middleware/best_standards_support.rb:17:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.3.2/lib/rack/etag.rb:23:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.3.2/lib/rack/conditionalget.rb:25:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/middleware/head.rb:14:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/middleware/params_parser.rb:21:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/middleware/flash.rb:243:in `call'
vendor/bundle/ruby/1.9.1/gems/rack-1.3.2/lib/rack/session/abstract/id.rb:195:in `context'
vendor/bundle/ruby/1.9.1/gems/rack-1.3.2/lib/rack/session/abstract/id.rb:190:in `call'
vendor/bundle/ruby/1.9.1/gems/actionpack-3.1.0.rc8/lib/action_dispatch/middleware/cookies.rb:326:in `call'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.1.0.rc8/lib/active_record/query_cache.rb:62:in `call'
vendor/bundle/ruby/1.9.1/gems/activerecord-3.1.0.rc8/lib/active_record/connection_adapters/abstract/connection_pool.rb:477:in `call'
```
