### PR TITLE
Hide Label and Help Blocks on Hidden Fields

### DIFF
--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -41,12 +41,16 @@ module RailsAdmin
     end
 
     def field_wrapper_for field, nested_in
-      # do not show nested field if the target is the origin
-      unless field.inverse_of.presence && field.inverse_of == nested_in
-        @template.content_tag(:div, :class => "control-group #{field.type_css_class} #{field.css_class} #{'error' if field.errors.present?}", :id => "#{dom_id(field)}_field") do
-          label(field.method_name, field.label, :class => 'control-label') +
-          (field.nested_form ? field_for(field) : input_for(field))
+      if field.label
+        # do not show nested field if the target is the origin
+        unless field.inverse_of.presence && field.inverse_of == nested_in
+          @template.content_tag(:div, :class => "control-group #{field.type_css_class} #{field.css_class} #{'error' if field.errors.present?}", :id => "#{dom_id(field)}_field") do
+            label(field.method_name, field.label, :class => 'control-label') +
+            (field.nested_form ? field_for(field) : input_for(field))
+          end
         end
+      else
+        (field.nested_form ? field_for(field) : input_for(field))      
       end
     end
 

--- a/lib/rails_admin/config/fields/types/hidden.rb
+++ b/lib/rails_admin/config/fields/types/hidden.rb
@@ -10,10 +10,16 @@ module RailsAdmin
           register_instance_option :view_helper do
             :hidden_field
           end
-          
-          register_instance_option(:partial) do
-            :form_field
+
+          register_instance_option :label do
+            false
           end
+
+          register_instance_option :help do
+            false
+          end
+
+
         end
       end
     end

--- a/spec/integration/rails_admin_spec.rb
+++ b/spec/integration/rails_admin_spec.rb
@@ -41,7 +41,8 @@ describe "RailsAdmin" do
   end
 
   describe 'hidden fields with default values' do
-    it "should show up with default value, hidden" do
+    
+    before (:each) do
       RailsAdmin.config Player do
         include_all_fields
         edit do
@@ -52,10 +53,20 @@ describe "RailsAdmin" do
           end
         end
       end
-
+    end
+    
+    it "should show up with default value, hidden" do
       visit new_path(:model_name => "player")
       should have_selector("#player_name[type=hidden][value='username@example.com']")
       should_not have_selector("#player_name[type=hidden][value='toto@example.com']")
+    end
+    
+    it "should not show label" do
+      should_not have_selector("label", :text => "Name")
+    end
+    
+    it "should not show help block" do
+      should_not have_xpath("id('player_name')/../p[@class='help-block']")
     end
   end
 


### PR DESCRIPTION
Will hide label and help block by default on hidden fields.  Two specs included.
