### PR TITLE
Prevent reassignment of window.$

### DIFF
--- a/app/assets/javascripts/rails_admin/ui.js.coffee
+++ b/app/assets/javascripts/rails_admin/ui.js.coffee
@@ -1,4 +1,4 @@
-$ = jQuery.noConflict()
+$ = jQuery
 
 $("#list input.checkbox.toggle").live "click", ->
   checked_status = $(this).is(":checked")


### PR DESCRIPTION
Assign $ to jQuery rather than jQuery.noConflict(). noConflict has side-effect of reassigning window.$, extending its affect outside the scope of this anonymous function. The purpose of this pattern appears only to be to use $ in place of jQuery inside the function scope.
