### PR TITLE
Fix for Issue #934 / Bug in wording_for

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -40,7 +40,7 @@ module RailsAdmin
       I18n.t("admin.actions.#{action.i18n_key}.#{label}", 
         :model_label => model_config.try(:label), 
         :model_label_plural => model_config.try(:label_plural), 
-        :object_label => object.is_a?(abstract_model.model) ? model_config && object.try(model_config.object_label_method) : nil
+        :object_label => model_config && abstract_model && object && object.is_a?(abstract_model.model) ? object.try(model_config.object_label_method) : nil
       )
     end
     


### PR DESCRIPTION
wording_for now checks, if object is an instance of abstract_model.model
