### PR TITLE
Ignore unrecognized columns

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -119,7 +119,7 @@ module RailsAdmin
       end
 
       def properties
-        columns = model.columns.reject {|c| DISABLED_COLUMN_TYPES.include?(c.type.to_sym) }
+        columns = model.columns.reject {|c| c.type.blank? || DISABLED_COLUMN_TYPES.include?(c.type.to_sym) }
         columns.map do |property|
           {
             :name => property.name.to_sym,
@@ -296,7 +296,7 @@ module RailsAdmin
           association.options[:foreign_type].try(:to_sym) || :"#{association.name}_type"
         end
       end
-      
+
       def association_nested_attributes_options_lookup(association)
         model.nested_attributes_options.try { |o| o[association.name.to_sym] }
       end


### PR DESCRIPTION
Hello,

I've tried to run rails_admin on an app that has Postgres hstore column in one of the models. That column is obviously not mapped to any known type by ActiveRecord and therefore its type is set to nil. In the line that I modified rails_admin calls :to_sym on a nil value and breaks on startup. I think it's for the best to skip columns that have unknown types.

P.S. Couldn't find a spec for the unit. Is it needed?
