### PR TITLE
Assets aren't precompiled with initialize_on_precompile=false

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -11,7 +11,7 @@ require 'rails_admin'
 module RailsAdmin
   class Engine < Rails::Engine
     isolate_namespace RailsAdmin
-    initializer "RailsAdmin precompile hook" do |app|
+    initializer "RailsAdmin precompile hook", :group => :assets do |app|
       app.config.assets.precompile += ['rails_admin/rails_admin.js', 'rails_admin/rails_admin.css', 'rails_admin/jquery.colorpicker.js', 'rails_admin/jquery.colorpicker.css']
     end
 


### PR DESCRIPTION
Currently, if you set config.assets.initialize_on_precompile = false in application.rb (e.g. when deploying to Heroku), the rails_admin.css and js files don't get precompiled.

The workaround is to add them into config.assets.precompile manually, but this is messy and duplicating code.

This fix adds :group => :assets to the initializer in engine.rb, which evidently tells Rails to run it even if the application was not initialized. This was mentioned in the Rails 3.1.1 release notes:

"Plugins developers need to special case their initializers that are meant to be run in the assets group by adding :group => :assets. [José Valim]"
http://weblog.rubyonrails.org/2011/10/7/ann-rails-3-1-1/

Long story short, it means everything will work nicely if you set config.assets.initialize_on_precompile = false, without any extra configuration needed :)
