### PR TITLE
Fixing NoMEthodError when creating model that references itself.

### DIFF
--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -106,7 +106,7 @@ module RailsAdmin
 
         # Reader for the association's value unformatted
         def value
-          bindings[:object].send(association[:name])
+          bindings && bindings[:object].send(association[:name])
         end
       end
     end


### PR DESCRIPTION
For example via belongs_to relationship (tree structure). For some reason bindings are not passed to field config. This is workaround but seems to work ok.
