### PR TITLE
Modify the rails 3.0 branch of rails_admin based on github pull request

### DIFF
--- a/app/views/rails_admin/main/list.html.haml
+++ b/app/views/rails_admin/main/list.html.haml
@@ -130,7 +130,7 @@
                 - other_left = rails_admin_list_path(params.except("set").merge(:model_name => @abstract_model.to_param, :set => params[:set].to_i - 1))
                 %td.other.left{ :style => "#{'display: none' if @other.include?("left")}" }= link_to "...", other_left, :remote => true
                 - properties.map{|property| property.bind(:object, object)}.each do |property|
-                  %td{:class => "#{property.css_class}"}= ([:text, :string].include?(property.type) && property.truncated?) ? property.pretty_value.truncate(40) : property.pretty_value
+                  %td{:class => "#{property.css_class}"}= property.pretty_value
                 - other_right = rails_admin_list_path(params.except("set").merge(:model_name => @abstract_model.to_param, :set => params[:set].to_i + 1))
                 %td.other.right{ :style => "#{'display: none' if @other.include?("right")}" }= link_to "...", other_right, :remote => true
                 %td.last

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -55,7 +55,7 @@ module RailsAdmin
         end
         
         register_instance_option(:truncated?) do
-          true
+          ActiveSupport::Deprecation.warn("'#{self.name}.truncated?' is deprecated, use '#{self.name}.pretty_value' instead", caller)
         end
 
         register_instance_option(:sortable) do

--- a/lib/rails_admin/config/fields/types/string.rb
+++ b/lib/rails_admin/config/fields/types/string.rb
@@ -27,6 +27,10 @@ module RailsAdmin
             text
           end
 
+          register_instance_option(:pretty_value) do
+            bindings[:view].truncate(formatted_value.to_s, :length => 60)
+          end
+
           register_instance_option(:html_attributes) do
             {
               :class => "#{css_class} #{has_errors? ? "errorField" : nil} #{color? ? 'color' : nil}",

--- a/lib/rails_admin/config/fields/types/text.rb
+++ b/lib/rails_admin/config/fields/types/text.rb
@@ -21,6 +21,10 @@ module RailsAdmin
             "/javascripts/ckeditor/config.js"
           end
 
+          register_instance_option(:pretty_value) do
+            bindings[:view].truncate(formatted_value.to_s, :length => 60)
+          end
+
           register_instance_option(:html_attributes) do
             {
               :class => "#{css_class} #{has_errors? ? "errorField" : nil}",


### PR DESCRIPTION
We are still using rails admin for a rails 3.0 app.  We ran into an issue that was addressed by this fix https://github.com/sferik/rails_admin/issues/643.  Since the 3.0 branch is not currently maintained we forked the project and updated the rails 3.0 branch with the fix.
