### PR TITLE
Can't edit an STI subclass from the base class's edit page

### DIFF
--- a/app/views/rails_admin/main/edit.html.haml
+++ b/app/views/rails_admin/main/edit.html.haml
@@ -1,2 +1,2 @@
-= form_for @object, :url => update_path(@abstract_model, @object.id), :html => { :method => "put", :multipart => true, :data => { :title => @page_name } }, :builder => RailsAdmin::FormBuilder do |form|
+= form_for @object, :url => update_path(@abstract_model, @object.id), :as => ActiveModel::Naming.param_key(@abstract_model.model), :html => { :method => "put", :multipart => true, :data => { :title => @page_name } }, :builder => RailsAdmin::FormBuilder do |form|
   = form.render :update

--- a/spec/dummy_app/app/models/hardball.rb
+++ b/spec/dummy_app/app/models/hardball.rb
@@ -1,0 +1,2 @@
+class Hardball < Ball
+end

--- a/spec/dummy_app/db/migrate/20111115041025_add_type_to_balls.rb
+++ b/spec/dummy_app/db/migrate/20111115041025_add_type_to_balls.rb
@@ -1,0 +1,5 @@
+class AddTypeToBalls < ActiveRecord::Migration
+  def change
+    add_column :balls, :type, :string
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -59,4 +59,8 @@ FactoryGirl.define do
   factory :ball do
     color(%W(red blue green yellow purple brown black white).sample)
   end
+
+  factory :hardball do
+    color('blue')
+  end
 end

--- a/spec/requests/basic/update/rails_admin_basic_update_spec.rb
+++ b/spec/requests/basic/update/rails_admin_basic_update_spec.rb
@@ -166,4 +166,21 @@ describe "RailsAdmin Basic Update" do
     end
   end
 
+  describe "update of STI subclass on superclass view" do
+    before(:each) do
+      @hardball = FactoryGirl.create :hardball
+
+      visit edit_path(:model_name => "ball", :id => @hardball.id)
+
+      fill_in "ball[color]", :with => "cyan"
+      click_button "Save and edit"
+
+      @hardball.reload
+    end
+
+    it "should update an object with correct attributes" do
+      @hardball.color.should eql("cyan")
+    end
+  end
+
 end

--- a/spec/requests/config/navigation/rails_admin_config_navigation_spec.rb
+++ b/spec/requests/config/navigation/rails_admin_config_navigation_spec.rb
@@ -8,7 +8,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
 
     it "should be alphabetical by default" do
       visit dashboard_path
-      ["Balls", "Basic pages", "Comments", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Unscoped pages", "Users"].each_with_index do |content, i|
+      ["Balls", "Basic pages", "Comments", "Divisions", "Drafts", "Fans", "Hardballs", "Leagues", "Players", "Teams", "Unscoped pages", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]").should have_content(content)
       end
     end
@@ -20,7 +20,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit dashboard_path
-      ["Teams", "Balls", "Basic pages", "Comments", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Unscoped pages", "Users"].each_with_index do |content, i|
+      ["Teams", "Balls", "Basic pages", "Comments", "Divisions", "Drafts", "Fans", "Hardballs", "Leagues", "Players", "Unscoped pages", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]").should have_content(content)
       end
     end
@@ -32,7 +32,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit dashboard_path
-      ["Balls", "Basic pages", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Unscoped pages", "Users"].each_with_index do |content, i|
+      ["Balls", "Basic pages", "Divisions", "Drafts", "Fans", "Hardballs", "Leagues", "Players", "Teams", "Unscoped pages", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]").should have_content(content)
       end
       ["Basic pages", "Comments"].each_with_index do |content, i|
@@ -50,7 +50,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit dashboard_path
-      ["Balls", "CMS related", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Unscoped pages", "Users"].each_with_index do |content, i|
+      ["Balls", "CMS related", "Divisions", "Drafts", "Fans", "Hardballs", "Leagues", "Players", "Teams", "Unscoped pages", "Users"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]").should have_content(content)
       end
       ["Basic pages", "Comments"].each_with_index do |content, i|
@@ -69,7 +69,7 @@ describe "RailsAdmin Config DSL Navigation Section" do
         end
       end
       visit dashboard_path
-      ["Balls", "Divisions", "Drafts", "Fans", "Leagues", "Players", "Teams", "Unscoped pages", "Users", "CMS related"].each_with_index do |content, i|
+      ["Balls", "Divisions", "Drafts", "Fans", "Hardballs", "Leagues", "Players", "Teams", "Unscoped pages", "Users", "CMS related"].each_with_index do |content, i|
         find(:xpath, "//ul[@id='nav']/li[#{i + 2}]").should have_content(content)
       end
     end


### PR DESCRIPTION
I have an STI model, Page, with subclasses LifePage and CompanyPage. I can create a LifePage from the Pages tab in rails_admin (/admin/pages/new), but when I make changes on the edit page (/admin/pages/edit/1) and then save, the page shows no errors but doesn't save the changes either; If, however, I create an ordinary Page on the Pages tab (without selecting a type from the dropdown), then I can edit that Page and the changes stick.

I think the edit page for the base model (in this case, Page) should be able to save instances of its sublcasses.
