### PR TITLE
Add i18n to filters options

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js.erb
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js.erb
@@ -1,3 +1,11 @@
+<%
+  # Translation helper method
+  # Escapes simple quotes to be inserted into strings
+  def t key, opts = nil
+    I18n.t("admin.filters.values.#{ key }", opts).gsub(/'/, "\\\\'")
+  end
+%>
+
 (function($) {
 
   var filters;
@@ -18,38 +26,38 @@
         case 'boolean':
           var control = '<select class="input-small" name="' + value_name + '">' +
             '<option value="_discard">...</option>' +
-            '<option value="true"' + (field_value == "true" ? 'selected="selected"' : '') + '>True</option>' +
-            '<option value="false"' + (field_value == "false" ? 'selected="selected"' : '') + '>False</option>' +
+            '<option value="true"' + (field_value == "true" ? 'selected="selected"' : '') + '><%= t(:is_true) %></option>' +
+            '<option value="false"' + (field_value == "false" ? 'selected="selected"' : '') + '><%= t(:is_false) %></option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">Is present</option>' +
-            '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank"  >Is blank</option>' +
+            '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present"><%= t(:present) %></option>' +
+            '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank"  ><%= t(:blank) %></option>' +
           '</select>';
           break;
         case 'date':
         case 'datetime':
         case 'timestamp':
           var control = '<select class="switch-additionnal-fieldsets input-small" name="' + operator_name + '">' +
-            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">Date ...</option>' +
-            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">Between ... and ...</option>' +
-            '<option ' + (field_operator == "today"   ? 'selected="selected"' : '') + ' value="today">Today</option>' +
-            '<option ' + (field_operator == "yesterday"   ? 'selected="selected"' : '') + ' value="yesterday">Yesterday</option>' +
-            '<option ' + (field_operator == "this_week"   ? 'selected="selected"' : '') + ' value="this_week">This week</option>' +
-            '<option ' + (field_operator == "last_week"   ? 'selected="selected"' : '') + ' value="last_week">Last week</option>' +
+            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default"><%= t(:date_default) %></option>' +
+            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between"><%= t(:between) %></option>' +
+            '<option ' + (field_operator == "today"   ? 'selected="selected"' : '') + ' value="today"><%= t(:today) %></option>' +
+            '<option ' + (field_operator == "yesterday"   ? 'selected="selected"' : '') + ' value="yesterday"><%= t(:yesterday) %></option>' +
+            '<option ' + (field_operator == "this_week"   ? 'selected="selected"' : '') + ' value="this_week"><%= t(:this_week) %></option>' +
+            '<option ' + (field_operator == "last_week"   ? 'selected="selected"' : '') + ' value="last_week"><%= t(:last_week) %></option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">Is present</option>' +
-            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >Is blank</option>' +
+            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null"><%= t(:present) %></option>' +
+            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" ><%= t(:blank) %></option>' +
           '</select>'
-          var additional_control = 
-          '<input class="date additional-fieldset default input-small" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' + 
-          '<input placeholder="-∞" class="date additional-fieldset between input-small" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[1] || '') + '" /> ' + 
+          var additional_control =
+          '<input class="date additional-fieldset default input-small" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' +
+          '<input placeholder="-∞" class="date additional-fieldset between input-small" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[1] || '') + '" /> ' +
           '<input placeholder="∞" class="date additional-fieldset between input-small" style="display:' + ((field_operator == "between") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[2] || '') + '" />';
           break;
         case 'enum':
           var multiple_values = ((field_value instanceof Array) ? true : false)
           var control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + value_name + '"') + ' data-name="' + value_name + '" class="select-single input-small">' +
               '<option value="_discard">...</option>' +
-              '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">Is present</option>' +
-              '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank">Is blank</option>' +
+              '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present"><%= t(:present) %></option>' +
+              '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank"><%= t(:blank) %></option>' +
               '<option disabled="disabled">---------</option>' +
               field_options +
             '</select>' +
@@ -62,13 +70,13 @@
         case 'text':
         case 'belongs_to_association':
           var control = '<select class="switch-additionnal-fieldsets input-small" value="' + field_operator + '" name="' + operator_name + '">' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "like"        ? 'selected="selected"' : '') + ' value="like">Contains</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "is"          ? 'selected="selected"' : '') + ' value="is">Is exactly</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">Starts with</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "ends_with"   ? 'selected="selected"' : '') + ' value="ends_with">Ends with</option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "like"        ? 'selected="selected"' : '') + ' value="like"><%= t(:contains) %></option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "is"          ? 'selected="selected"' : '') + ' value="is"><%= t(:is) %></option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with"><%= t(:starts_with) %></option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "ends_with"   ? 'selected="selected"' : '') + ' value="ends_with"><%= t(:ends_with) %></option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_present"    ? 'selected="selected"' : '') + ' value="_present">Is present</option>' +
-            '<option ' + (field_operator == "_blank"      ? 'selected="selected"' : '') + ' value="_blank">Is blank</option>' +
+            '<option ' + (field_operator == "_present"    ? 'selected="selected"' : '') + ' value="_present"><%= t(:present) %></option>' +
+            '<option ' + (field_operator == "_blank"      ? 'selected="selected"' : '') + ' value="_blank"><%= t(:blank) %></option>' +
           '</select>'
           var additional_control = '<input class="additional-fieldset input-small" style="display:' + (field_operator == "_blank" || field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + value_name + '" value="' + field_value + '" /> ';
           break;

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -128,3 +128,19 @@ en:
         default_col_sep: ","
         col_sep: "Column separator"
         col_sep_help: "Leave blank for default ('%{value}')" # value is default_col_sep
+    filters:
+      values:
+        is_true: "True"
+        is_false: "False"
+        present: "Is present"
+        blank: "Is blank"
+        date_default: "Date ..."
+        between: "Between ... and ..."
+        today: "Today"
+        yesterday: "Yesterday"
+        this_week: "This week"
+        last_week: "Last week"
+        contains: "Contains"
+        is: "Is exactly"
+        starts_with: "Starts with"
+        ends_with: "Ends with"


### PR DESCRIPTION
Hi,

I was missing the ability to cleanly translate the filter options in my application.
What I call filter options is the HTML options hardcoded in the ra.filter-box.js that are proposed depending on the field type that you're trying to filter.

This pull request is made so it can be criticized and solutions can be given because, while the hack works, it's quite ugly in some places.

The things to note that I'd like to discuss :
- I had to rename `ra.filter-box.js` to `ra.filter-box.js.erb` so I can dynamically insert the I18n names. I could have loaded them through Ajax, or even worst made a JS translation file, but I thought it was a cleaner way.
- I coded an erb inlined helper inside the `ra.filter-box.js.erb` because, as we don't have access to ActionView helpers in this file, I didn't want to make every call to the translate helper method too long so it keeps readable.
- Should I test this kind of code ? I suppose it can be done, but if it can be I'll be glad someone gives me a clue on how to proceed here.

The patch lets you translate those filter options directly in the locale file
