### PR TITLE
Added in tinymce support

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -134,16 +134,45 @@ $(document).live 'rails_admin.dom_ready', ->
         window.CKEDITOR.replace(this, options['options'])
         $(this).addClass('ckeditored')
 
-    array = $('form [data-richtext=ckeditor]').not('.ckeditored')
-    if array.length
-      @array = array
+    arrayck = $('form [data-richtext=ckeditor]').not('.ckeditored')
+    if arrayck.length
+      @arrayck = arrayck
       if not window.CKEDITOR
-        options = $(array[0]).data('options')
+        options = $(arrayck[0]).data('options')
         window.CKEDITOR_BASEPATH = options['base_location']
         $.getScript options['jspath'], (script, textStatus, jqXHR) =>
-          goCkeditors(@array)
+          goCkeditors(@arrayck)
       else
-        goCkeditors(@array)
+        goCkeditors(@arrayck)
+
+    #tinymce
+
+    gotinyMCE = (array) =>
+      array.each (index, domEle) ->
+        options = $(this).data('options')
+        tinyMCE.init(jQuery.extend({
+          mode : "exact",
+          elements : $(this).attr("id")
+        }, options))
+        $(this).addClass('tinymced')
+
+
+    arraytmc = $('form [data-richtext=tinymce]').not('.tinymced')
+    if arraytmc.length
+      @arraytmc = arraytmc
+      if not window.tinyMCE
+        options = $(arraytmc[0]).data('options')
+        window.tinyMCEPreInit = {
+          base: options['base'],
+          theme: options['theme'],
+          suffix: '',
+          mode: "specific_textareas"
+        }
+        $.getScript options['jspath'], (script, textStatus, jqXHR) =>
+          $.getScript options['jqpath'], (script, textStatus, jqXHR) =>
+            gotinyMCE(@arraytmc)
+      else
+        gotinyMCE(@arraytmc)
 
     #codemirror
 
@@ -156,14 +185,14 @@ $(document).live 'rails_admin.dom_ready', ->
           CodeMirror.fromTextArea(textarea,{mode:options['options']['mode'],theme:options['options']['theme']})
           $(textarea).addClass('codemirrored')
 
-    array = $('form [data-richtext=codemirror]').not('.codemirrored')      
-    if array.length
-      @array = array
+    arraycm = $('form [data-richtext=codemirror]').not('.codemirrored')      
+    if arraycm.length
+      @arraycm = arraycm
       if not window.CodeMirror
-        options = $(array[0]).data('options')
+        options = $(arraycm[0]).data('options')
         $('head').append('<link href="' + options['csspath'] + '" rel="stylesheet" media="all" type="text\/css">')
         $.getScript options['jspath'], (script, textStatus, jqXHR) =>
-          goCodeMirrors(@array)
+          goCodeMirrors(@arraycm)
       else
-        goCodeMirrors(@array)
+        goCodeMirrors(@arraycm)
 

--- a/app/views/rails_admin/main/_form_text.html.haml
+++ b/app/views/rails_admin/main/_form_text.html.haml
@@ -16,6 +16,15 @@
       :options => field.codemirror_config,
       :locations => field.codemirror_assets
     }
+  elsif field.tinymce
+    richtext = 'tinymce'
+    js_data = {
+      :jspath => field.tinymce_js_location,
+      :jqpath => field.tinymce_jquery_location,
+      :theme => field.tinymce_theme_options,
+      :base => field.tinymce_base_location,
+      :options => field.tinymce_options
+    }
   else
     richtext = false
     js_data = {}

--- a/lib/rails_admin/config/fields/types/text.rb
+++ b/lib/rails_admin/config/fields/types/text.rb
@@ -67,6 +67,31 @@ module RailsAdmin
             }
           end
 
+          # TinyMCE is disabled by default
+          register_instance_option(:tinymce) do
+            false
+          end
+
+          register_instance_option(:tinymce_js_location) do
+            "/assets/tinymce/tiny_mce_jquery_src.js"
+          end
+
+          register_instance_option(:tinymce_jquery_location) do
+            "/assets/tinymce/jquery.tinymce.js"
+          end
+
+          register_instance_option(:tinymce_theme_options) do
+            "advanced"
+          end
+
+          register_instance_option(:tinymce_options) do
+            {}
+          end
+
+          register_instance_option(:tinymce_base_location) do
+            '/assets/tinymce'
+          end
+
           register_instance_option(:partial) do
             :form_text
           end


### PR DESCRIPTION
Added in TinyMCE support. Tested with the tinymce-rails gem.

The set up is very simliar to how code-mirror works.

The only major difference is the defaults have to be set like bellow.

``` coffee
window.tinyMCEPreInit = {
  base: options['base'],
  theme: options['theme'],
  suffix: '',
  mode: "specific_textareas"
}
```

Also because the jquery version is loaded, two different scripts must be loaded, with the second as a call back, and then the load events as yet another call back for the second script load.

``` coffee
$.getScript options['jspath'], (script, textStatus, jqXHR) =>
  $.getScript options['jqpath'], (script, textStatus, jqXHR) =>
    gotinyMCE(@arraytmc)
```

The options are as follows

``` ruby
register_instance_option(:tinymce) do
  false
end

register_instance_option(:tinymce_js_location) do
  "/assets/tinymce/tiny_mce_jquery_src.js"
end

register_instance_option(:tinymce_jquery_location) do
  "/assets/tinymce/jquery.tinymce.js"
end

register_instance_option(:tinymce_theme_options) do
  "advanced"
end

register_instance_option(:tinymce_options) do
  {}
end

register_instance_option(:tinymce_base_location) do
  '/assets/tinymce'
end
```

The theme option is really just the default theme option, and once again because the jquery version is being used two scripts must be loaded, so there are two options for script location.

From what I have been able to test everything seems to work fine, but about every 10th load or so TinyMCE will just refuse to load. I tried forcing a wait to make sure it wasn't an issue with TinyMCE getting called before all the corresponding files where loaded, even with the nested callbacks. But I wasn't able to find the root cause of the issue.

I hope this helps, and let me know if anything is explained poorly or you have any questions.

PS: I also changed the array variable name for each of the editor setups in the coffee script, just to make things clearer. 
