### PR TITLE
Added rails_admin namespace to translations

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -62,13 +62,13 @@ module RailsAdmin
     end
 
     rescue_from RailsAdmin::ObjectNotFound do
-      flash[:error] = I18n.t('admin.flash.object_not_found', :model => @model_name, :id => params[:id])
+      flash[:error] = I18n.t('rails_admin.admin.flash.object_not_found', :model => @model_name, :id => params[:id])
       params[:action] = 'index'
       index
     end
 
     rescue_from RailsAdmin::ModelNotFound do
-      flash[:error] = I18n.t('admin.flash.model_not_found', :model => @model_name)
+      flash[:error] = I18n.t('rails_admin.admin.flash.model_not_found', :model => @model_name)
       params[:action] = 'dashboard'
       dashboard
     end

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -40,7 +40,7 @@ module RailsAdmin
     end
 
     private
-    
+
     def get_layout
       "rails_admin/#{request.headers['X-PJAX'] ? 'pjax' : 'application'}"
     end
@@ -77,7 +77,7 @@ module RailsAdmin
     end
 
     def redirect_to_on_success
-      notice = t("admin.flash.successful", :name => @model_config.label, :action => t("admin.actions.#{@action.key}.done"))
+      notice = t("rails_admin.admin.flash.successful", :name => @model_config.label, :action => t("rails_admin.admin.actions.#{@action.key}.done"))
       if params[:_add_another]
         redirect_to new_path(:return_to => params[:return_to]), :flash => { :success => notice }
       elsif params[:_add_edit]
@@ -103,7 +103,7 @@ module RailsAdmin
     def handle_save_error whereto = :new
       action = params[:action]
 
-      flash.now[:error] = t("admin.flash.error", :name => @model_config.label, :action => t("admin.actions.#{@action.key}.done"))
+      flash.now[:error] = t("rails_admin.admin.flash.error", :name => @model_config.label, :action => t("rails_admin.admin.actions.#{@action.key}.done"))
       flash.now[:error] += ". #{@object.errors[:base].to_sentence}" unless @object.errors[:base].blank?
 
       respond_to do |format|
@@ -114,7 +114,7 @@ module RailsAdmin
 
     def check_for_cancel
       if params[:_continue]
-        redirect_to(back_or_index, :flash => { :info => t("admin.flash.noaction") })
+        redirect_to(back_or_index, :flash => { :info => t("rails_admin.admin.flash.noaction") })
       end
     end
 

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -10,8 +10,8 @@ module RailsAdmin
     end
 
     def current_action?(action, abstract_model = @abstract_model, object = @object)
-      @action.custom_key == action.custom_key && 
-      abstract_model.try(:to_param) == @abstract_model.try(:to_param) && 
+      @action.custom_key == action.custom_key &&
+      abstract_model.try(:to_param) == @abstract_model.try(:to_param) &&
       (@object.try(:persisted?) ? @object.id == object.try(:id) : !object.try(:persisted?))
     end
 
@@ -35,7 +35,7 @@ module RailsAdmin
       object = abstract_model && object.is_a?(abstract_model.model) ? object : nil
       action = RailsAdmin::Config::Actions.find(action.to_sym) if (action.is_a?(Symbol) || action.is_a?(String))
 
-      I18n.t("admin.actions.#{action.i18n_key}.#{label}",
+      t("rails_admin.admin.actions.#{action.i18n_key}.#{label}",
         :model_label => model_config.try(:label),
         :model_label_plural => model_config.try(:label_plural),
         :object_label => model_config && object.try(model_config.object_label_method)
@@ -43,10 +43,10 @@ module RailsAdmin
     end
 
     def main_navigation
-      nodes_stack = RailsAdmin::Config.visible_models(:controller => self.controller)      
+      nodes_stack = RailsAdmin::Config.visible_models(:controller => self.controller)
       nodes_stack.group_by(&:navigation_label).map do |navigation_label, nodes|
 
-        %{<li class='nav-header'>#{navigation_label || t('admin.misc.navigation')}</li>}.html_safe +
+        %{<li class='nav-header'>#{navigation_label || t('rails_admin.admin.misc.navigation')}</li>}.html_safe +
         nodes.select{|n| n.parent.nil? || !n.parent.to_s.in?(nodes_stack.map{|c| c.abstract_model.model_name }) }.map do |node|
           %{
             <li data-model="#{node.abstract_model.to_param}">
@@ -110,7 +110,7 @@ module RailsAdmin
       actions = actions(:bulkable, abstract_model)
       return '' if actions.empty?
       content_tag :li, { :class => 'dropdown', :style => 'float:right' } do
-        content_tag(:a, { :class => 'dropdown-toggle', :'data-toggle' => "dropdown", :href => '#' }) { t('admin.misc.bulk_menu_title').html_safe + '<b class="caret"></b>'.html_safe } +
+        content_tag(:a, { :class => 'dropdown-toggle', :'data-toggle' => "dropdown", :href => '#' }) { t('rails_admin.admin.misc.bulk_menu_title').html_safe + '<b class="caret"></b>'.html_safe } +
         content_tag(:ul, :class => 'dropdown-menu', :style => 'left:auto; right:0;') do
           actions.map do |action|
             content_tag :li do

--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -14,11 +14,11 @@ module RailsAdmin
       if options[:nested_in]
         action = :nested
       elsif @template.request.format == 'text/javascript'
-        action = :modal      
+        action = :modal
       else
         action = options[:action]
       end
-      
+
       groups = options[:model_config].send(action).with(:form => self, :object => @object, :view => @template).visible_groups
 
       object_infos +
@@ -50,7 +50,7 @@ module RailsAdmin
           end
         end
       else
-        (field.nested_form ? field_for(field) : input_for(field))      
+        (field.nested_form ? field_for(field) : input_for(field))
       end
     end
 
@@ -81,7 +81,7 @@ module RailsAdmin
     def object_infos
       model_config = RailsAdmin.config(object)
       model_label = model_config.label
-      object_label = (object.new_record? ? I18n.t('admin.form.new_model', :name => model_label) : object.send(model_config.object_label_method).presence || "#{model_config.label} ##{object.id}")
+      object_label = (object.new_record? ? I18n.t('rails_admin.admin.form.new_model', :name => model_label) : object.send(model_config.object_label_method).presence || "#{model_config.label} ##{object.id}")
       %{<span style="display:none" class="object-infos" data-model-label="#{model_label}" data-object-label="#{object_label}"></span>}.html_safe
     end
 

--- a/app/views/kaminari/twitter-bootstrap/_gap.html.haml
+++ b/app/views/kaminari/twitter-bootstrap/_gap.html.haml
@@ -1,2 +1,2 @@
 %li.disabled
-  %a{:href => '#'}= raw(t 'views.pagination.truncate')
+  %a{:href => '#'}= raw(t 'rails_admin.views.pagination.truncate')

--- a/app/views/kaminari/twitter-bootstrap/_next_page.html.haml
+++ b/app/views/kaminari/twitter-bootstrap/_next_page.html.haml
@@ -1,4 +1,4 @@
 - if current_page.last?
-  %li.next.disabled= link_to raw(t 'views.pagination.next'), '#'
+  %li.next.disabled= link_to raw(t 'rails_admin.views.pagination.next'), '#'
 - else
-  %li.next= link_to raw(t 'views.pagination.next'), url, :class => (remote ? 'pjax' : '')
+  %li.next= link_to raw(t 'rails_admin.views.pagination.next'), url, :class => (remote ? 'pjax' : '')

--- a/app/views/kaminari/twitter-bootstrap/_prev_page.html.haml
+++ b/app/views/kaminari/twitter-bootstrap/_prev_page.html.haml
@@ -1,4 +1,4 @@
 - if current_page.first?
-  %li.prev.disabled= link_to raw(t 'views.pagination.previous'), '#'
+  %li.prev.disabled= link_to raw(t 'rails_admin.views.pagination.previous'), '#'
 - else
-  %li.prev= link_to raw(t 'views.pagination.previous'), url, :class => (remote ? 'pjax' : '')
+  %li.prev= link_to raw(t 'rails_admin.views.pagination.previous'), url, :class => (remote ? 'pjax' : '')

--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -2,11 +2,11 @@
   - actions(:root).each do |action|
     %li= link_to wording_for(:menu, action), { :action => action.action_name, :controller => 'rails_admin/main' }, :class => 'pjax'
   - if main_app_root_path = (main_app.root_path rescue false)
-    %li= link_to t('home.name').capitalize, main_app_root_path
+    %li= link_to t('rails_admin.home.name').capitalize, main_app_root_path
   - if _current_user
     - if user_link = edit_user_link
       %li= user_link
     - if defined?(Devise) && (devise_scope = request.env["warden"].config[:default_scope] rescue false) && (logout_path = main_app.send("destroy_#{devise_scope}_session_path") rescue false)
-      %li= link_to content_tag('span', t('admin.misc.log_out'), :class => 'label label-important'), logout_path, :method => Devise.sign_out_via
+      %li= link_to content_tag('span', t('rails_admin.admin.misc.log_out'), :class => 'label label-important'), logout_path, :method => Devise.sign_out_via
     - if _current_user.respond_to?(:email) && _current_user.email.present?
       %li= image_tag "#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", :style => 'padding-top:5px'

--- a/app/views/rails_admin/main/_dashboard_history.html.haml
+++ b/app/views/rails_admin/main/_dashboard_history.html.haml
@@ -1,8 +1,8 @@
 %table.table.table-condensed.table-striped
   %thead
     %tr
-      %th.shrink.user= t("admin.table_headers.username")
-      %th.changes= t("admin.table_headers.changes")
+      %th.shrink.user= t("rails_admin.admin.table_headers.username")
+      %th.changes= t("rails_admin.admin.table_headers.changes")
   %tbody
     - @history.each do |t|
       %tr

--- a/app/views/rails_admin/main/_form_enumeration.html.haml
+++ b/app/views/rails_admin/main/_form_enumeration.html.haml
@@ -1,1 +1,1 @@
-= form.select field.method_name, field.enum, { :include_blank => true }.reverse_merge((hdv = field.html_default_value).nil? ? {} : { :selected => hdv }), field.html_attributes.reverse_merge({ :data => { :enumeration => true }, :placeholder => t('admin.misc.search') })
+= form.select field.method_name, field.enum, { :include_blank => true }.reverse_merge((hdv = field.html_default_value).nil? ? {} : { :selected => hdv }), field.html_attributes.reverse_merge({ :data => { :enumeration => true }, :placeholder => t('rails_admin.admin.misc.search') })

--- a/app/views/rails_admin/main/_form_file_upload.html.haml
+++ b/app/views/rails_admin/main/_form_file_upload.html.haml
@@ -7,7 +7,7 @@
 - if field.optional? && field.errors.blank? && file && field.delete_method
   %a.btn.btn-info{:href => '#', :'data-toggle' => 'button', :onclick => "$(this).siblings('[type=checkbox]').click(); $(this).siblings('.toggle').toggle('slow'); jQuery(this).toggleClass('btn-danger btn-info'); return false"}
     %i.icon-white.icon-trash
-    = I18n.t('admin.actions.delete.menu').capitalize + " #{field.method_name}"
+    = t('rails_admin.admin.actions.delete.menu').capitalize + " #{field.method_name}"
   = form.check_box(field.delete_method, :style => 'display:none;' )
 - if field.cache_method
   = form.hidden_field(field.cache_method)

--- a/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_multiselect.html.haml
@@ -11,16 +11,16 @@
   selected_ids = selected.map{|s| s.send(field.associated_primary_key)}
 
   current_action = params[:action].in?(['create', 'new']) ? 'create' : 'update'
-  
+
   xhr = !field.associated_collection_cache_all
-  
+
   collection = if xhr
     selected.map { |o| [o.send(field.associated_object_label_method), o.send(field.associated_primary_key)] }
   else
     i = 0
     controller.list_entries(config, :index, field.associated_collection_scope, false).map { |o| [o.send(field.associated_object_label_method), o.send(field.associated_primary_key)] }.sort_by {|a| [selected_ids.index(a[1]) || selected_ids.size, i+=1] }
   end
-  
+
   js_data = {
     :xhr => xhr,
     :'edit-url' => (authorized?(:edit, config.abstract_model) ? edit_path(:model_name => config.abstract_model.to_param, :id => '__ID__') : ''),
@@ -28,15 +28,15 @@
     :sortable => !!field.orderable,
     :cacheAll => !!field.associated_collection_cache_all,
     :regional => {
-      :chooseAll => t("admin.misc.chose_all"),
-      :chosen    => t("admin.misc.chosen", :name => config.label_plural),
-      :clearAll  => t("admin.misc.clear_all"),
-      :search    => t("admin.misc.search"),
-      :up        => t("admin.misc.up"),
-      :down      => t("admin.misc.down")
+      :chooseAll => t("rails_admin.admin.misc.chose_all"),
+      :chosen    => t("rails_admin.admin.misc.chosen", :name => config.label_plural),
+      :clearAll  => t("rails_admin.admin.misc.clear_all"),
+      :search    => t("rails_admin.admin.misc.search"),
+      :up        => t("rails_admin.admin.misc.up"),
+      :down      => t("rails_admin.admin.misc.down")
     }
   }
-  
+
 %input{:name => form.dom_name(field), :type => "hidden", :value => ""}
 
 - selected_ids = (hdv = field.html_default_value).nil? ? selected_ids : hdv

--- a/app/views/rails_admin/main/_form_filtering_select.html.haml
+++ b/app/views/rails_admin/main/_form_filtering_select.html.haml
@@ -17,16 +17,16 @@
   edit_url = authorized?(:edit, config.abstract_model) ? edit_path(:model_name => config.abstract_model.to_param, :modal => true, :id => '__ID__') : ''
 
   xhr = !field.associated_collection_cache_all
-  
+
   collection = xhr ? [[selected_name, selected_id]] : controller.list_entries(config, :index, field.associated_collection_scope, false).map { |o| [o.send(field.associated_object_label_method), o.send(field.associated_primary_key)] }
-  
+
   js_data = {
     :xhr => xhr,
     :remote_source => index_path(config.abstract_model.to_param, :source_object_id => form.object.id, :source_abstract_model => source_abstract_model.to_param, :associated_collection => field.name, :current_action => current_action, :compact => true)
   }
 
 - selected_id = (hdv = field.html_default_value).nil? ? selected_id : hdv
-= form.select field.method_name, collection, { :selected => selected_id, :include_blank => true }, field.html_attributes.reverse_merge({ :data => { :filteringselect => true, :options => js_data.to_json }, :placeholder => t('admin.misc.search') })
+= form.select field.method_name, collection, { :selected => selected_id, :include_blank => true }, field.html_attributes.reverse_merge({ :data => { :filteringselect => true, :options => js_data.to_json }, :placeholder => t('rails_admin.admin.misc.search') })
 
 - if authorized? :new, config.abstract_model
   - path_hash = { :model_name => config.abstract_model.to_param, :modal => true }

--- a/app/views/rails_admin/main/_submit_buttons.html.haml
+++ b/app/views/rails_admin/main/_submit_buttons.html.haml
@@ -1,15 +1,15 @@
 %input{:type => :hidden, :name => 'return_to', :value => (params[:return_to].presence || request.referer)}
 .form-actions
-  %button.btn.btn-primary{:type => "submit", :name => "_save", :'data-disable-with' => t("admin.form.save")}
+  %button.btn.btn-primary{:type => "submit", :name => "_save", :'data-disable-with' => t("rails_admin.admin.form.save")}
     %i.icon-white.icon-ok
-    = t("admin.form.save")
+    = t("rails_admin.admin.form.save")
   %span.extra_buttons
     - if authorized? :new, @abstract_model
-      %button.btn.btn-info{:type => "submit", :name => "_add_another", :'data-disable-with' => t("admin.form.save_and_add_another")}
-        = t("admin.form.save_and_add_another")
+      %button.btn.btn-info{:type => "submit", :name => "_add_another", :'data-disable-with' => t("rails_admin.admin.form.save_and_add_another")}
+        = t("rails_admin.admin.form.save_and_add_another")
     - if authorized? :edit, @abstract_model
-      %button.btn.btn-info{:type => "submit", :name => "_add_edit", :'data-disable-with' => t("admin.form.save_and_edit")}
-        = t("admin.form.save_and_edit")
-    %button.btn{:type => "submit", :name => "_continue", :'data-disable-with' => t("admin.form.cancel")}
+      %button.btn.btn-info{:type => "submit", :name => "_add_edit", :'data-disable-with' => t("rails_admin.admin.form.save_and_edit")}
+        = t("rails_admin.admin.form.save_and_edit")
+    %button.btn{:type => "submit", :name => "_continue", :'data-disable-with' => t("rails_admin.admin.form.cancel")}
       %i.icon-remove
-      = t("admin.form.cancel")
+      = t("rails_admin.admin.form.cancel")

--- a/app/views/rails_admin/main/bulk_delete.html.haml
+++ b/app/views/rails_admin/main/bulk_delete.html.haml
@@ -1,11 +1,11 @@
-%h4= I18n.t('admin.form.bulk_delete')
+%h4= t('rails_admin.admin.form.bulk_delete')
 %ul= render :partial => "delete_notice", :collection => @objects
 = form_tag bulk_delete_path(:model_name => @abstract_model.to_param, :bulk_ids => @objects.map(&:id)), :method => :delete do
   .form-actions
     %input{:type => :hidden, :name => 'return_to', :value => (params[:return_to].presence || request.referer)}
-    %button.btn.btn-danger{:type => "submit", :'data-disable-with' => t("admin.form.confirmation")}
+    %button.btn.btn-danger{:type => "submit", :'data-disable-with' => t("rails_admin.admin.form.confirmation")}
       %i.icon-white.icon-ok
-      = t("admin.form.confirmation")
-    %button.btn{:type => "submit", :name => "_continue", :'data-disable-with' => t("admin.form.cancel")}
+      = t("rails_admin.admin.form.confirmation")
+    %button.btn{:type => "submit", :name => "_continue", :'data-disable-with' => t("rails_admin.admin.form.cancel")}
       %i.icon-remove
-      = t("admin.form.cancel")
+      = t("rails_admin.admin.form.cancel")

--- a/app/views/rails_admin/main/dashboard.html.haml
+++ b/app/views/rails_admin/main/dashboard.html.haml
@@ -1,9 +1,9 @@
 %table.table.table-condensed.table-striped
   %thead
     %tr
-      %th.shrink.model-name= t "admin.table_headers.model_name"
-      %th.shrink.last-used= t "admin.table_headers.last_used"
-      %th.records= t "admin.table_headers.records"
+      %th.shrink.model-name= t("rails_admin.admin.table_headers.model_name")
+      %th.shrink.last-used= t("rails_admin.admin.table_headers.last_used")
+      %th.records= t("rails_admin.admin.table_headers.records")
       %th.shrink.controls
   %tbody
     - @abstract_models.each do |abstract_model|
@@ -17,7 +17,7 @@
           %td
             - if (last_used = @most_recent_changes[abstract_model.pretty_name])
               = time_ago_in_words last_used
-              = t "admin.misc.ago"
+              = t("rails_admin.admin.misc.ago")
           %td
             - count = @count[abstract_model.pretty_name]
             - percent = count > 0 ? (@max < 2.0 ? count : ((Math.log(count) * 100.0) / Math.log(@max))) : -1
@@ -27,5 +27,5 @@
 - if @auditing_adapter && authorized?(:history)
   #block-tables.block
     .content
-      %h2= t("admin.actions.history_index.menu")
+      %h2= t("rails_admin.admin.actions.history_index.menu")
       = render :partial => 'rails_admin/main/dashboard_history'

--- a/app/views/rails_admin/main/delete.html.haml
+++ b/app/views/rails_admin/main/delete.html.haml
@@ -1,18 +1,18 @@
 %h4
-  = t("admin.form.are_you_sure_you_want_to_delete_the_object", :model_name => @abstract_model.pretty_name.downcase)
+  = t("rails_admin.admin.form.are_you_sure_you_want_to_delete_the_object", :model_name => @abstract_model.pretty_name.downcase)
   &ldquo;
   %strong>= @model_config.with(:object => @object).object_label
   \&rdquo;
   %span>
-  = t("admin.form.all_of_the_following_related_items_will_be_deleted")
+  = t("rails_admin.admin.form.all_of_the_following_related_items_will_be_deleted")
 
 %ul= render :partial => "delete_notice", :object => @object
 = form_for(@object, :url => delete_path(:model_name => @abstract_model.to_param, :id => @object.id), :html => {:method => "delete"}) do
   %input{:type => :hidden, :name => 'return_to', :value => (params[:return_to].presence || request.referer)}
   .form-actions
-    %button.btn.btn-danger{:type => "submit", :'data-disable-with' => t("admin.form.confirmation")}
+    %button.btn.btn-danger{:type => "submit", :'data-disable-with' => t("rails_admin.admin.form.confirmation")}
       %i.icon-white.icon-ok
-      = t("admin.form.confirmation")
-    %button.btn{:type => "submit", :name => "_continue", :'data-disable-with' => t("admin.form.cancel")}
+      = t("rails_admin.admin.form.confirmation")
+    %button.btn{:type => "submit", :name => "_continue", :'data-disable-with' => t("rails_admin.admin.form.cancel")}
       %i.icon-remove
-      = t("admin.form.cancel")
+      = t("rails_admin.admin.form.cancel")

--- a/app/views/rails_admin/main/export.html.haml
+++ b/app/views/rails_admin/main/export.html.haml
@@ -7,9 +7,9 @@
   %fieldset
     %legend
       %i.icon-chevron-down
-      = t('admin.export.select')
+      = t('rails_admin.admin.export.select')
     .control-group
-      %label.control-label{:rel => 'tooltip', :'data-original-title' => t('admin.export.click_to_reverse_selection'), :onclick => 'jQuery(this).siblings(".controls").find("input").click()'}= t('admin.export.fields_from', :name => @model_config.label_plural.downcase)
+      %label.control-label{:rel => 'tooltip', :'data-original-title' => t('rails_admin.admin.export.click_to_reverse_selection'), :onclick => 'jQuery(this).siblings(".controls").find("input").click()'}= t('rails_admin.admin.export.fields_from', :name => @model_config.label_plural.downcase)
       .controls
         - visible_fields.select{ |f| !f.association? || f.association[:polymorphic] }.each do |field|
           - list = field.virtual? ? 'methods' : 'only'
@@ -29,7 +29,7 @@
     - visible_fields.select{ |f| f.association? && !f.association[:polymorphic] }.each do |field|
       - fields = field.associated_model_config.export.with(:view => self, :object => (associated_model = field.associated_model_config.abstract_model.model).new).visible_fields.select{ |f| !f.association? }
       .control-group
-        %label.control-label{:rel => 'tooltip', :'data-original-title' => t('admin.export.click_to_reverse_selection'), :onclick => 'jQuery(this).siblings(".controls").find("input").click()'}= t('admin.export.fields_from_associated', :name => field.label.downcase)
+        %label.control-label{:rel => 'tooltip', :'data-original-title' => t('rails_admin.admin.export.click_to_reverse_selection'), :onclick => 'jQuery(this).siblings(".controls").find("input").click()'}= t('rails_admin.admin.export.fields_from_associated', :name => field.label.downcase)
         .controls
           - fields.each do |associated_model_field|
             - list = associated_model_field.virtual? ? 'methods' : 'only'
@@ -40,36 +40,36 @@
   %fieldset
     %legend
       %i.icon-chevron-down
-      = t('admin.export.options_for', :name => 'csv')
+      = t('rails_admin.admin.export.options_for', :name => 'csv')
     .control-group
       - guessed_encoding = (Rails.configuration.database_configuration[Rails.env]['encoding'].presence rescue 'UTF-8') || 'UTF-8'
-      %label.control-label{:for => "csv_options_encoding_to"}= t('admin.export.csv.encoding_to')
+      %label.control-label{:for => "csv_options_encoding_to"}= t('rails_admin.admin.export.csv.encoding_to')
       .controls
         -# from http://books.google.com/support/partner/bin/answer.py?answer=30990 :
         = select_tag 'csv_options[encoding_to]', options_for_select(["", "UTF-8", "UTF-16LE", "UTF-16BE", "UTF-32LE", "UTF-32BE", "UTF-7", "ISO-8859-1", "ISO-8859-15", "IBM-850", "MacRoman", "Windows-1252", "ISO-8859-3", "IBM-852", "ISO-8859-2", "MacCE", "Windows-1250", "IBM-855", "ISO-8859-5", "ISO-IR-111", "KOI8-R", "MacCyrillic", "Windows-1251", "CP-866", "KOI-U", "MacUkranian", "GB2312", "GBK", "GB18030", "HZ", "ISO-2022-CN", "Big5", "Big5-HKSCS", "EUC-TW", "EUC-JP", "ISO-2022-JP", "Shift_JIS", "EUC-KR", "UHC", "JOHAB", "ISO-2022-KR"])
-        %p.help-block= t('admin.export.csv.encoding_to_help', :name => guessed_encoding)
+        %p.help-block= t('rails_admin.admin.export.csv.encoding_to_help', :name => guessed_encoding)
 
     .control-group
-      %label.control-label{:for => "csv_options_skip_header"}= t('admin.export.csv.skip_header')
+      %label.control-label{:for => "csv_options_skip_header"}= t('rails_admin.admin.export.csv.skip_header')
       .controls
         = check_box_tag 'csv_options[skip_header]', 'true'
-        %p.help-block= t('admin.export.csv.skip_header_help')
+        %p.help-block= t('rails_admin.admin.export.csv.skip_header_help')
 
     .control-group
-      %label.control-label{:for => "csv_options_generator_col_sep"}= t('admin.export.csv.col_sep')
+      %label.control-label{:for => "csv_options_generator_col_sep"}= t('rails_admin.admin.export.csv.col_sep')
       .controls
-        = select_tag 'csv_options[generator][col_sep]', options_for_select({ '' => t('admin.export.csv.default_col_sep'), "<comma> ','" => ',', "<semicolon> ';'" => ';', '<tabs>' => "'\t'" })
-        %p.help-block= t('admin.export.csv.col_sep_help', :value => t('admin.export.csv.default_col_sep'))
+        = select_tag 'csv_options[generator][col_sep]', options_for_select({ '' => t('rails_admin.admin.export.csv.default_col_sep'), "<comma> ','" => ',', "<semicolon> ';'" => ';', '<tabs>' => "'\t'" })
+        %p.help-block= t('rails_admin.admin.export.csv.col_sep_help', :value => t('rails_admin.admin.export.csv.default_col_sep'))
 
   .form-actions
     %input{:type => :hidden, :name => 'return_to', :value => (params[:return_to].presence || request.referer)}
     %button.btn.btn-primary{:type => "submit", :name => 'csv'}
       %i.icon-white.icon-ok
-      = t("admin.export.confirmation", :name => 'csv')
+      = t("rails_admin.admin.export.confirmation", :name => 'csv')
     %button.btn.btn-info{:type => "submit", :name => 'json'}
-      = t("admin.export.confirmation", :name => 'json')
+      = t("rails_admin.admin.export.confirmation", :name => 'json')
     %button.btn.btn-info{:type => "submit", :name => 'xml'}
-      = t("admin.export.confirmation", :name => 'xml')
+      = t("rails_admin.admin.export.confirmation", :name => 'xml')
     %button.btn{:type => "submit", :name => "_continue"}
       %i.icon-remove
-      = t("admin.form.cancel")
+      = t("rails_admin.admin.form.cancel")

--- a/app/views/rails_admin/main/history.html.haml
+++ b/app/views/rails_admin/main/history.html.haml
@@ -7,18 +7,18 @@
 
 = form_tag("", :method => "get", :class => "search pjax-form form-inline") do
   .well
-    %input{:name => "query", :type => "search", :value => query, :placeholder => "#{t("admin.misc.filter")}", :class => 'input-small'}
-    %button.btn.btn-primary{:type => "submit", :'data-disable-with' => "<i class='icon-white icon-refresh'></i> ".html_safe + t("admin.misc.refresh")}
+    %input{:name => "query", :type => "search", :value => query, :placeholder => "#{t("rails_admin.admin.misc.filter")}", :class => 'input-small'}
+    %button.btn.btn-primary{:type => "submit", :'data-disable-with' => "<i class='icon-white icon-refresh'></i> ".html_safe + t("rails_admin.admin.misc.refresh")}
       %i.icon-white.icon-refresh
-      = t("admin.misc.refresh")
+      = t("rails_admin.admin.misc.refresh")
 %table#history.table.table-striped.table-condensed
   %thead
     %tr
       - columns = []
-      - columns << { :property_name => "created_at", :css_class => "created_at",:link_text => t('admin.table_headers.created_at') }
-      - columns << { :property_name => "username",   :css_class => "username",  :link_text => t('admin.table_headers.username')   }
-      - columns << { :property_name => "item",       :css_class => "item",      :link_text => t('admin.table_headers.item')       } if @general
-      - columns << { :property_name => "message",    :css_class => "message",   :link_text => t('admin.table_headers.message')    }
+      - columns << { :property_name => "created_at", :css_class => "created_at",:link_text => t('rails_admin.admin.table_headers.created_at') }
+      - columns << { :property_name => "username",   :css_class => "username",  :link_text => t('rails_admin.admin.table_headers.username')   }
+      - columns << { :property_name => "item",       :css_class => "item",      :link_text => t('rails_admin.admin.table_headers.item')       } if @general
+      - columns << { :property_name => "message",    :css_class => "message",   :link_text => t('rails_admin.admin.table_headers.message')    }
 
       - columns.each do |column|
         - property_name = column[:property_name]
@@ -38,5 +38,5 @@
 
 - unless params[:all] || !@history.respond_to?(:current_page)
   = paginate(@history, :theme => 'twitter-bootstrap', :remote => true)
-  = link_to(t("admin.misc.show_all"), send(path_method, params.merge(:all => true)), :class => "show-all btn pjax") unless (tc = @history.total_count) <= @history.size || tc > 100
+  = link_to(t("rails_admin.admin.misc.show_all"), send(path_method, params.merge(:all => true)), :class => "show-all btn pjax") unless (tc = @history.total_count) <= @history.size || tc > 100
 

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -54,7 +54,7 @@
   - if @filterable_fields.present?
     %li.dropdown{:style => 'float:right'}
       %a.dropdown-toggle{:href => '#', :'data-toggle' => "dropdown"}
-        = t('admin.misc.add_filter')
+        = t('rails_admin.admin.misc.add_filter')
         %b.caret
       %ul.dropdown-menu#filters{:style => 'left:auto; right:0;'}
         - @filterable_fields.each do |field|
@@ -71,7 +71,7 @@
     jQuery(function($) {
     $.filters.options.regional = {
     datePicker: {
-    dateFormat: #{raw I18n.t("admin.misc.filter_date_format", :default => I18n.t("admin.misc.filter_date_format", :locale => :en)).to_json},
+    dateFormat: #{raw I18n.t("rails_admin.admin.misc.filter_date_format", :default => I18n.t("rails_admin.admin.misc.filter_date_format", :locale => :en)).to_json},
     dayNames: #{raw RailsAdmin::Config::Fields::Types::Datetime.day_names.to_json},
     dayNamesShort: #{raw RailsAdmin::Config::Fields::Types::Datetime.abbr_day_names.to_json},
     dayNamesMin: #{raw RailsAdmin::Config::Fields::Types::Datetime.abbr_day_names.to_json},
@@ -80,9 +80,9 @@
     monthNamesShort: #{raw RailsAdmin::Config::Fields::Types::Datetime.abbr_month_names.to_json},
     }
     }
-    
+
     = @ordered_filter_string
-    
+
     });
   %style
     - properties.select{ |p| p.column_width.present? }.each do |property|
@@ -92,10 +92,10 @@
     .well
       %span#filters_box
       %hr.filters_box{:style => "display:#{@ordered_filters.empty? ? 'none' : 'block'}"}
-      %input.input-small{:name => "query", :type => "search", :value => query, :placeholder => t("admin.misc.filter")}
-      %button.btn.btn-primary{:type => "submit", :'data-disable-with' => "<i class='icon-white icon-refresh'></i> ".html_safe + t("admin.misc.refresh")}
+      %input.input-small{:name => "query", :type => "search", :value => query, :placeholder => t("rails_admin.admin.misc.filter")}
+      %button.btn.btn-primary{:type => "submit", :'data-disable-with' => "<i class='icon-white icon-refresh'></i> ".html_safe + t("rails_admin.admin.misc.refresh")}
         %i.icon-white.icon-refresh
-        = t("admin.misc.refresh")
+        = t("rails_admin.admin.misc.refresh")
       - if export_action
         %span{:style => 'float:right'}= link_to wording_for(:link, export_action), export_path(params.except('set').except('page')), :class => 'btn btn-info'
 
@@ -134,7 +134,7 @@
     - if @objects.respond_to?(:total_count)
       - total_count = @objects.total_count.to_i
       = paginate(@objects, :theme => 'twitter-bootstrap', :remote => true)
-      = link_to(t("admin.misc.show_all"), index_path(params.merge(:all => true)), :class => "show-all btn clearfix pjax") unless total_count > 100 || total_count <= @objects.to_a.size
+      = link_to(t("rails_admin.admin.misc.show_all"), index_path(params.merge(:all => true)), :class => "show-all btn clearfix pjax") unless total_count > 100 || total_count <= @objects.to_a.size
       .clearfix.total-count= "#{total_count} #{@model_config.label_plural.downcase}"
     - else
       .clearfix.total-count= "#{@objects.size} #{@model_config.label_plural.downcase}"

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -1,130 +1,131 @@
 en:
-  home:
-    name: Home
-  views:
-    pagination:
-      previous: "&laquo; Prev"
-      next: "Next &raquo;"
-      truncate: "…"
-  admin:
-    misc:
-      filter_date_format: "mm/dd/yy" # a combination of 'dd', 'mm' and 'yy' with any delimiter. No other interpolation will be done!
-      search: "Search"
-      filter: "Filter"
-      refresh: "Refresh"
-      show_all: "Show all"
-      add_filter: "Add filter"
-      bulk_menu_title: "Selected items"
-      remove: "Remove"
-      add_new: "Add new"
-      chosen: "Chosen %{name}"
-      chose_all: "Choose all"
-      clear_all: "Clear all"
-      up: "Up"
-      down: "Down"
-      navigation: "Navigation"
-      log_out: "Log out"
-      ago: "ago"
-    flash:
-      successful: "%{name} successfully %{action}"
-      error: "%{name} failed to be %{action}"
-      noaction: "No actions were taken"
-      model_not_found: "Model '%{model}' could not be found"
-      object_not_found: "%{model} with id '%{id}' could not be found"
-    table_headers:
-      model_name: "Model name"
-      last_used: "Last used"
-      records: "Records"
-      username: "User"
-      changes: "Changes"
-      created_at: "Date/Time"
-      item: "Item"
-      message: "Message"
-    actions:
-      dashboard:
-        title: "Site administration"
-        menu: "Dashboard"
-        breadcrumb: "Dashboard"
-      index:
-        title: "List of %{model_label_plural}"
-        menu: "List"
-        breadcrumb: "%{model_label_plural}"
-      show:
-        title: "Details for %{model_label} '%{object_label}'"
-        menu: "Show"
-        breadcrumb: "%{object_label}"
-      show_in_app:
-        menu: "Show in app"
-      new:
-        title: "New %{model_label}"
-        menu: "Add new"
-        breadcrumb: "New"
-        link: "Add a new %{model_label}"
-        done: "created"
-      edit:
-        title: "Edit %{model_label} '%{object_label}'"
-        menu: "Edit"
-        breadcrumb: "Edit"
-        link: "Edit this %{model_label}"
-        done: "updated"
-      delete:
-        title: "Delete %{model_label} '%{object_label}'"
-        menu: "Delete"
-        breadcrumb: "Delete"
-        link: "Delete '%{object_label}'"
-        done: "deleted"
-      bulk_delete:
-        title: "Delete %{model_label_plural}"
-        menu: "Multiple delete"
-        breadcrumb: "Multiple delete"
-        bulk_link: "Delete selected %{model_label_plural}"
+  rails_admin:
+    home:
+      name: Home
+    views:
+      pagination:
+        previous: "&laquo; Prev"
+        next: "Next &raquo;"
+        truncate: "…"
+    admin:
+      misc:
+        filter_date_format: "mm/dd/yy" # a combination of 'dd', 'mm' and 'yy' with any delimiter. No other interpolation will be done!
+        search: "Search"
+        filter: "Filter"
+        refresh: "Refresh"
+        show_all: "Show all"
+        add_filter: "Add filter"
+        bulk_menu_title: "Selected items"
+        remove: "Remove"
+        add_new: "Add new"
+        chosen: "Chosen %{name}"
+        chose_all: "Choose all"
+        clear_all: "Clear all"
+        up: "Up"
+        down: "Down"
+        navigation: "Navigation"
+        log_out: "Log out"
+        ago: "ago"
+      flash:
+        successful: "%{name} successfully %{action}"
+        error: "%{name} failed to be %{action}"
+        noaction: "No actions were taken"
+        model_not_found: "Model '%{model}' could not be found"
+        object_not_found: "%{model} with id '%{id}' could not be found"
+      table_headers:
+        model_name: "Model name"
+        last_used: "Last used"
+        records: "Records"
+        username: "User"
+        changes: "Changes"
+        created_at: "Date/Time"
+        item: "Item"
+        message: "Message"
+      actions:
+        dashboard:
+          title: "Site administration"
+          menu: "Dashboard"
+          breadcrumb: "Dashboard"
+        index:
+          title: "List of %{model_label_plural}"
+          menu: "List"
+          breadcrumb: "%{model_label_plural}"
+        show:
+          title: "Details for %{model_label} '%{object_label}'"
+          menu: "Show"
+          breadcrumb: "%{object_label}"
+        show_in_app:
+          menu: "Show in app"
+        new:
+          title: "New %{model_label}"
+          menu: "Add new"
+          breadcrumb: "New"
+          link: "Add a new %{model_label}"
+          done: "created"
+        edit:
+          title: "Edit %{model_label} '%{object_label}'"
+          menu: "Edit"
+          breadcrumb: "Edit"
+          link: "Edit this %{model_label}"
+          done: "updated"
+        delete:
+          title: "Delete %{model_label} '%{object_label}'"
+          menu: "Delete"
+          breadcrumb: "Delete"
+          link: "Delete '%{object_label}'"
+          done: "deleted"
+        bulk_delete:
+          title: "Delete %{model_label_plural}"
+          menu: "Multiple delete"
+          breadcrumb: "Multiple delete"
+          bulk_link: "Delete selected %{model_label_plural}"
+        export:
+          title: "Export %{model_label_plural}"
+          menu: "Export"
+          breadcrumb: "Export"
+          link: "Export found %{model_label_plural}"
+          bulk_link: "Export selected %{model_label_plural}"
+          done: "exported"
+        history_index:
+          title: "History for %{model_label_plural}"
+          menu: "History"
+          breadcrumb: "History"
+        history_show:
+          title: "History for %{model_label} '%{object_label}'"
+          menu: "History"
+          breadcrumb: "History"
+      form:
+        cancel: "Cancel"
+        basic_info: "Basic info"
+        required: "Required"
+        optional: "Optional"
+        one_char: "character"
+        char_length_up_to: "length up to"
+        char_length_of: "length of"
+        save: "Save"
+        save_and_add_another: "Save and add another"
+        save_and_edit: "Save and edit"
+        all_of_the_following_related_items_will_be_deleted: "? The following related items may be deleted or orphaned:"
+        are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete this %{model_name}"
+        confirmation: "Yes, I'm sure"
+        bulk_delete: "The following objects will be deleted, which may delete or orphan some of their related dependencies:"
+        new_model: "%{name} (new)"
       export:
-        title: "Export %{model_label_plural}"
-        menu: "Export"
-        breadcrumb: "Export"
-        link: "Export found %{model_label_plural}"
-        bulk_link: "Export selected %{model_label_plural}"
-        done: "exported"
-      history_index:
-        title: "History for %{model_label_plural}"
-        menu: "History"
-        breadcrumb: "History"
-      history_show:
-        title: "History for %{model_label} '%{object_label}'"
-        menu: "History"
-        breadcrumb: "History"
-    form:
-      cancel: "Cancel"
-      basic_info: "Basic info"
-      required: "Required"
-      optional: "Optional"
-      one_char: "character"
-      char_length_up_to: "length up to"
-      char_length_of: "length of"
-      save: "Save"
-      save_and_add_another: "Save and add another"
-      save_and_edit: "Save and edit"
-      all_of_the_following_related_items_will_be_deleted: "? The following related items may be deleted or orphaned:"
-      are_you_sure_you_want_to_delete_the_object: "Are you sure you want to delete this %{model_name}"
-      confirmation: "Yes, I'm sure"
-      bulk_delete: "The following objects will be deleted, which may delete or orphan some of their related dependencies:"
-      new_model: "%{name} (new)"
-    export:
-      confirmation: "Export to %{name}"
-      select: "Select fields to export"
-      fields_from: "Fields from %{name}"
-      fields_from_associated: "Fields from associated %{name}"
-      display: "Display %{name}: %{type}"
-      options_for: "Options for %{name}"
-      empty_value_for_associated_objects: "<empty>"
-      click_to_reverse_selection: 'Click to reverse selection'
-      csv:
-        header_for_root_methods: "%{name}" # 'model' is available
-        header_for_association_methods: "%{name} [%{association}]"
-        encoding_to: "Encode to"
-        encoding_to_help: "Choose output encoding. Leave empty to let current input encoding untouched: (%{name})"
-        skip_header: "No header"
-        skip_header_help: "Do not output a header (no fields description)"
-        default_col_sep: ","
-        col_sep: "Column separator"
-        col_sep_help: "Leave blank for default ('%{value}')" # value is default_col_sep
+        confirmation: "Export to %{name}"
+        select: "Select fields to export"
+        fields_from: "Fields from %{name}"
+        fields_from_associated: "Fields from associated %{name}"
+        display: "Display %{name}: %{type}"
+        options_for: "Options for %{name}"
+        empty_value_for_associated_objects: "<empty>"
+        click_to_reverse_selection: 'Click to reverse selection'
+        csv:
+          header_for_root_methods: "%{name}" # 'model' is available
+          header_for_association_methods: "%{name} [%{association}]"
+          encoding_to: "Encode to"
+          encoding_to_help: "Choose output encoding. Leave empty to let current input encoding untouched: (%{name})"
+          skip_header: "No header"
+          skip_header_help: "Do not output a header (no fields description)"
+          default_col_sep: ","
+          col_sep: "Column separator"
+          col_sep_help: "Leave blank for default ('%{value}')" # value is default_col_sep

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -83,7 +83,7 @@ module RailsAdmin
     private
 
     def get_filtering_duration(operator, value)
-      date_format = I18n.t("admin.misc.filter_date_format", :default => I18n.t("admin.misc.filter_date_format", :locale => :en)).gsub('dd', '%d').gsub('mm', '%m').gsub('yy', '%Y')
+      date_format = I18n.t("rails_admin.admin.misc.filter_date_format", :default => I18n.t("rails_admin.admin.misc.filter_date_format", :locale => :en)).gsub('dd', '%d').gsub('mm', '%m').gsub('yy', '%Y')
       case operator
       when 'between'
         start_date = value[1].present? ? (Date.strptime(value[1], date_format) rescue false) : false

--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -33,8 +33,8 @@ module RailsAdmin
                 @auditing_adapter && @auditing_adapter.delete_object("Destroyed #{@model_config.with(:object => object).object_label}", object, @abstract_model, _current_user)
               end
 
-              flash[:success] = t("admin.flash.successful", :name => pluralize(destroyed.count, @model_config.label), :action => t("admin.actions.delete.done")) unless destroyed.empty?
-              flash[:error] = t("admin.flash.error", :name => pluralize(not_destroyed.count, @model_config.label), :action => t("admin.actions.delete.done")) unless not_destroyed.empty?
+              flash[:success] = t("rails_admin.admin.flash.successful", :name => pluralize(destroyed.count, @model_config.label), :action => t("rails_admin.admin.actions.delete.done")) unless destroyed.empty?
+              flash[:error] = t("rails_admin.admin.flash.error", :name => pluralize(not_destroyed.count, @model_config.label), :action => t("rails_admin.admin.actions.delete.done")) unless not_destroyed.empty?
 
               redirect_to back_or_index
 

--- a/lib/rails_admin/config/actions/delete.rb
+++ b/lib/rails_admin/config/actions/delete.rb
@@ -33,9 +33,9 @@ module RailsAdmin
 
               @auditing_adapter && @auditing_adapter.delete_object("Destroyed #{@model_config.with(:object => @object).object_label}", @object, @abstract_model, _current_user)
               if @abstract_model.destroy(@object)
-                flash[:success] = t("admin.flash.successful", :name => @model_config.label, :action => t("admin.actions.delete.done"))
+                flash[:success] = t("rails_admin.admin.flash.successful", :name => @model_config.label, :action => t("rails_admin.admin.actions.delete.done"))
               else
-                flash[:error] = t("admin.flash.error", :name => @model_config.label, :action => t("admin.actions.delete.done"))
+                flash[:error] = t("rails_admin.admin.flash.error", :name => @model_config.label, :action => t("rails_admin.admin.actions.delete.done"))
               end
 
               redirect_to back_or_index

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -11,7 +11,7 @@ module RailsAdmin
         include RailsAdmin::Config::Configurable
         include RailsAdmin::Config::Hideable
         include RailsAdmin::Config::Groupable
-        
+
         attr_reader :name, :properties, :abstract_model
         attr_accessor :defined, :order, :section
         attr_reader :parent, :root
@@ -120,7 +120,7 @@ module RailsAdmin
 
         # Accessor for field's help text displayed below input field.
         register_instance_option :help do
-          (@help ||= {})[::I18n.locale] ||= (required? ? I18n.translate("admin.form.required") : I18n.translate("admin.form.optional")) + '. '
+          (@help ||= {})[::I18n.locale] ||= (required? ? I18n.translate("rails_admin.admin.form.required") : I18n.translate("rails_admin.admin.form.optional")) + '. '
         end
 
         register_instance_option :html_attributes do

--- a/lib/rails_admin/config/fields/types/string.rb
+++ b/lib/rails_admin/config/fields/types/string.rb
@@ -16,16 +16,16 @@ module RailsAdmin
            end
 
           register_instance_option(:help) do
-            text = (required? ? I18n.translate("admin.form.required") : I18n.translate("admin.form.optional")) + '. '
+            text = (required? ? I18n.translate("rails_admin.admin.form.required") : I18n.translate("rails_admin.admin.form.optional")) + '. '
             if valid_length.present? && valid_length[:is].present?
-              text += "#{I18n.translate("admin.form.char_length_of").capitalize} #{valid_length[:is]}."
+              text += "#{I18n.translate("rails_admin.admin.form.char_length_of").capitalize} #{valid_length[:is]}."
             else
               max_length = [length, valid_length[:maximum] || nil].compact.min
               min_length = [0, valid_length[:minimum] || nil].compact.max
               if min_length == 0
-                text += "#{I18n.translate("admin.form.char_length_up_to").capitalize} #{max_length}."
+                text += "#{I18n.translate("rails_admin.admin.form.char_length_up_to").capitalize} #{max_length}."
               else
-                text += "#{I18n.translate("admin.form.char_length_of").capitalize} #{min_length}-#{max_length}."
+                text += "#{I18n.translate("rails_admin.admin.form.char_length_of").capitalize} #{min_length}-#{max_length}."
               end
             end
             text

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -36,7 +36,7 @@ module RailsAdmin
             RailsAdmin::AbstractModel.new(entity.class)
           end
         end
-        @groups = [ RailsAdmin::Config::Fields::Group.new(self, :default).tap {|g| g.label{I18n.translate("admin.form.basic_info")} } ]
+        @groups = [ RailsAdmin::Config::Fields::Group.new(self, :default).tap {|g| g.label{I18n.translate("rails_admin.admin.form.basic_info")} } ]
       end
 
       def excluded?

--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -16,7 +16,7 @@ module RailsAdmin
       @model_config = @abstract_model.config
       @methods = [(schema[:only] || []) + (schema[:methods] || [])].flatten.compact
       @fields = @model_config.export.fields.select{|f| @methods.include? f.name }
-      @empty = ::I18n.t('admin.export.empty_value_for_associated_objects')
+      @empty = ::I18n.t('rails_admin.admin.export.empty_value_for_associated_objects')
       @associations = {}
 
       (schema.delete(:include) || {}).each do |key, values|
@@ -61,11 +61,11 @@ module RailsAdmin
       csv_string = CSVClass.generate(options[:generator] ? options[:generator].symbolize_keys.delete_if {|key, value| value.blank? } : {}) do |csv|
         unless options[:skip_header]
           csv << @fields.map do |field|
-            output(::I18n.t('admin.export.csv.header_for_root_methods', :name => field.label, :model => @abstract_model.pretty_name))
+            output(::I18n.t('rails_admin.admin.export.csv.header_for_root_methods', :name => field.label, :model => @abstract_model.pretty_name))
           end +
           @associations.map do |association_name, option_hash|
             option_hash[:fields].map do |field|
-              output(::I18n.t('admin.export.csv.header_for_association_methods', :name => field.label, :association => option_hash[:association].label))
+              output(::I18n.t('rails_admin.admin.export.csv.header_for_association_methods', :name => field.label, :association => option_hash[:association].label))
             end
           end.flatten
         end

--- a/spec/unit/abstract_model_spec.rb
+++ b/spec/unit/abstract_model_spec.rb
@@ -8,7 +8,7 @@ describe RailsAdmin::AbstractModel do
 
     context 'on dates' do
       it 'lists elements within outbound limits' do
-        date_format = I18n.t("admin.misc.filter_date_format", :default => I18n.t("admin.misc.filter_date_format", :locale => :en)).gsub('dd', '%d').gsub('mm', '%m').gsub('yy', '%Y')
+        date_format = I18n.t("rails_admin.admin.misc.filter_date_format", :default => I18n.t("rails_admin.admin.misc.filter_date_format", :locale => :en)).gsub('dd', '%d').gsub('mm', '%m').gsub('yy', '%Y')
 
         FactoryGirl.create(:field_test, :date_field => Date.strptime("01/01/2012", date_format))
         FactoryGirl.create(:field_test, :date_field => Date.strptime("01/02/2012", date_format))


### PR DESCRIPTION
Currently there was a problem with overwriting locales keys, such as "home" and "views".
When you defined a translation in your app: "home.my_awsome_homepage", rails_admin translations were broken.
