### PR TITLE
Fix correct name for "drop rails_admin" migration file

### DIFF
--- a/lib/generators/rails_admin/uninstall_generator.rb
+++ b/lib/generators/rails_admin/uninstall_generator.rb
@@ -12,7 +12,7 @@ module RailsAdmin
 
     def uninstall
       display "Why you leaving so soon? :("
-      migration_template 'drop.rb', 'db/migrate/drop_rails_admin_histories.rb'
+      migration_template 'drop.rb', 'db/migrate/drop_rails_admin_histories_table.rb'
       remove_file 'config/initializers/rails_admin.rb'
       remove_file 'config/initializers/rails_admin.rb.example'
       gsub_file "config/routes.rb", /mount RailsAdmin::Engine => \'\/.+\', :as => \'rails_admin\'/, ''


### PR DESCRIPTION
Referring to #700 and #701.

Table-suffix was missing from the migration file.
