### PR TITLE
Updated devise engine routes and initializer to embed devise_for

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -1,0 +1,3 @@
+Devise.setup do |config|
+  config.router_name = :rails_admin
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 RailsAdmin::Engine.routes.draw do
+  devise_for :users, :module => :devise
+
   controller "main" do
     RailsAdmin::Config::Actions.all(:root).each { |action| match "/#{action.route_fragment}", :to => action.action_name, :as => action.action_name, :via => action.http_methods }
     scope ":model_name" do


### PR DESCRIPTION
Related to #976. Small change to update how the embedded devise engine handles the devise_for route. Rationale for this change is explained here:

https://github.com/plataformatec/devise/wiki/How-to:-use-devise-inside-a-mountable-engine

Devise 2.0 was warning on app startup regarding the currently way devise_for is declared from outside the engine within the application's route configs. I attempted to run the spec quite before submitting this, but got so many failures I wasn't able to suss out if my changes really broke anything. Let me know if there's anything more you'd like me to do in that regard.

A nice side-effect of this change is that I was able to take the devise_for declaration entirely out of my app's routes config, which should mean that all of the fuffing about that rails_admin does in its generators to update the devise_for routes in the app can be removed. I'm not intimately familiar with everything rails_admin does in that regard, otherwise I'd just clean that code up myself as part of this pull request. If anyone wants to spell out for me which files (generators, dummy-app, specs, etc) need to be updated, I'd be happy to amend the pull request. Otherwise, I will leave that as an exercise to someone better acquainted with rails_admin.

Cheers!
