### PR TITLE
active_record_extensions.rb#safe_send inefficiently searches for an attribute

### DIFF
--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -9,7 +9,7 @@ if defined?(::ActiveRecord)
     end
 
     def safe_send(value)
-      if self.attributes.find{ |k,v| k.to_s == value.to_s }
+      if self.has_attribute?(value)
         self.read_attribute(value)
       else
         self.send(value)

--- a/spec/unit/active_record_extension_spec.rb
+++ b/spec/unit/active_record_extension_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+require File.expand_path('../../../config/initializers/active_record_extensions', __FILE__)
+
+describe 'ActiveRecord::Base', :active_record => true do
+  describe '#safe_send' do
+    it "only calls #read_attribute once" do
+      @player = Player.new
+      @player.number = 23
+      original_method = @player.method(:read_attribute)
+      @player.should_receive(:read_attribute).exactly(1).times do |*args|
+        original_method.call(*args)
+      end
+      @player.safe_send(:number).should == 23
+    end
+  end
+end


### PR DESCRIPTION
Currently [active_record_extensions#L20](https://github.com/sferik/rails_admin/blob/master/config/initializers/active_record_extensions.rb#L12) uses `self.attributes.find{ |k,v| k.to_s == value.to_s }` to check the existence of an attribute, but this ends up unnecessarily calling the costly `ActiveRecord AttributeMethods ClassMethods#generated_external_attribute_methods` method.

It would be more efficient to look up the existence of an attribute at [L20](https://github.com/sferik/rails_admin/blob/master/config/initializers/active_record_extensions.rb#L12) with `self.has_attribute?(value)`
