### PR TITLE
Fix to # polymorphic-association ajax request.

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -120,7 +120,7 @@ $(document).live 'rails_admin.dom_ready', ->
               xhr.setRequestHeader("Accept", "application/json")
             success: (data, status, xhr) ->
               html = '<option></option>'
-              $(data).each (i, el) ->
+              $(data.main).each (i, el) ->
                 html += '<option value="' + el.id + '">' + el.label + '</option>'
               object_select.html(html)
 


### PR DESCRIPTION
Relating to the following issue
https://github.com/sferik/rails_admin/issues/1228

Which boils down to polymorphic-association not updating via ajax correctly.

The polymorphic-association junk of code in ra.widgets.coffee was calling on line 123

``` coffee
$(data).each (i, el) ->
```

on the returned ajax object, ie data. Only issue was that the data was not the array. Rather the array was at data.main. So the issue was fixed for me when i changed the above to

``` coffee
$(data.main).each (i, el) ->
```

which seems to solve the issue.

I hope this helps, and let me know if I didn't explain something properly.
