### PR TITLE
Hints for fields in index view

### DIFF
--- a/app/assets/javascripts/rails_admin/ui.js.coffee
+++ b/app/assets/javascripts/rails_admin/ui.js.coffee
@@ -62,3 +62,5 @@ $(document).live 'rails_admin.dom_ready', ->
 
   $('.form-horizontal legend').has('i.icon-chevron-right').each ->
     $(this).siblings('.control-group').hide()
+
+  $(".table").tooltip selector: "th[rel=tooltip]"

--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -113,7 +113,7 @@
             - if property.sortable
               - sort_location = index_path params.except('sort_reverse').except('page').merge(:sort => property.name).merge(selected && sort_reverse != "true" ? {:sort_reverse => "true"} : {})
               - sort_direction = selected ? (sort_reverse == 'true' ? "headerSortUp" : "headerSortDown") : nil
-            %th{:class => "#{property.sortable && "header pjax" || nil} #{property.sortable && sort_direction ? sort_direction : nil} #{property.css_class} #{property.type_css_class}", :'data-href' => (property.sortable && sort_location)}= property.label
+            %th{:class => "#{property.sortable && "header pjax" || nil} #{property.sortable && sort_direction ? sort_direction : nil} #{property.css_class} #{property.type_css_class}", :'data-href' => (property.sortable && sort_location), :rel => "tooltip", :title => "#{property.hint}"}= property.label
           - if other_right
             %th.other.right.shrink= "..."
           %th.last.shrink

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -138,6 +138,10 @@ module RailsAdmin
           (@label ||= {})[::I18n.locale] ||= abstract_model.model.human_attribute_name name
         end
 
+        register_instance_option :hint do
+          (@hint ||= "")
+        end
+
         # Accessor for field's maximum length per database.
         #
         # @see RailsAdmin::AbstractModel.properties

--- a/spec/unit/config/fields/base_spec.rb
+++ b/spec/unit/config/fields/base_spec.rb
@@ -92,6 +92,21 @@ describe RailsAdmin::Config::Fields::Base do
     end
   end
 
+  describe "#hint" do
+    it "should be user customizable" do
+      RailsAdmin.config Team do
+        list do
+          field :division do
+            hint "Great Division"
+          end
+          field :name
+        end
+      end
+      RailsAdmin.config('Team').list.fields.find{|f| f.name == :division}.hint.should == "Great Division" # custom
+      RailsAdmin.config('Team').list.fields.find{|f| f.name == :name}.hint.should == "" # default
+    end
+  end
+
   describe "#css_class" do
     it "should have a default and be user customizable" do
       RailsAdmin.config Team do


### PR DESCRIPTION
Implement hints (such as custom labels) for fields in index view. I think, also it close #737
