### PR TITLE
Change paper_trail audit extension to use ::Version. Fixes #1234

### DIFF
--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -44,7 +44,7 @@ module RailsAdmin
         end
 
         def latest
-          Version.limit(100).map{|version| VersionProxy.new(version, @user_class)}
+          ::Version.limit(100).map{|version| VersionProxy.new(version, @user_class)}
         end
 
         def delete_object(message, object, model, user)
@@ -66,7 +66,7 @@ module RailsAdmin
             sort = :created_at
             sort_reverse = "true"
           end
-          versions = Version.where :item_type => model.model.name
+          versions = ::Version.where :item_type => model.model.name
           versions = versions.where("event LIKE ?", "%#{query}%") if query.present?
           versions = versions.order(sort_reverse == "true" ? "#{sort} DESC" : sort)
           versions = all ? versions : versions.send(Kaminari.config.page_method_name, page.presence || "1").per(per_page)
@@ -80,7 +80,7 @@ module RailsAdmin
             sort = :created_at
             sort_reverse = "true"
           end
-          versions = Version.where :item_type => model.model.name, :item_id => object.id
+          versions = ::Version.where :item_type => model.model.name, :item_id => object.id
           versions = versions.where("event LIKE ?", "%#{query}%") if query.present?
           versions = versions.order(sort_reverse == "true" ? "#{sort} DESC" : sort)
           versions = all ? versions : versions.send(Kaminari.config.page_method_name, page.presence || "1").per(per_page)


### PR DESCRIPTION
This patch should fix the immediate issue of paper_trail not working within rails_admin anymore.
