### PR TITLE
add some smooth border between links

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.css.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.css.scss
@@ -60,7 +60,7 @@ table.zebra-striped {
     text-overflow: ellipsis;
     max-width:150px;
   }
-  
+
   td.links {
     max-width: none;
     .inline {
@@ -70,14 +70,26 @@ table.zebra-striped {
       }
     }
   }
-  
+
 
   /* Shrink to content width */
   .shrink {
     width:1px;
     white-space:nowrap;
   }
-
+td.links {
+  li {
+    a {
+      border-right: 1px solid #DDD;
+      padding-right: 5px;
+    }
+    &:last-child {
+      a {
+        border-right: none;
+      }
+    }
+  }
+}
 
   /* Can't apply width:1px on sortable headers => don't play nice with sorting arrows on firefox. same for white-space:nowrap.. */
   /* History */


### PR DESCRIPTION
Even with the capitalized text, it might look like a single link/text instead of 2 or 3.

![ss](http://f.cl.ly/items/0X3O0L0w1T0h1a3i183F/Screen%20shot%202011-10-28%20at%2011.12.58%20AM.png)
