### PR TITLE
Hide statistics on dashboard via CanCan and cannot :statistics

### DIFF
--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -1,29 +1,30 @@
-%table.table.table-condensed.table-striped
-  %thead
-    %tr
-      %th.shrink.model-name= t "admin.table_headers.model_name"
-      %th.shrink.last-used= t "admin.table_headers.last_used"
-      %th.records= t "admin.table_headers.records"
-      %th.shrink.controls
-  %tbody
-    - @abstract_models.each do |abstract_model|
-      - if authorized? :index, abstract_model
-        - index_path = index_path(:model_name => abstract_model.to_param)
-        - row_class = "#{cycle("odd", "even")}#{" link" if index_path}"
+- unless @auditing_adapter && !authorized?(:statistics)
+  %table.table.table-condensed.table-striped
+    %thead
+      %tr
+        %th.shrink.model-name= t "admin.table_headers.model_name"
+        %th.shrink.last-used= t "admin.table_headers.last_used"
+        %th.records= t "admin.table_headers.records"
+        %th.shrink.controls
+    %tbody
+      - @abstract_models.each do |abstract_model|
+        - if authorized? :index, abstract_model
+          - index_path = index_path(:model_name => abstract_model.to_param)
+          - row_class = "#{cycle("odd", "even")}#{" link" if index_path}"
 
-        %tr{:class => row_class, :"data-link" => index_path}
-          %td
-            %span.show= link_to abstract_model.config.label_plural, index_path, :class => 'pjax'
-          %td
-            - if (last_used = @most_recent_changes[abstract_model.pretty_name])
-              = time_ago_in_words last_used
-              = t "admin.misc.ago"
-          %td
-            - count = @count[abstract_model.pretty_name]
-            - percent = count > 0 ? (@max < 2.0 ? count : ((Math.log(count) * 100.0) / Math.log(@max))) : -1
-            .label.animate-width-to{:class => 'label-'+get_indicator(percent), :'data-animate-length' => ([1.0, percent].max.to_i * 20), :'data-animate-width-to' => "#{[2.0, percent - 1].max.to_i}%", :style => "width:2%"}= @count[abstract_model.pretty_name]
-          %td.links
-            %ul.inline= menu_for :collection, abstract_model, nil, true
+          %tr{:class => row_class, :"data-link" => index_path}
+            %td
+              %span.show= link_to abstract_model.config.label_plural, index_path, :class => 'pjax'
+            %td
+              - if (last_used = @most_recent_changes[abstract_model.pretty_name])
+                = time_ago_in_words last_used
+                = t "admin.misc.ago"
+            %td
+              - count = @count[abstract_model.pretty_name]
+              - percent = count > 0 ? (@max < 2.0 ? count : ((Math.log(count) * 100.0) / Math.log(@max))) : -1
+              .label.animate-width-to{:class => 'label-'+get_indicator(percent), :'data-animate-length' => ([1.0, percent].max.to_i * 20), :'data-animate-width-to' => "#{[2.0, percent - 1].max.to_i}%", :style => "width:2%"}= @count[abstract_model.pretty_name]
+            %td.links
+              %ul.inline= menu_for :collection, abstract_model, nil, true
 - if @auditing_adapter && authorized?(:history)
   #block-tables.block
     .content

--- a/spec/integration/authorization/cancan_spec.rb
+++ b/spec/integration/authorization/cancan_spec.rb
@@ -4,6 +4,7 @@ class Ability
   include CanCan::Ability
   def initialize(user)
     can :access, :rails_admin if user.roles.include? :admin
+    cannot :statistics
     unless user.roles.include? :test_exception
       can :dashboard
       can :manage, Player if user.roles.include? :manage_player
@@ -29,6 +30,7 @@ class AdminAbility
     can :access, :rails_admin if user.roles.include? :admin
     can :show_in_app, :all
     can :manage, :all
+    can :statistics
   end
 end
 
@@ -72,6 +74,11 @@ describe "RailsAdmin CanCan Authorization" do
       body.should_not have_content("League")
       body.should_not have_content("Add new")
     end
+
+    it "GET /admin/ should not show statistics" do
+      visit dashboard_path
+      body.should_not have_content('Records')
+    end    
 
     it "GET /admin/player should render successfully but not list retired players and not show new, edit, or delete actions" do
       # ensure :name column to be shown
@@ -352,7 +359,11 @@ describe "RailsAdmin CanCan Authorization" do
         visit delete_path(:model_name => "player", :id => @player.id)
         page.status_code.should == 200
       end
+
+      it "GET /admin/ should show statistics" do
+        visit dashboard_path
+        body.should have_content('Records')
+      end
     end
   end
-
 end


### PR DESCRIPTION
Referencing #1097, where with some applications, the record counts on the dashboard don't make sense. This lets you remove it with CanCan, so: `cannot :statistics` would hide that part of the dashboard but leave the history part up.

Passing tests attached.

I'm not sure if this is the best approach, perhaps somebody has a better methodology? 
