### PR TITLE
Fixes error: "Unknown association type :belongs_to"

### DIFF
--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -285,7 +285,7 @@ module RailsAdmin
       
       def association_type_lookup(macro)
         case macro.to_sym
-        when :referenced_in, :embedded_in
+        when :referenced_in, :embedded_in, :belongs_to
           :belongs_to
         when :references_one, :embeds_one
           :has_one


### PR DESCRIPTION
This error occurs when running the install Rails task:
`rails g rails_admin:install`

Full output:

```
bundle exec rails g rails_admin:install
:public is no longer used to avoid overloading Module#public, use :public_folder instead
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/mongo-resque-1.19.0.1/lib/resque/server.rb:12:in `<class:Server>'
           -  Hello, RailsAdmin installer will help you sets things up!
           -  I need to work with Devise, let's look at a few things first:
           -  Checking for a current installation of devise...
           -  Found it!
           -  Looks like you've already installed it, good!
           -  And you already set it up, good! We just need to know about your user model name...
           -  We found 'user' (should be one of 'user', 'admin', etc.)
           ?  Correct Devise model name if needed. Press <enter> for [user] > admin_user
           -  Now setting up devise with user model name 'admin_user':
    generate  devise
:public is no longer used to avoid overloading Module#public, use :public_folder instead
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/mongo-resque-1.19.0.1/lib/resque/server.rb:12:in `<class:Server>'
      invoke  mongoid
      insert    app/models/admin_user.rb
      insert    app/models/admin_user.rb
       route  devise_for :admin_users
           -  Now you'll need an initializer...
      create  config/initializers/rails_admin.rb
~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/adapters/mongoid.rb:297:in `association_type_lookup': Unknown association type: :belongs_to (RuntimeError)
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/adapters/mongoid.rb:59:in `block in associations'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/adapters/mongoid.rb:55:in `map'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/adapters/mongoid.rb:55:in `associations'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields/factories/belongs_to_association.rb:6:in `block in <top (required)>'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields.rb:54:in `call'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields.rb:54:in `block (2 levels) in factory'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields.rb:54:in `each'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields.rb:54:in `find'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields.rb:54:in `block in factory'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields.rb:50:in `each'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/fields.rb:50:in `factory'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/has_fields.rb:129:in `_fields'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/has_fields.rb:127:in `_fields'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/has_fields.rb:107:in `all_fields'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/rails_admin/config/has_fields.rb:82:in `fields'
    from (erb):85:in `block in template'
    from (erb):82:in `map'
    from (erb):82:in `template'
    from ~/.rvm/rubies/ruby-1.9.3-p0-falcon/lib/ruby/1.9.1/erb.rb:838:in `eval'
    from ~/.rvm/rubies/ruby-1.9.3-p0-falcon/lib/ruby/1.9.1/erb.rb:838:in `result'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/file_manipulation.rb:111:in `block in template'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/create_file.rb:54:in `call'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/create_file.rb:54:in `render'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/create_file.rb:63:in `block (2 levels) in invoke!'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/create_file.rb:63:in `open'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/create_file.rb:63:in `block in invoke!'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/empty_directory.rb:114:in `call'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/empty_directory.rb:114:in `invoke_with_conflict_check'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/create_file.rb:61:in `invoke!'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions.rb:95:in `action'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/create_file.rb:26:in `create_file'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/actions/file_manipulation.rb:110:in `template'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/bundler/gems/rails_admin-7a4fdd931f95/lib/generators/rails_admin/install_generator.rb:59:in `install'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `block in invoke_all'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `each'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `map'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/invocation.rb:124:in `invoke_all'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/group.rb:226:in `dispatch'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/railties-3.2.2/lib/rails/generators.rb:170:in `invoke'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/railties-3.2.2/lib/rails/commands/generate.rb:12:in `<top (required)>'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `require'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `block in require'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:236:in `load_dependency'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/activesupport-3.2.2/lib/active_support/dependencies.rb:251:in `require'
    from ~/.rvm/gems/ruby-1.9.3-p0-falcon@crm/gems/railties-3.2.2/lib/rails/commands.rb:29:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'


```
