### PR TITLE
Backport 8e81211 to rails-3.0

### DIFF
--- a/lib/rails_admin/config/fields/types/date.rb
+++ b/lib/rails_admin/config/fields/types/date.rb
@@ -15,7 +15,7 @@ module RailsAdmin
           }
 
           def parse_input(params)
-            params[name] = self.class.normalize(params[name], localized_date_format) if params[name]
+            params[name] = self.class.normalize(params[name], localized_date_format).to_date if params[name]
           end
         end
       end

--- a/spec/requests/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/requests/config/edit/rails_admin_config_edit_spec.rb
@@ -534,6 +534,15 @@ describe "RailsAdmin Config DSL Edit Section" do
         @record.date_field.should eql(::Date.parse(@time.to_s))
       end
 
+      it "should cover a timezone lag even if in UTC+n:00 timezone." do
+        Time.zone = 'Tokyo' # +09:00
+
+        visit rails_admin_new_path(:model_name => "field_test")
+        fill_in "field_test[date_field]", :with => @time.strftime("%B %d, %Y")
+        click_button "Save"
+        @record = RailsAdmin::AbstractModel.new("FieldTest").first
+        @record.date_field.should eql(::Date.parse(@time.to_s))
+      end
 
       it "should have a simple customization option" do
         RailsAdmin.config FieldTest do


### PR DESCRIPTION
8e81211 fixes a bug in I18n date parsing, it would be nice to have it in the rails 3.0 branch for us stuck on older versions.
