### PR TITLE
Utf-8 problem with asset precompile

### DIFF
--- a/app/assets/stylesheets/rails_admin/imports.css.scss.erb
+++ b/app/assets/stylesheets/rails_admin/imports.css.scss.erb
@@ -1,3 +1,5 @@
+@charset "UTF-8";
+
 <%
   theme = ENV['RAILS_ADMIN_THEME'] || :default
 %>

--- a/app/assets/stylesheets/rails_admin/rails_admin.css
+++ b/app/assets/stylesheets/rails_admin/rails_admin.css
@@ -1,4 +1,3 @@
-@charset "UTF-8";
 /*
  *= require rails_admin/imports.css.scss
 */


### PR DESCRIPTION
Hi,
i've solved a problem in precompiling rails_admin's css in my rails 3.2.6 app. Some utf-8 chars broke my assets precompile. Simply, including @charset "UTF-8"; in imports.css.scss.erb solved the problem.
