### PR TITLE
Fix empty models on Heroku.

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -5,7 +5,7 @@ module RailsAdmin
   module Adapters
     module ActiveRecord
       DISABLED_COLUMN_TYPES = [:tsvector, :blob, :binary, :spatial, :hstore]
-      AR_ADAPTER = ::ActiveRecord::Base.configurations[Rails.env]['adapter']
+      AR_ADAPTER = Rails.configuration.database_configuration[Rails.env]['adapter']
       LIKE_OPERATOR = AR_ADAPTER == "postgresql" ? 'ILIKE' : 'LIKE'
 
       def new(params = {})


### PR DESCRIPTION
When deploying RailsAdmin on Heroku no models are shown/detected.

`RailsAdmin::Config.visible_models` returns an empty array, that is because `ActiveRecord::Base.configurations` returns an empty Hash instead of the database configuration.

You can fix this calling `Rails.configuration.database_configuration` to retrieve the adapter settings like it is done for the encoding in [lib/rails_admin/adapters/active_record.rb](https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/adapters/active_record.rb#L98).
