### PR TITLE
Update bootstrap-sass dependency to 2.0.3, because 2.0.2 breaks on master.

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -5,7 +5,7 @@ Gem::Specification.new do |gem|
   # If you add a dependency, please maintain alphabetical order
   gem.add_dependency 'bbenezech-nested_form', '~> 0.0.6'
   gem.add_dependency 'sass-rails', '~> 3.1'
-  gem.add_dependency 'bootstrap-sass', '~> 2.0.3'
+  gem.add_dependency 'bootstrap-sass', ['~> 2.0', '>= 2.0.3']
   gem.add_dependency 'jquery-ui-rails', '~> 0.2.2'
   gem.add_dependency 'builder', '~> 3.0'
   gem.add_dependency 'coffee-rails', '~> 3.1'


### PR DESCRIPTION
With pull request #1131, rails_admin master breaks with bootstrap-sass 2.0.2. Bootstrap 2.0.2 satisfies master's dependencies however, making rails_admin break on some installations.

`File to import not found or unreadable: bootstrap/labels-badges.`
