### PR TITLE
added "change" triggers on filtering select's

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-multiselect.js
@@ -103,24 +103,28 @@
       this.addAll.click(function(e){
         widget._select($('option', widget.collection));
         e.preventDefault();
+        widget.selection.trigger('change');
       });
 
       /* Add to selection */
       this.add.click(function(e){
         widget._select($(':selected', widget.collection));
         e.preventDefault();
+        widget.selection.trigger('change');
       });
 
       /* Remove all from selection */
       this.removeAll.click(function(e){
         widget._deSelect($('option', widget.selection));
         e.preventDefault();
+        widget.selection.trigger('change');
       });
 
       /* Remove from selection */
       this.remove.click(function(e){
         widget._deSelect($(':selected', widget.selection));
         e.preventDefault();
+        widget.selection.trigger('change');
       });
 
       var timeout = null;

--- a/app/assets/javascripts/rails_admin/ra.filtering-select.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-select.js
@@ -52,6 +52,7 @@
           select: function(event, ui) {
             var option = $('<option value="' + ui.item.id + '" selected="selected">' + ui.item.value + '</option>');
             select.html(option);
+            select.trigger("change", ui.item.id);
             self._trigger("selected", event, {
               item: option
             });
@@ -79,6 +80,14 @@
             }
           }
         })
+        .keyup(function() {
+          /* Clear select options and trigger change if selected item is deleted */
+          if ($(this).val().length == 0) {
+            select.empty();
+            select.trigger("change");
+          }
+        })
+
       if(select.attr('placeholder'))
         input.attr('placeholder', select.attr('placeholder'))
 


### PR DESCRIPTION
I have two fields in a model. one of these is required.
so, i want to hide unneeded field by firing "change" event of select, but does not work with `select.html(option);` !

Here my UI logic

``` coffeescript
$(document).ready ->
  game_hidden = false
  consoles_hidden = false

  #
  # First select
  #
  $("#actu_game_id").bind 'change', (event,item) ->
    if item
      $("#actu_console_ids_field").hide('slow')
      consoles_hidden = true
    else
      if consoles_hidden
        $("#actu_console_ids_field").show('slow')
        consoles_hidden = false

  #
  # Second (multi-select)
  #
  $("#actu_console_ids_field select.ra-multiselect-selection").bind 'change', ->
    options = $(this).find('option').size()
    if (options > 0)
      $("#actu_game_id_field").hide('slow')
      game_hidden = true
    else
      if game_hidden
        $("#actu_game_id_field").show('slow')
        game_hidden = false
```

And if we add an item via single select then delete it, `<option>` element is still alive. I added `select.empty();` in the keyup
