### PR TITLE
Icon-share is more illustrative for export, than icon-file (which is usu...

### DIFF
--- a/lib/rails_admin/config/actions/export.rb
+++ b/lib/rails_admin/config/actions/export.rb
@@ -32,7 +32,7 @@ module RailsAdmin
         end
 
         register_instance_option :link_icon do
-          'icon-file'
+          'icon-share'
         end
       end
     end


### PR DESCRIPTION
...ally used to create new file).
