### PR TITLE
added bootstrap_wysihtml5 text editor

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -159,7 +159,7 @@ $(document).live 'rails_admin.dom_ready', ->
           CodeMirror.fromTextArea(textarea,{mode:options['options']['mode'],theme:options['options']['theme']})
           $(textarea).addClass('codemirrored')
 
-    array = $('form [data-richtext=codemirror]').not('.codemirrored')      
+    array = $('form [data-richtext=codemirror]').not('.codemirrored')
     if array.length
       @array = array
       if not window.CodeMirror
@@ -170,3 +170,21 @@ $(document).live 'rails_admin.dom_ready', ->
       else
         goCodeMirrors(@array)
 
+    # bootstrap_wysihtml5
+
+    goBootstrapWysihtml5s = (array) =>
+      array.each ->
+        $(@).addClass('bootstrap-wysihtml5ed')
+        $(@).closest('.controls').addClass('well')
+        $(@).wysihtml5()
+
+    array = $('form [data-richtext=bootstrap-wysihtml5]').not('.bootstrap-wysihtml5ed')
+    if array.length
+      @array = array
+      if not window.wysihtml5
+        options = $(array[0]).data('options')
+        $('head').append('<link href="' + options['csspath'] + '" rel="stylesheet" media="all" type="text\/css">')
+        $.getScript options['jspath'], (script, textStatus, jqXHR) =>
+          goBootstrapWysihtml5s(@array)
+      else
+        goBootstrapWysihtml5s(@array)

--- a/app/assets/stylesheets/rails_admin/imports.css.scss.erb
+++ b/app/assets/stylesheets/rails_admin/imports.css.scss.erb
@@ -27,6 +27,7 @@
 @import "rails_admin/jquery.ui.timepicker";
 @import "rails_admin/ra.calendar-additions";
 @import "rails_admin/ra.filtering-multiselect";
+@import "rails_admin/ra.widgets";
 @import "rails_admin/jquery.colorpicker";
 
 

--- a/app/assets/stylesheets/rails_admin/ra.widgets.css.scss
+++ b/app/assets/stylesheets/rails_admin/ra.widgets.css.scss
@@ -1,0 +1,4 @@
+iframe.wysihtml5-sandbox{
+  height: 250px !important;
+  width: 75% !important;
+}

--- a/app/views/rails_admin/main/_form_text.html.haml
+++ b/app/views/rails_admin/main/_form_text.html.haml
@@ -4,7 +4,7 @@
     js_data = {
       :jspath => field.ckeditor_location ? field.ckeditor_location : field.ckeditor_base_location + "ckeditor.js",
       :base_location => field.ckeditor_base_location,
-      :options => { 
+      :options => {
         :customConfig => field.ckeditor_config_js ? field.ckeditor_config_js : field.ckeditor_base_location + "config.js"
       }
     }
@@ -15,6 +15,12 @@
       :jspath => field.codemirror_js_location,
       :options => field.codemirror_config,
       :locations => field.codemirror_assets
+    }
+  elsif field.bootstrap_wysihtml5
+    richtext = 'bootstrap-wysihtml5'
+    js_data = {
+      :csspath => field.bootstrap_wysihtml5_css_location,
+      :jspath => field.bootstrap_wysihtml5_js_location
     }
   else
     richtext = false

--- a/lib/rails_admin/config/fields/types/text.rb
+++ b/lib/rails_admin/config/fields/types/text.rb
@@ -7,7 +7,7 @@ module RailsAdmin
         class Text < RailsAdmin::Config::Fields::Base
           # Register field type for the type loader
           RailsAdmin::Config::Fields::Types::register(self)
-          
+
           # CKEditor is disabled by default
           register_instance_option(:ckeditor) do
             false
@@ -45,7 +45,7 @@ module RailsAdmin
           #Pass the location of the theme and mode for Codemirror
           register_instance_option(:codemirror_assets) do
             {
-              :mode => '/assets/codemirror/modes/css.js',  
+              :mode => '/assets/codemirror/modes/css.js',
               :theme => '/assets/codemirror/themes/night.css'
             }
           end
@@ -60,6 +60,19 @@ module RailsAdmin
             '/assets/codemirror.css'
           end
 
+          # bootstrap_wysihtml5
+          register_instance_option(:bootstrap_wysihtml5) do
+            false
+          end
+
+          register_instance_option(:bootstrap_wysihtml5_css_location) do
+            '/assets/bootstrap-wysihtml5.css'
+          end
+
+          register_instance_option(:bootstrap_wysihtml5_js_location) do
+            '/assets/bootstrap-wysihtml5-all.js'
+          end
+
           register_instance_option(:html_attributes) do
             {
               :cols => '48',
@@ -69,6 +82,10 @@ module RailsAdmin
 
           register_instance_option(:partial) do
             :form_text
+          end
+
+          register_instance_option :formatted_value do
+            value.to_s.html_safe
           end
         end
       end

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'bbenezech-nested_form', '~> 0.0.6'
   gem.add_dependency 'sass-rails', '~> 3.1'
   gem.add_dependency 'bootstrap-sass', ['~> 2.0', '>= 2.0.3']
+  gem.add_dependency 'bootstrap-wysihtml5-rails', '~> 0.3'
   gem.add_dependency 'jquery-ui-rails', ['>= 0.5', '< 2']
   gem.add_dependency 'builder', '~> 3.0'
   gem.add_dependency 'coffee-rails', '~> 3.1'

--- a/spec/integration/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/integration/config/edit/rails_admin_config_edit_spec.rb
@@ -962,6 +962,26 @@ describe "RailsAdmin Config DSL Edit Section" do
     end
   end
 
+  describe "bootstrap_wysihtml5 Support" do
+
+    it "should start with bootstrap_wysihtml5 disabled" do
+       field = RailsAdmin::config("Draft").edit.fields.find{|f| f.name == :notes}
+       field.bootstrap_wysihtml5.should be false
+    end
+
+    it "should add Javascript to enable bootstrap_wysihtml5" do
+      RailsAdmin.config Draft do
+        edit do
+          field :notes do
+            bootstrap_wysihtml5 true
+          end
+        end
+      end
+      visit new_path(:model_name => "draft")
+      should have_selector('textarea#draft_notes[data-richtext="bootstrap-wysihtml5"]')
+    end
+  end
+
   describe "Paperclip Support" do
 
     it "should show a file upload field" do


### PR DESCRIPTION
Besides CKEditor usually being way too feature rich by default for the average WYSIWYG user, it always looked really outdated to me.  Since rails_admin is already using bootstrap, this textarea area seemed a perfect fit.

http://jhollingworth.github.com/bootstrap-wysihtml5/

I hope i was thorough!
