### PR TITLE
Main navigation helper should not draw empty navigation labels when there is namespaced models

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -46,8 +46,7 @@ module RailsAdmin
       nodes_stack = RailsAdmin::Config.visible_models(:controller => self.controller)      
       nodes_stack.group_by(&:navigation_label).map do |navigation_label, nodes|
 
-        %{<li class='nav-header'>#{navigation_label || t('admin.misc.navigation')}</li>}.html_safe +
-        nodes.select{|n| n.parent.nil? || !n.parent.to_s.in?(nodes_stack.map{|c| c.abstract_model.model_name }) }.map do |node|
+        li_stack = nodes.select{|n| n.parent.nil? || !n.parent.to_s.in?(nodes_stack.map{|c| c.abstract_model.model_name }) }.map do |node|
           %{
             <li data-model="#{node.abstract_model.to_param}">
               <a class="pjax" href="#{url_for(:action => :index, :controller => 'rails_admin/main', :model_name => node.abstract_model.to_param)}">#{node.label_plural}</a>
@@ -55,6 +54,12 @@ module RailsAdmin
             #{navigation(nodes_stack, nodes_stack.select{|n| n.parent.to_s == node.abstract_model.model_name}, 1)}
           }.html_safe
         end.join.html_safe
+
+        if li_stack.present?
+          li_stack = %{<li class='nav-header'>#{navigation_label || t('admin.misc.navigation')}</li>}.html_safe + li_stack
+        end
+
+        li_stack
       end.join.html_safe
     end
 

--- a/spec/dummy_app/app/active_record/comment/confirmed.rb
+++ b/spec/dummy_app/app/active_record/comment/confirmed.rb
@@ -1,0 +1,3 @@
+class Comment::Confirmed < Comment
+  default_scope where(:content => 'something')
+end

--- a/spec/dummy_app/app/mongoid/comment/confirmed.rb
+++ b/spec/dummy_app/app/mongoid/comment/confirmed.rb
@@ -1,0 +1,3 @@
+class Comment::Confirmed < Comment
+  default_scope where(:content => 'something')
+end

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -187,6 +187,20 @@ describe RailsAdmin::ApplicationHelper do
       helper.main_navigation.should match /(nav\-header).*(Navigation).*(Balls).*(Comments)/m
     end
 
+    it 'should not draw empty navigation labels' do
+      RailsAdmin.config do |config|
+        config.included_models = [Ball, Comment, Comment::Confirmed]
+        config.model Comment do
+          navigation_label 'Commentz'
+        end
+        config.model Comment::Confirmed do
+          label_plural 'Confirmed'
+        end
+      end
+      helper.main_navigation.should match /(nav\-header).*(Navigation).*(Balls).*(Commentz).*(Confirmed)/m
+      helper.main_navigation.should_not match /(nav\-header).*(Navigation).*(Balls).*(Commentz).*(Confirmed).*(Comment)/m
+    end
+
     it 'should not show unvisible models' do
       RailsAdmin.config do |config|
         config.included_models = [Ball, Comment]


### PR DESCRIPTION
In my project I need to add navigation labels for different scopes of one table. But I didn't find option which will do it for me. So I decided to use namespaced models with default scopes for right navigation labels. But when I set `navigation_label` for parent model, previous label not disappeared.

I made one spec to show my point - it will not work without changes in main navigation helper.

P.s. thank you for rails admin - it's really great! I definitely will use it again.
