### PR TITLE
support for latest bootstrap-wysihtml5

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -195,7 +195,7 @@ $(document).live 'rails_admin.dom_ready', ->
       array.each ->
         $(@).addClass('bootstrap-wysihtml5ed')
         $(@).closest('.controls').addClass('well')
-        $(@).wysihtml5()
+        $(@).wysihtml5 { stylesheets: false }
 
     array = $('form [data-richtext=bootstrap-wysihtml5]').not('.bootstrap-wysihtml5ed')
     if array.length

--- a/lib/rails_admin/config/fields/types/text.rb
+++ b/lib/rails_admin/config/fields/types/text.rb
@@ -70,7 +70,7 @@ module RailsAdmin
           end
 
           register_instance_option(:bootstrap_wysihtml5_js_location) do
-            '/assets/bootstrap-wysihtml5-all.js'
+            '/assets/bootstrap-wysihtml5.js'
           end
 
           register_instance_option(:html_attributes) do


### PR DESCRIPTION
file name update for latest bootstrap-wysihtml5-rails.  also set configuration to prevent 404 on the unneeded wysihtml5.css.

this is a bug with the bootstrap-wysihtml5 repo.

existing tests apply to this change.
