### PR TITLE
Add PostGIS geometry type to DISABLED_COLUMN_TYPES

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -4,7 +4,7 @@ require 'rails_admin/adapters/active_record/abstract_object'
 module RailsAdmin
   module Adapters
     module ActiveRecord
-      DISABLED_COLUMN_TYPES = [:tsvector, :blob, :binary, :spatial, :hstore]
+      DISABLED_COLUMN_TYPES = [:tsvector, :blob, :binary, :spatial, :hstore, :geometry]
       DISABLED_COLUMN_MATCHERS = [/_array$/]
 
       def ar_adapter


### PR DESCRIPTION
Some databases with installed PostGIS extensions have columns with geometry type. Rails Admin should ignore this type.
