### PR TITLE
show nested model associations

### DIFF
--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -43,7 +43,7 @@ module RailsAdmin
     def field_wrapper_for field, nested_in
       if field.label
         # do not show nested field if the target is the origin
-        unless field.inverse_of.presence && field.inverse_of == nested_in
+        unless field.inverse_of.presence && field.inverse_of == nested_in && @template.instance_variable_get(:@model_config).label == field.label
           @template.content_tag(:div, :class => "control-group #{field.type_css_class} #{field.css_class} #{'error' if field.errors.present?}", :id => "#{dom_id(field)}_field") do
             label(field.method_name, field.label, :class => 'control-label') +
             (field.nested_form ? field_for(field) : input_for(field))


### PR DESCRIPTION
if you have say:

``` ruby
class Company
  has_many :addresses, :inverse_of => :company
end

class Country
  belongs_to :address, :inverse_of => :country
end

class Address
  belongs_to :company, :inverse_of => :addresses
  belongs_to :country, :inverse_of => :addresses
end
```

In RA the nested form for addresses in /admin/company/new will not show select fields for either company_id or country_id, even though country_id should still be present. I believe this change fixes the filtering, which was seemingly before skipping all associations in nested models? I'm not actually sure the 'field.inverse_of.presence && field.inverse_of == nested_in' is correct/needed?
