### PR TITLE
Use #presence when fetching field's value.

### DIFF
--- a/app/views/rails_admin/main/show.html.haml
+++ b/app/views/rails_admin/main/show.html.haml
@@ -1,6 +1,6 @@
 - @model_config.show.with(:object => @object, :view => self).visible_groups.each do |fieldset|
   - unless (fields = fieldset.with(:object => @object, :view => self, :controller => self.controller).visible_fields).empty?
-    - if !(values = fields.map{ |f| v = f.value; (!v.nil? && v != '' && v != []) ? v : nil }).compact.empty? || !RailsAdmin::config.compact_show_view
+    - if !(values = fields.map{ |f| f.value.presence }).compact.empty? || !RailsAdmin::config.compact_show_view
       .fieldset
         %h4
           = fieldset.label


### PR DESCRIPTION
Hi,

I encountered an exception when trying to display IPAddr field in show view. That happens because of IPAddr#<=> implementation (see http://www.ruby-doc.org/stdlib-1.9.3/libdoc/ipaddr/rdoc/IPAddr.html#method-i-3C-3D-3E). 

``` ruby
irb(main):006:0> ip = IPAddr.new('127.0.0.1')
=> #<IPAddr: IPv4:127.0.0.1/255.255.255.255>
irb(main):007:0> ip != []
NoMethodError: undefined method `to_i' for []:Array
irb(main):008:0> ip != ''
ArgumentError: invalid address
```

I suspect there may be other classes (custom or in stdlib) that may be affected by this. ActiveSupport's #presence, based on #blank? seems to yield the expected result.
