### PR TITLE
Fix default date value display issue as mentioned in issue #1353

### DIFF
--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -52,6 +52,7 @@ module RailsAdmin
           end
 
           def formatted_date_value
+            value = bindings[:object].new_record? && self.value.nil? && !self.default_value.nil? ? self.default_value : nil
             value.nil? ? "" : I18n.l(value, :format => localized_date_format).strip
           end
 

--- a/spec/integration/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/integration/config/edit/rails_admin_config_edit_spec.rb
@@ -39,7 +39,7 @@ describe "RailsAdmin Config DSL Edit Section" do
             default_value true
           end
           field :date_field do
-            default_value Date.today.to_s
+            default_value Date.today
           end
         end
       end

--- a/spec/unit/config/fields/date_spec.rb
+++ b/spec/unit/config/fields/date_spec.rb
@@ -50,4 +50,25 @@ describe RailsAdmin::Config::Fields::Types::Date do
       expect(@object.date_field).to eq(::Date.parse(@time.to_s))
     end
   end
+  describe 'default value' do
+    before :each do
+      RailsAdmin.config FieldTest do
+        field :date_field do
+          default_value Date.current
+        end
+      end
+      @object = FactoryGirl.create(:field_test)
+      @time = ::Time.now.getutc
+      @field = RailsAdmin.config(FieldTest).fields.find{ |f| f.name == :date_field }
+      @field.bindings = {:object => @object}
+    end
+    it "should contain the default value" do
+      expect(@field.default_value).to eq(Date.current)
+    end
+    it "should propagate to the field formatted_date_value when the object is a new record" do
+      object = FactoryGirl.build(:field_test)
+      @field.bindings = {:object => object}
+      expect(@field.formatted_date_value).to eq( Date.current.strftime("%B %d, %Y") )
+    end
+  end
 end


### PR DESCRIPTION
In issue #1353 it is mentioned that the default value is not displayed in the forms. The reason was that the :formatted_date_value of the date field object was not looking at the default date for new records. I assume that persisted records should take the persisted value. An error will occur if the default date is set as a string, but given separation of logic and display this should not be a problem.
