### PR TITLE
Give hidden input fields a field-specific classname

### DIFF
--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -49,7 +49,15 @@ module RailsAdmin
     end
 
     def input_for field
-      @template.content_tag(:div, :class => 'input') do
+      classnames = []
+      classnames << "input"
+      # add css class to hidden inputs (rails_admin doesn't do this)
+      if field.is_a?(RailsAdmin::Config::Fields::Types::Hidden)
+        classnames << "hidden-#{field.css_class}"
+      end
+      classnames = classnames.join(' ').underscore
+
+      @template.content_tag(:div, :class => classnames) do
         field_for(field) +
         errors_for(field) +
         help_for(field)


### PR DESCRIPTION
Without this patch, rails_admin skips hidden fields when it's handing out classnames.

_Bummer._

Because, I found a case where I really wanted to hook into classnames on hidden fields, too.

The case goes like this: I want to drag-and-drop nested items around, re-order them. So, I hacked together something using the `position` attribute rails_admin already favors, and I add `position` to the form as a hidden input.
Next, I have to get jQuery UI's Sortables to _find_ that hidden `position` input. But all I have is a name and an id to work with. So unless I do something ugly like `$("input[name$='[position]']")` I can't find the hidden inputs and add behavior to them.

It seemed that if I just had a classname to grab onto, it would make the code much more clear.

So, with the code in this pull request, now I get a `hidden_position_field` on the div containing the `position` inputs. Now I can update the position values whenever I drag and drop a nested item around. 

_Totally sweet._

How about an example? Well, given a configuration like this:

```
config.model Thing do
  nested do
    field :position, :hidden do
      help '' # no caption
    end
    field :description
  end
end
```

… I can setup jQuery UI's Sortables on the nested items like so:

```
$(function() {
  var sortable_model        = 'things';

  var sortable_target       = '#' + sortable_model + '_attributes_field';
  var sortable_input_field  = '.hidden_position_field';
  var sortable_items        = 'div.fields';
  $(sortable_target).sortable({
    items: sortable_items,
    cursor: 'all-scroll',
    tolerance: 'pointer',
    scroll: true,
    scrollSensitivity: 100,
    placeholder: 'ui-state-highlight',
    forcePlaceholderSize: true,
    forceHelperSize: true,
    update: function() {
      $.each($(sortable_target).find(sortable_input_field), function(n, obj) {
        $(obj).find('input').val(n);
      });
    }
  });
});
```
