### PR TITLE
Add JSON format support in the show action.

### DIFF
--- a/lib/rails_admin/config/actions/show.rb
+++ b/lib/rails_admin/config/actions/show.rb
@@ -18,10 +18,12 @@ module RailsAdmin
 
         register_instance_option :controller do
           Proc.new do
-            render @action.template_name
+            respond_to do |format|
+              format.json { render :json => @object }
+              format.html { render @action.template_name }
+            end
           end
         end
-
 
         register_instance_option :link_icon do
           'icon-info-sign'

--- a/spec/integration/config/show/rails_admin_config_show_spec.rb
+++ b/spec/integration/config/show/rails_admin_config_show_spec.rb
@@ -13,6 +13,24 @@ describe "RailsAdmin Config DSL Show Section" do
     visit show_path(:model_name => "team", :id => team.id)
   end
 
+  describe "JSON show view" do
+    before do
+      @player = FactoryGirl.create :player
+       visit uri
+    end
+
+    let(:uri) { show_path(:model_name => 'player', :id => @player.id, :format => :json) }
+    let(:body) { page.body }
+
+    it 'should create a JSON uri' do
+      uri.should == "/admin/player/#{@player.id}.json"
+    end
+
+    it 'should contain the JSONified object' do
+      body.should include(@player.to_json)
+    end
+  end
+
   describe "compact_show_view" do
 
     it 'should hide empty fields in show view by default' do


### PR DESCRIPTION
I have a client using rails_admin as an admin API, one of his requirements is the ability to show objects in JSON format.  This patch enables this, and tests that the output is correct.
