### PR TITLE
Fix path typo in custom/theming.css.scss 

### DIFF
--- a/app/assets/stylesheets/rails_admin/custom/theming.css.scss
+++ b/app/assets/stylesheets/rails_admin/custom/theming.css.scss
@@ -1,6 +1,6 @@
 /*
   Customize RailsAdmin theme here.
-  Copy this file to your app/assets/rails_admin/custom/theming.css.scss, leave this one untouched
+  Copy this file to your app/assets/stylesheets/rails_admin/custom/theming.css.scss, leave this one untouched
   Don't require it in your application.rb
 
   Look at the markup in RailsAdmin and go there to get inspiration from:


### PR DESCRIPTION
When css-diving, you find this before you'll find the folders' README.
