### PR TITLE
UTC parsing for Time fields

### DIFF
--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -41,7 +41,12 @@ module RailsAdmin
                   end
                 end
               end
-              ::Time.zone.parse(date_string, format)
+              parse_date_string(date_string)
+            end
+
+            # Parse normalized date strings using time zone
+            def parse_date_string(date_string)
+              ::Time.zone.parse(date_string)
             end
 
           end

--- a/lib/rails_admin/config/fields/types/time.rb
+++ b/lib/rails_admin/config/fields/types/time.rb
@@ -21,6 +21,11 @@ module RailsAdmin
             params[name] = self.class.normalize(params[name], localized_time_format) if params[name]
           end
 
+          # Parse normalized date (time) strings using UTC
+          def self.parse_date_string(date_string)
+            ::DateTime.parse(date_string)
+          end
+
           register_instance_option(:strftime_format) do
             (localized_format.include? "%p") ? "%I:%M %p" : "%H:%M"
           end

--- a/spec/requests/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/requests/config/edit/rails_admin_config_edit_spec.rb
@@ -617,6 +617,16 @@ describe "RailsAdmin Config DSL Edit Section" do
         @record.time_field.strftime("%H:%M").should eql(@time.strftime("%H:%M"))
       end
 
+      it "should interpret time value as UTC when timezone is specified" do
+        Time.zone = 'Eastern Time (US & Canada)' # -05:00
+
+        visit new_path(:model_name => "field_test")
+        fill_in "field_test[time_field]", :with => @time.strftime("%H:%M")
+        click_button "Save"
+        @record = RailsAdmin::AbstractModel.new("FieldTest").first
+        @record.time_field.strftime("%H:%M").should eql(@time.strftime("%H:%M"))
+      end
+
       it "should have a customization option" do
         RailsAdmin.config FieldTest do
           edit do


### PR DESCRIPTION
As it currently operates, rails admin parses time fields (time, timestamp, datetime, date) before submitting as part of the normalize method defined in the Datetime field type. This works for timestamp, datetime, and date, but not for time, since ActiveRecord reads and writes time columns in UTC. 

For apps with a time zone configured, rails_admin currently displays times in UTC (the rails default), the user enters a time in UTC, rails admin parses this using the app's time zone, then it is saved it to the database, where rails converts to UTC, offsetting the time by the time zone's offset from UTC.

ie.. for an app in eastern time: I create an object and set the time to '13:37' in the time field, i click 'save and edit' then it says '18:37', click again, it says '23:37', and so on.

I added a test to verify this. Without the fix it fails, and with the fix it passes. I also gave a brief description of the separate normalize and parse_date_string methods for documentation purposes. 

This is my first contribution to open source projects, so let me know if you need any additional information or help.

Merry Christmas! 
