### PR TITLE
right aligns the actual dropdown menu (<ul>) to its parent dropdown menu button

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -109,7 +109,7 @@ module RailsAdmin
       return '' if actions.empty?
       content_tag :li, { :class => 'dropdown', :style => 'float:right' } do
         content_tag(:a, { :class => 'dropdown-toggle', :'data-toggle' => "dropdown", :href => '#' }) { t('admin.misc.bulk_menu_title').html_safe + '<b class="caret"></b>'.html_safe } +
-        content_tag(:ul, :class => 'dropdown-menu') do
+        content_tag(:ul, :class => 'dropdown-menu', :style => 'left:auto; right:0;') do
           actions.map do |action|
             content_tag :li do
               link_to_function wording_for(:bulk_link, action), "jQuery('#bulk_action').val('#{action.action_name}'); jQuery('#bulk_form').submit()"

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -53,7 +53,7 @@
       %a.dropdown-toggle{:href => '#', :'data-toggle' => "dropdown"}
         = t('admin.misc.add_filter')
         %b.caret
-      %ul.dropdown-menu#filters
+      %ul.dropdown-menu#filters{:style => 'left:auto; right:0;'}
         - @filterable_fields.each do |field|
           - field_options = case field.type
           - when :enum


### PR DESCRIPTION
This solves the problem of the farthest right dropdown ("Selected Items" in the list view, for example) displaying some of its menu content off the right edge of the viewport—basically making it unreadable.

Not sure if there is a way to test for DOM element visibility within a browser viewport programmatically—if there is, I'd love to add a test to this patch!
