### PR TITLE
Exclude sqlite from being tested on travis-ci.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - rbx
   - ree
 env:
-  - "CI_DB_ADAPTER=sqlite3"
   - "CI_DB_ADAPTER=postgresql CI_DB_USERNAME=postgres"
   - "CI_DB_ADAPTER=mysql"
 notifications:


### PR DESCRIPTION
rails_admin takes a lot of worker time and SQLite is probably not used in production anyway. So lets
focus on MySQL and PostgreSQL compatibility.
