### PR TITLE
add japanese [ja] translation.

### DIFF
--- a/config/locales/rails_admin.ja.yml
+++ b/config/locales/rails_admin.ja.yml
@@ -1,0 +1,105 @@
+# Sample localization file for English. Add more files in this directory for other locales.
+# See http://github.com/svenfuchs/rails-i18n/tree/master/rails%2Flocale for starting points.
+
+ja:
+  home:
+    name: "ホーム"
+  admin:
+    dashboard:
+      pagename: "サイト管理"
+      name: "管理画面トップ"
+      model_name: "モデル名"
+      last_used: "最終アクセス日"
+      records: "レコード数"
+      modify: "修正"
+      add_new: "追加"
+      show: "表示"
+      ago: "前"
+      navigation: "ナビゲーション"
+    history:
+      name: "履歴"
+      page_name: "\"%{name}\"の更新履歴"
+      no_activity: "なし"
+    show:
+      show_in_app: "アプリで見る"
+      page_name: "この%{name}の詳細"
+      no_file_found: "ファイルが見つかりません"
+    credentials:
+      log_out: "ログアウト"
+    list:
+      edit_action: "編集"
+      delete_action: "削除"
+      select_action: "選択"
+      export_action: "表示中のものをエクスポート"
+      show_action: "表示"
+      export_selected: "選択中をエクスポート"
+      delete_selected: "選択中を削除"
+      add_new: "追加"
+      search: "検索"
+      select: "編集したい%{name}を選択"
+      show_all: "すべて表示"
+      add_filter: "絞り込み"
+    new:
+      basic_info: "基本情報"
+      required: "必須"
+      optional: "オプション"
+      one_char: "character"
+      many_chars: "文字以内"
+      chosen: "選択された%{name}"
+      select_choice: "クリックして選択"
+      chose_all: "すべて選択"
+      clear_all: "選択解除"
+      up: "上へ"
+      down: "下へ"
+      save: "保存"
+      save_and_add_another: "保存して次へ"
+      save_and_edit: "保存して編集"
+      cancel: "キャンセル"
+    delete:
+      all_of_the_following_related_items_will_be_deleted: "? 関連する子レコードも削除されるまたは辿れなくなる可能性があります。"
+      are_you_sure_you_want_to_delete_the_object: "この'%{model_name}'を本当に削除しますか 対象:"
+      confirmation: "削除する"
+      delete_confirmation: "本当に削除しますか?"
+      bulk_delete: "これらのデータを本当に削除しますか? 関連するこれコード模索所され殳旗どれなくなる可能性があります。"
+    export:
+      confirmation: "%{name}としてエクスポート"
+      select: "エクスポートするフィールドを選択してください"
+      fields_from: "%{name}のフィールド"
+      fields_from_associated: "関連する%{name}のフィールド"
+      display: "カラム:%{name} 型:%{type}"
+      options_for: "%{name}の出力オプション"
+      empty_value_for_associated_objects: "<empty>"
+      csv:
+        header_for_root_methods: "%{name}" # 'model' is available
+        header_for_association_methods: "%{name} [%{association}]"
+        encoding_to: "文字コード"
+        encoding_to_help: "空白の場合は%{name}になります"
+        skip_header: "ヘッダなし"
+        skip_header_help: "チェックすると出力にヘッダ行を含めません"
+        default_col_sep: ","
+        col_sep: "区切り文字"
+        col_sep_help: "空白の場合は'%{value}'区切りです" # value is default_col_sep
+    flash:
+      successful: "%{name}の%{action}に成功しました"
+      error: "%{name}の%{action}に失敗しました"
+      noaction: "操作を取り消しました"
+    actions:
+      create: "追加"
+      created: "追加"
+      update: "更新"
+      updated: "更新"
+      delete: "削除"
+      deleted: "削除"
+      export: "エクスポート"
+      exported: "エクスポート"
+    breadcrumbs:
+      delete: "削除"
+      history: "履歴"
+      show: "詳細"
+      edit: "編集"
+      export: "エクスポート"
+      bulk_destroy: "削除"
+      new: "追加"
+      model_history: "履歴"
+      list: "一覧"
+      dashboard: "管理画面トップ"


### PR DESCRIPTION
Hi.

I translated `config/locales/rails_admin.en.yml` to `rails_admin.ja.yml`, japanese locale for rails' i18n.
Please merge this.

Thanks.
