### PR TITLE
Filtering timestamps fields by blank or present generates a query error

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -29,8 +29,8 @@
             '<option data-additional-fieldset="true" ' + (field_operator == "less_than" ? 'selected="selected"' : '') + ' value="less_than">Less than ... days ago</option>' +
             '<option data-additional-fieldset="true" ' + (field_operator == "more_than" ? 'selected="selected"' : '') + ' value="more_than">More than ... days ago</option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option data-additional-fieldset="false"' + (field_operator == "_present"  ? 'selected="selected"' : '') + ' value="_present">Is present</option>' +
-            '<option data-additional-fieldset="false"' + (field_operator == "_blank"    ? 'selected="selected"' : '') + ' value="_blank" >Is blank</option>' +
+            '<option data-additional-fieldset="false"' + (field_operator == "_not_null"  ? 'selected="selected"' : '') + ' value="_not_null">Is not null</option>' +
+            '<option data-additional-fieldset="false"' + (field_operator == "_null"      ? 'selected="selected"' : '') + ' value="_null" >Is null</option>' +
           '</select>' +
           '<input class="additional-fieldset text_field" style="display:' + (field_operator == "less_than" || field_operator == "more_than" ? 'block' : 'none') + ';" type="text" name="' + value_name + '" value="' + field_value + '" /> ';
           break;


### PR DESCRIPTION
Filtering timestamps fields by blank or present generates a query error (on Postgres at least).

Postgres does not allow to compare a timestamp with "" (empty string).
This patch enables to filter timestamps with (not) null.
