### PR TITLE
ignore ActiveRecord models that are abstract_class=true

### DIFF
--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -29,12 +29,15 @@ module RailsAdmin
 
     # Given a string +model_name+, finds the corresponding model class
     def self.lookup(model_name)
-      begin
-        (model = model_name.constantize rescue nil) && model.is_a?(Class) && (superclasses(model).include?(ActiveRecord::Base) ? model : nil) || nil
-      rescue LoadError
-        Rails.logger.error "Error while loading '#{model_name}': #{$!}"
+      model = model_name.constantize rescue nil
+      if model && model.is_a?(Class) && superclasses(model).include?(ActiveRecord::Base) && !model.abstract_class?
+        model
+      else
         nil
       end
+    rescue LoadError
+      Rails.logger.error "Error while loading '#{model_name}': #{$!}"
+      nil
     end
 
     def initialize(model)

--- a/spec/dummy_app/app/models/abstract.rb
+++ b/spec/dummy_app/app/models/abstract.rb
@@ -1,0 +1,5 @@
+class Abstract < ActiveRecord::Base
+  
+  self.abstract_class = true
+
+end


### PR DESCRIPTION
ActiveRecord models that are marked [abstract](http://railsapi.com/doc/rails-v3.0.8rc1/classes/ActiveRecord/Base.html#M005059), such as:

```
class Part < ActiveRecord::Base
  self.abstract_class = true
  ...
end

class AutoPart < Part
end
```

...cause RailsAdmin to throw an exception when visiting /admin ([full stack here](https://gist.github.com/cd5f96e48f4cb66c6617))

```
ActiveRecord::StatementInvalid (PGError: ERROR:  relation "" does not exist
LINE 4:              WHERE a.attrelid = '""'::regclass
                                        ^
:             SELECT a.attname, format_type(a.atttypid, a.atttypmod), d.adsrc, a.attnotnull
              FROM pg_attribute a LEFT JOIN pg_attrdef d
                ON a.attrelid = d.adrelid AND a.attnum = d.adnum
             WHERE a.attrelid = '""'::regclass
               AND a.attnum > 0 AND NOT a.attisdropped
             ORDER BY a.attnum
):
```

The patch just skips over models that are abstract.
