### PR TITLE
Using append_file directly to update Gemfile to fix leading newline issue

### DIFF
--- a/lib/generators/rails_admin/install_generator.rb
+++ b/lib/generators/rails_admin/install_generator.rb
@@ -25,7 +25,7 @@ module RailsAdmin
       display "Checking for a current installation of devise..."
       unless defined?(Devise)
         display "Adding devise gem to your Gemfile:"
-        append_file "Gemfile", "\n", :verbose => false
+        append_file "Gemfile", "\n", :force => true
         gem 'devise'
       else
         display "Found it!"


### PR DESCRIPTION
## Issue

The `gem` action appends to the `Gemfile` without inserting a leading newline which can
break installers.
## Steps to Reproduce

Create a TestApp:

```
$ rails new TestApp
$ cd TestApp/
```

Edit the `Gemfile` to add `rails_admin` to the bottom with no trailing line break:

```
.
.
gem 'rails_admin', :git => 'git://github.com/sferik/rails_admin.git'
```

Bundle and run rails_admin installer:

```
$ bundle install
$ rails g rails_admin:install
```

Results in the following edited `Gemfile`:

```
.
.
gem 'rails_admin', :git => 'git://github.com/sferik/rails_admin.git'gem "devise"
```

Which fails on `generate devise:install`:

```
generate  devise:install
/Users/username/.rvm/gems/ruby-1.9.3-head/gems/bundler-1.0.21/lib/bundler/dsl.rb:7:in `instance_eval': /Users/username/TestApp/Gemfile:38: syntax error, unexpected tIDENTIFIER, expecting $end (SyntaxError)
....com/sferik/rails_admin.git'gem "devise"
```
## Solution

This appears to be a problem with the [`gem` generator action](http://github.com/rails/rails/blob/master/railties/lib/rails/generators/actions.rb#L70-74), where
`append_file` is called with a trailing newline but not a leading one.

```
in_root do
  str = "gem #{parts.join(", ")}\n" # Problem here
  str = "  " + str if @in_group
  append_file "Gemfile", str, :verbose => false
end
```

It seems like it might make sense to add a leading newline here:

```
in_root do
  str = "\ngem #{parts.join(", ")}\n"
  str = "  " + str if @in_group
  append_file "Gemfile", str, :verbose => false
end
```

I submitted a pull request on the [Rails repo](https://github.com/rails/rails/pull/3751) as well but in lieu of a fix there, the following modification seems to fix the issue without modifying other behavior on RailsAdmin:

`rails_admin/lib/generators/rails_admin/install_generator.rb` _line 28_

```
append_file "Gemfile", "\ngem 'devise'\n", :verbose => false
```

Thoughts?    
