### PR TITLE
Added pjax? option to Actions::Base

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -114,7 +114,7 @@ module RailsAdmin
         wording = wording_for(:menu, action)
         %{
           <li title="#{wording if only_icon}" rel="#{'tooltip' if only_icon}" class="icon #{action.key}_#{parent}_link #{'active' if current_action?(action)}">
-            <a class="#{action.key == :show_in_app ? '' : 'pjax'}" href="#{url_for({ :action => action.action_name, :controller => 'rails_admin/main', :model_name => abstract_model.try(:to_param), :id => (object.try(:persisted?) && object.try(:id) || nil) })}">
+            <a class="#{action.pjax? ? 'pjax' : ''}" href="#{url_for({ :action => action.action_name, :controller => 'rails_admin/main', :model_name => abstract_model.try(:to_param), :id => (object.try(:persisted?) && object.try(:id) || nil) })}">
               <i class="#{action.link_icon}"></i>
               <span#{only_icon ? " style='display:none'" : ""}>#{wording}</span>
             </a>

--- a/lib/rails_admin/config/actions/base.rb
+++ b/lib/rails_admin/config/actions/base.rb
@@ -39,6 +39,11 @@ module RailsAdmin
           false
         end
 
+        # Render via pjax?
+        register_instance_option :pjax? do
+          true
+        end
+
         # This block is evaluated in the context of the controller when action is called
         # You can access:
         # - @objects if you're on a model scope

--- a/lib/rails_admin/config/actions/show_in_app.rb
+++ b/lib/rails_admin/config/actions/show_in_app.rb
@@ -21,6 +21,10 @@ module RailsAdmin
         register_instance_option :link_icon do
           'icon-eye-open'
         end
+
+        register_instance_option :pjax? do
+          false
+        end
       end
     end
   end


### PR DESCRIPTION
Some actions, like logging in as another user, should be rendered
in the app, not via pjax.  This change allows an action to indicate
how it should be rendered.
