### PR TITLE
reset config in dev mode fix

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -4,6 +4,7 @@ module RailsAdmin
   class ApplicationController < ::ApplicationController
     newrelic_ignore if defined?(NewRelic)
 
+    before_filter :init_config
     before_filter :_authenticate!
     before_filter :_authorize!
     before_filter :set_plugin_name
@@ -30,6 +31,19 @@ module RailsAdmin
     end
 
     private
+
+    def init_config
+      if RailsAdmin.config.reload_between_requests
+        RailsAdmin.reset
+        RailsAdmin.module_eval{@initializers = []}
+        RailsAdmin.module_eval{@initialized = false}
+        RailsAdmin::AbstractModel.all_models = nil
+        RailsAdmin::AbstractModel.all_abstract_models = nil
+        load "#{Rails.root}/config/initializers/rails_admin.rb"
+      end
+
+      RailsAdmin.setup
+    end
 
     def _authenticate!
       instance_eval &RailsAdmin::Config.authenticate_with

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -4,15 +4,5 @@ require 'rails'
 module RailsAdmin
   class Engine < Rails::Engine
     isolate_namespace RailsAdmin
-
-    ActionDispatch::Callbacks.before do
-      RailsAdmin.setup
-    end
-
-    initializer "rails admin development mode" do |app|
-      ActionDispatch::Callbacks.after do
-        RailsAdmin.reset if !app.config.cache_classes && RailsAdmin.config.reload_between_requests
-      end
-    end
   end
 end


### PR DESCRIPTION
Hello, 

The config.reload_between_requests  var doesn't seem to work, 

callbacks in engine.rb works fine, but when it calls to RailsAdmin.setup it executes intializers block, but actual app/config/initializers/rails_admin.rb file was not reload , since Rails requires intializers/\* once, 
so it evaluate same old proc even if did some changed into it.

so i had to  load "#{Rails.root}/config/initializers/rails_admin.rb" to make it work and clear misc initialized class attributes

Another issue was perfomance. engine calls were executed per each request, so for assets requests as well. Therefore it was reloading config on each asset request, 

I had to move setup block to the bas controller.. 
probably I should move 

RailsAdmin.module_eval{@initializers = []}
... 

into  RailsAdmin.reset function.

But I would like to confirm idea first, maybe i have missed something ?

Thanks
