### PR TITLE
fix kaminari vs will_paginate conflict bug

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -35,7 +35,9 @@ module RailsAdmin
         scope = scope.where(model.primary_key => options[:bulk_ids]) if options[:bulk_ids]
         scope = scope.where(query_conditions(options[:query])) if options[:query]
         scope = scope.where(filter_conditions(options[:filters])) if options[:filters]
-        scope = scope.page(options[:page]).per(options[:per]) if options[:page] && options[:per]
+        if options[:page] && options[:per]
+          scope = scope.send(Kaminari.config.page_method_name, options[:page]).per(options[:per])
+        end
         scope = scope.reorder("#{options[:sort]} #{options[:sort_reverse] ? 'asc' : 'desc'}") if options[:sort]
         scope
       end

--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -35,11 +35,13 @@ module RailsAdmin
         scope = scope.any_in(:_id => options[:bulk_ids]) if options[:bulk_ids]
         scope = scope.where(query_conditions(options[:query])) if options[:query]
         scope = scope.where(filter_conditions(options[:filters])) if options[:filters]
-        scope = scope.page(options[:page]).per(options[:per]) if options[:page] && options[:per]
+        if options[:page] && options[:per]
+          scope = scope.send(Kaminari.config.page_method_name, options[:page]).per(options[:per])
+        end
         scope = sort_by(options, scope) if options[:sort]
         scope
       end
-      
+
       def count(options = {},scope=nil)
         all(options.merge({:limit => false, :page => false}), scope).count
       end
@@ -317,7 +319,7 @@ module RailsAdmin
           association.foreign_key.to_sym rescue nil
         end
       end
-      
+
       def association_type_lookup(macro)
         case macro.to_sym
         when :belongs_to, :referenced_in, :embedded_in

--- a/lib/rails_admin/extensions/history/history.rb
+++ b/lib/rails_admin/extensions/history/history.rb
@@ -53,7 +53,7 @@ class RailsAdmin::History < ActiveRecord::Base
     else
       history = history.order('created_at DESC')
     end
-    all ? history : history.page(page.presence || "1").per(per_page)
+    all ? history : history.send(Kaminari.config.page_method_name, page.presence || "1").per(per_page)
   end
 
   def self.history_for_object(model, object, query, sort, sort_reverse, all, page, per_page = (RailsAdmin::Config.default_items_per_page || 20))
@@ -64,6 +64,6 @@ class RailsAdmin::History < ActiveRecord::Base
     else
       history = history.order('created_at DESC')
     end
-    all ? history : history.page(page.presence || "1").per(per_page)
+    all ? history : history.send(Kaminari.config.page_method_name, page.presence || "1").per(per_page)
   end
 end

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -69,7 +69,7 @@ module RailsAdmin
           versions = Version.where :item_type => model.model.name
           versions = versions.where("event LIKE ?", "%#{query}%") if query.present?
           versions = versions.order(sort_reverse == "true" ? "#{sort} DESC" : sort)
-          versions = all ? versions : versions.page(page.presence || "1").per(per_page)
+          versions = all ? versions : versions.send(Kaminari.config.page_method_name, page.presence || "1").per(per_page)
           versions.map{|version| VersionProxy.new(version, @user_class)}
         end
 
@@ -83,7 +83,7 @@ module RailsAdmin
           versions = Version.where :item_type => model.model.name, :item_id => object.id
           versions = versions.where("event LIKE ?", "%#{query}%") if query.present?
           versions = versions.order(sort_reverse == "true" ? "#{sort} DESC" : sort)
-          versions = all ? versions : versions.page(page.presence || "1").per(per_page)
+          versions = all ? versions : versions.send(Kaminari.config.page_method_name, page.presence || "1").per(per_page)
           versions.map{|version| VersionProxy.new(version, @user_class)}
         end
       end


### PR DESCRIPTION
To avoid kaminari will_paginate incompatibility errors like:
`undefined method `per' for #<ActiveRecord::Relation:0x007fa013a6abe8>`
Just put this in `config/initializers/kaminari.rb`

```
Kaminari.configure do |config|
  config.page_method_name = :per_page_kaminari
end
```
