### PR TITLE
Change location of Bootstrap labels import. Fixes #1129

### DIFF
--- a/app/assets/stylesheets/rails_admin/imports.css.scss.erb
+++ b/app/assets/stylesheets/rails_admin/imports.css.scss.erb
@@ -54,7 +54,7 @@
 @import "bootstrap/tooltip";
 @import "bootstrap/popovers";
 @import "bootstrap/thumbnails";
-@import "bootstrap/labels";
+@import "bootstrap/labels-badges";
 @import "bootstrap/progress-bars";
 @import "bootstrap/accordion";
 @import "bootstrap/carousel";


### PR DESCRIPTION
Bootstrap 2.0.3 combined badge and label styling into the same
file. This broke rails_admin.

The change just imports the right file.
