### PR TITLE
Fix for Postgresql hstore columns not being recognized

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -4,7 +4,7 @@ require 'rails_admin/adapters/active_record/abstract_object'
 module RailsAdmin
   module Adapters
     module ActiveRecord
-      DISABLED_COLUMN_TYPES = [:tsvector, :blob, :binary, :spatial]
+      DISABLED_COLUMN_TYPES = [:tsvector, :blob, :binary, :spatial, :hstore]
       AR_ADAPTER = ::ActiveRecord::Base.configurations[Rails.env]['adapter']
       LIKE_OPERATOR = AR_ADAPTER == "postgresql" ? 'ILIKE' : 'LIKE'
 


### PR DESCRIPTION
Fixes what https://github.com/sferik/rails_admin/pull/899 had fixed before AR recognized :hstore columns in Postgresql.
