### PR TITLE
RailsAdmin::AbstractModel.new fails on Heroku

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -5,8 +5,14 @@ module RailsAdmin
   module Adapters
     module ActiveRecord
       DISABLED_COLUMN_TYPES = [:tsvector, :blob, :binary, :spatial, :hstore]
-      AR_ADAPTER = Rails.configuration.database_configuration[Rails.env]['adapter']
-      LIKE_OPERATOR = AR_ADAPTER == "postgresql" ? 'ILIKE' : 'LIKE'
+
+      def ar_adapter
+        Rails.configuration.database_configuration[Rails.env]['adapter']
+      end
+
+      def like_operator
+        ar_adapter == "postgresql" ? 'ILIKE' : 'LIKE'
+      end
 
       def new(params = {})
         AbstractObject.new(model.new(params))
@@ -184,7 +190,7 @@ module RailsAdmin
           else
             return
           end
-          ["(#{column} #{LIKE_OPERATOR} ?)", value]
+          ["(#{column} #{like_operator} ?)", value]
         when :date
           start_date, end_date = get_filtering_duration(operator, value)
 


### PR DESCRIPTION
In prod on my local and on Heroku:

``` ruby
RailsAdmin::Config.models_pool #=> ["Agency"]
```

In prod on Heroku:

``` ruby
RailsAdmin::AbstractModel.new("Agency") #=> nil
```

In prod on my local:

``` ruby
RailsAdmin::AbstractModel.new("Agency") #=>  <RailsAdmin::AbstractModel:0x007fe2fcb40690 @model_name="Agency", @adapter=:active_record>
```

Strange huh!

My guess is it has something to do with https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/adapters/active_record.rb#L8

In local and Heroku:

``` ruby
Rails.configuration.database_configuration[Rails.env]['adapter'] #=> "postgresql"
```

On Heroku:

``` ruby
RailsAdmin::AbstractModel.old_new(Agency)
```

```
/app/vendor/bundle/ruby/1.9.1/gems/rails_admin-0.0.3/lib/rails_admin/adapters/active_record.rb:7: warning: already initialized constant DISABLED_COLUMN_TYPES
NoMethodError: undefined method `[]' for nil:NilClass
    from /app/vendor/bundle/ruby/1.9.1/gems/rails_admin-0.0.3/lib/rails_admin/adapters/active_record.rb:8:in `<module:ActiveRecord>'
    from /app/vendor/bundle/ruby/1.9.1/gems/rails_admin-0.0.3/lib/rails_admin/adapters/active_record.rb:6:in `<module:Adapters>'
    from /app/vendor/bundle/ruby/1.9.1/gems/rails_admin-0.0.3/lib/rails_admin/adapters/active_record.rb:5:in `<module:RailsAdmin>'
    from /app/vendor/bundle/ruby/1.9.1/gems/rails_admin-0.0.3/lib/rails_admin/adapters/active_record.rb:4:in `<top (required)>'
    from /app/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.5/lib/active_support/dependencies.rb:251:in `require'
    from /app/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.5/lib/active_support/dependencies.rb:251:in `block in require'
    from /app/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.5/lib/active_support/dependencies.rb:236:in `load_dependency'
    from /app/vendor/bundle/ruby/1.9.1/gems/activesupport-3.2.5/lib/active_support/dependencies.rb:251:in `require'
    from /app/vendor/bundle/ruby/1.9.1/gems/rails_admin-0.0.3/lib/rails_admin/abstract_model.rb:48:in `initialize'
    from (irb):8:in `new'
    from (irb):8
    from /app/vendor/bundle/ruby/1.9.1/gems/railties-3.2.5/lib/rails/commands/console.rb:47:in `start'
    from /app/vendor/bundle/ruby/1.9.1/gems/railties-3.2.5/lib/rails/commands/console.rb:8:in `start'
    from /app/vendor/bundle/ruby/1.9.1/gems/railties-3.2.5/lib/rails/commands.rb:41:in `<top (required)>'
    from script/rails:6:in `require'
    from script/rails:6:in `<main>'
```
