### PR TITLE
Searching columns of type Decimal does not work with active_record

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -173,6 +173,9 @@ module RailsAdmin
         when :boolean
           return ["(#{column} IS NULL OR #{column} = ?)", false] if ['false', 'f', '0'].include?(value)
           return ["(#{column} = ?)", true] if ['true', 't', '1'].include?(value)
+        when :decimal
+          return if value.blank?
+          ["(#{column} = ?)", value.to_f] if value.to_f.to_s == value
         when :integer, :belongs_to_association
           return if value.blank?
           ["(#{column} = ?)", value.to_i] if value.to_i.to_s == value

--- a/spec/unit/adapters/active_record_spec.rb
+++ b/spec/unit/adapters/active_record_spec.rb
@@ -323,6 +323,11 @@ describe 'RailsAdmin::Adapters::ActiveRecord', :active_record => true do
       @abstract_model.send(:build_statement, :field, :integer, 'word', nil).should be_nil
     end
 
+    it "supports decimal type query" do
+      @abstract_model.send(:build_statement, :field, :decimal, "1.1", nil).should == ["(field = ?)", 1.1]
+      @abstract_model.send(:build_statement, :field, :decimal, 'word', nil).should be_nil
+    end
+
     it "supports string type query" do
       @abstract_model.send(:build_statement, :field, :string, "", nil).should be_nil
       @abstract_model.send(:build_statement, :field, :string, "foo", "was").should be_nil


### PR DESCRIPTION
The [active record build statement](https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/adapters/active_record.rb#L152) doesn't have a condition for columns that are of type `module RailsAdmin::Config::Fields::Types::Decimal` (float database columns)

Was this deliberately ommitted or can `:decimal` be added to [this line](https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/adapters/active_record.rb#L176)?
