### PR TITLE
Changed show view to display simple_format instead of <pre>

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.css.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.css.scss
@@ -29,6 +29,11 @@ body.rails_admin {
     padding: 7px 7px 8px 7px;
   }
 
+  /* field value in show*/
+  .field_value{
+    padding: 10px;
+  }
+
   /* new/edit/export forms */
   .form-horizontal {
     /* hide hidden fields controls by default */

--- a/app/views/rails_admin/main/show.html.haml
+++ b/app/views/rails_admin/main/show.html.haml
@@ -11,4 +11,5 @@
             - if !values[index].nil? || !RailsAdmin::config.compact_show_view
               %dt.label{:class => "#{field.type_css_class} #{field.css_class}"}= field.label
               %dd
-                %pre.prettyprint= field.pretty_value
+                .field_value{:class=>field.css_class}
+                  = simple_format(field.pretty_value)

--- a/spec/integration/basic/show/rails_admin_basic_show_spec.rb
+++ b/spec/integration/basic/show/rails_admin_basic_show_spec.rb
@@ -11,6 +11,7 @@ describe "RailsAdmin Basic Show" do
       should have_selector("a", :text => "History")
       should have_selector("a", :text => "Edit")
       should have_selector("a", :text => "Delete")
+      should have_selector("div", :class=>"field_value")
       should have_content("Details")
       should have_content("Name")
       should have_content(@player.name)


### PR DESCRIPTION
When large amount of text are inserted in - lets say - textarea, each paragraph is single line and it's extended well over the browser's edge. 

I've changed the <pre> tag with div and formated the text with rails helper 'simple_format' and inserted it in div element with 'field_content' css style. Also created css style tag. 
