### PR TITLE
Added "success" trigger to remoteForm

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.remote-form.js
+++ b/app/assets/javascripts/rails_admin/ra.remote-form.js
@@ -109,6 +109,7 @@
               multiselect.find('select.ra-multiselect-selection').prepend(option);
             }
           }
+          widget._trigger("success");
           dialog.modal("hide");
         }
       });


### PR DESCRIPTION
I want to re-use the remoteForm in some of my custom form elements.  I added a trigger on AJAX success that I can bind to via:

```
    $("#new_photo_div").remoteForm({ success: function(event) { alert('success'); } });
```

Sorry, this is my first ever pull request so I apologize for anything I did wrong. 
