### PR TITLE
moved pagination and home translation keys to admin namespace

### DIFF
--- a/app/views/kaminari/twitter-bootstrap/_gap.html.haml
+++ b/app/views/kaminari/twitter-bootstrap/_gap.html.haml
@@ -1,2 +1,2 @@
 %li.disabled
-  %a{:href => '#'}= raw(t 'views.pagination.truncate')
+  %a{:href => '#'}= raw(t 'admin.pagination.truncate')

--- a/app/views/kaminari/twitter-bootstrap/_next_page.html.haml
+++ b/app/views/kaminari/twitter-bootstrap/_next_page.html.haml
@@ -1,4 +1,4 @@
 - if current_page.last?
-  %li.next.disabled= link_to raw(t 'views.pagination.next'), '#'
+  %li.next.disabled= link_to raw(t 'admin.pagination.next'), '#'
 - else
-  %li.next= link_to raw(t 'views.pagination.next'), url, :class => (remote ? 'pjax' : '')
+  %li.next= link_to raw(t 'admin.pagination.next'), url, :class => (remote ? 'pjax' : '')

--- a/app/views/kaminari/twitter-bootstrap/_prev_page.html.haml
+++ b/app/views/kaminari/twitter-bootstrap/_prev_page.html.haml
@@ -1,4 +1,4 @@
 - if current_page.first?
-  %li.prev.disabled= link_to raw(t 'views.pagination.previous'), '#'
+  %li.prev.disabled= link_to raw(t 'admin.pagination.previous'), '#'
 - else
-  %li.prev= link_to raw(t 'views.pagination.previous'), url, :class => (remote ? 'pjax' : '')
+  %li.prev= link_to raw(t 'admin.pagination.previous'), url, :class => (remote ? 'pjax' : '')

--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -2,7 +2,7 @@
   - actions(:root).each do |action|
     %li= link_to wording_for(:menu, action), { :action => action.action_name, :controller => 'rails_admin/main' }, :class => 'pjax'
   - if main_app_root_path = (main_app.root_path rescue false)
-    %li= link_to t('home.name').capitalize, main_app_root_path
+    %li= link_to t('admin.home.name').capitalize, main_app_root_path
   - if _current_user
     - if user_link = edit_user_link
       %li= user_link

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -1,12 +1,11 @@
 en:
-  home:
-    name: Home
-  views:
+  admin:
+    home:
+      name: "Home"
     pagination:
       previous: "&laquo; Prev"
       next: "Next &raquo;"
       truncate: "…"
-  admin:
     misc:
       filter_date_format: "mm/dd/yy" # a combination of 'dd', 'mm' and 'yy' with any delimiter. No other interpolation will be done!
       search: "Search"


### PR DESCRIPTION
As discussed in https://github.com/sferik/rails_admin/pull/1176 I'm moving "home.name" to admin namespace and changing "views.pagination" to "admin.pagination".

After merging, I'll ping translation gists owners placed on https://github.com/sferik/rails_admin/wiki/Translations to update their sources.
