### PR TITLE
Fixes #1390 and improves float/decimal compatibility

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -171,9 +171,9 @@ module RailsAdmin
         when :boolean
           return ["(#{column} IS NULL OR #{column} = ?)", false] if ['false', 'f', '0'].include?(value)
           return ["(#{column} = ?)", true] if ['true', 't', '1'].include?(value)
-        when :decimal
+        when :decimal, :float
           return if value.blank?
-          ["(#{column} = ?)", value.to_f] if value.to_f.to_s == value
+          ["(#{column} = ?)", value.to_f] if value.to_f.to_s == value || value.to_i.to_s == value
         when :integer
           case value
           when Array then


### PR DESCRIPTION
Query can be filtered not only by decimal fields. There is a valid float field type in active record.
