### PR TITLE
missing allowed_methods for polymorphic fields

### DIFF
--- a/lib/rails_admin/config/fields/types/polymorphic_association.rb
+++ b/lib/rails_admin/config/fields/types/polymorphic_association.rb
@@ -37,6 +37,10 @@ module RailsAdmin
             nil
           end
 
+          register_instance_option :allowed_methods do
+            [children_fields]
+          end
+
           def associated_collection(type)
             return [] if type.blank?
             config = RailsAdmin.config(type)


### PR DESCRIPTION
fix little bug that prevent polymorphic associations to be correctly updated . 
