### PR TITLE
fix for destroy session

### DIFF
--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -4,6 +4,11 @@
 - if _current_user
   - if authorized?(:edit, _current_user.class, _current_user) && _current_user.respond_to?(:email)
     %li= link_to _current_user.email, edit_path(_current_user.class.name.underscore.pluralize, _current_user)
-  - if defined?(Devise) && (devise_scope = request.env["warden"].config[:default_scope] rescue false) && (logout_path = main_app.send("destroy_#{devise_scope}_session_path") rescue false)
-    %li= link_to content_tag('span', t('admin.credentials.log_out'), :class => 'label important'), logout_path, :method => Devise.sign_out_via
-  %li= image_tag "#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", :style => 'padding-top:5px'
+  - if defined?(Devise)
+    %li
+      - if RailsAdmin.config.destroy_user_path
+        = link_to content_tag('span', t('admin.credentials.log_out'), :class => 'label important'), main_app.send(RailsAdmin.config.destroy_user_path), :method => Devise.sign_out_via
+      - else
+        = link_to content_tag('span', t('admin.credentials.log_out'), :class => 'label important'), main_app.url_for(:action => 'destroy', :controller => 'devise/sessions'), :method => Devise.sign_out_via
+    
+    %li= image_tag "#{(request.ssl? ? "https://secure" : "http://www") + ".gravatar.com/avatar"}/#{Digest::MD5.hexdigest _current_user.email}?s=30", :style => 'padding-top:5px'

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -22,15 +22,15 @@ module RailsAdmin
     DEFAULT_AUTHENTICATION = Proc.new do
       request.env['warden'].try(:authenticate!)
     end
-
+    
     DEFAULT_ATTR_ACCESSIBLE_ROLE = Proc.new { :default }
 
     DEFAULT_AUTHORIZE = Proc.new {}
 
     DEFAULT_CURRENT_USER = Proc.new do
-      request.env["warden"].try(:user) || respond_to?(:current_user) && current_user
+      request.env["warden"].try(:user) || respond_to?(:current_user) && current_user || raise("See RailsAdmin::Config.current_user_method or setup Devise / Warden")
     end
-
+  
 
     class << self
       # Application title, can be an array of two elements
@@ -64,6 +64,9 @@ module RailsAdmin
 
       # Set the max width of columns in list view before a new set is created
       attr_accessor :total_columns_width
+      
+      # Set the logout path
+      attr_accessor :destroy_user_path
 
       # Stores model configuration objects in a hash identified by model's class
       # name.
@@ -98,13 +101,12 @@ module RailsAdmin
         @authenticate = blk if blk
         @authenticate || DEFAULT_AUTHENTICATION
       end
-
-
+      
       def attr_accessible_role(&blk)
         @attr_accessible_role = blk if blk
         @attr_accessible_role || DEFAULT_ATTR_ACCESSIBLE_ROLE
       end
-
+      
       # Setup authorization to be run as a before filter
       # This is run inside the controller instance so you can setup any authorization you need to.
       #
@@ -182,11 +184,11 @@ module RailsAdmin
           raise ArgumentError, "Search operator '#{operator}' not supported"
         end
       end
-
+      
       def reload_between_requests=(thingy)
         ActiveSupport::Deprecation.warn("'#{self.name}.reload_between_requests=' is not in use any longer, please remove it from initialization files", caller)
       end
-
+      
       # Shortcut to access the list section's class configuration
       # within a config DSL block
       #


### PR DESCRIPTION
this is a proof of concept, 
when devise controllers are overriden with a custom configuration rails admin fails when tries to build the log out link, so i have added a session_destroy_path in config.

in the rails_admin initializer now you can do 

config.destroy_user_path =  "destroy_user_session_path"

it will correct the path for the log out link
