### PR TITLE
CKeditor in rails 3.1 failed.

### DIFF
--- a/app/views/rails_admin/main/_form_text.html.haml
+++ b/app/views/rails_admin/main/_form_text.html.haml
@@ -5,7 +5,7 @@
   -# needed for modal windows
   :javascript
     var CKEDITOR_BASEPATH = '/javascripts/ckeditor/';
-  - head_javascript "/javascripts/ckeditor/ckeditor.js"
+  - head_javascript "javascripts/ckeditor/ckeditor.js"
   - head_javascript do
     - if !File.exists?(File.join(Rails.root, 'public/javascripts/ckeditor/ckeditor.js'))
       alert("Install CKEditor first");


### PR DESCRIPTION
Rails admin tried to load: /javascripts/ckeditor/ckeditor.js. Sprockets then compained because this file could not be found in the sprockets load path.

Changed into javascripts/ckeditor/ckeditor.js and this worked, ckeditor.js was then served out of public/javascripts and my error gone.
