### PR TITLE
LazyModel: refactor to remove unnecessary #store method

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -244,9 +244,12 @@ module RailsAdmin
             entity.class.name.to_sym
           end
         end
-        config = @registry[key] ||= RailsAdmin::Config::LazyModel.new(entity)
-        config.store(block) if block
-        config
+
+        if block
+          @registry[key] = RailsAdmin::Config::LazyModel.new(entity, &block)
+        else
+          @registry[key] ||= RailsAdmin::Config::LazyModel.new(entity)
+        end
       end
 
       def default_hidden_fields=(fields)

--- a/lib/rails_admin/config/lazy_model.rb
+++ b/lib/rails_admin/config/lazy_model.rb
@@ -3,27 +3,18 @@ require 'rails_admin/config/model'
 module RailsAdmin
   module Config
     class LazyModel
-      def initialize(entity)
+      def initialize(entity, &block)
         @entity = entity
+        @deferred_block = block
       end
 
       def method_missing(method, *args, &block)
-        if @block && not(@block_already_evaluated)
-          @model ||= RailsAdmin::Config::Model.new(@entity)
-          @model.instance_eval(&@block)
-          @block_already_evaluated = true
-        else
-          @model ||= RailsAdmin::Config::Model.new(@entity)
-        end
-        @model.send(method, *args, &block)
-      end
-
-      def store(block)
-        if @block # reset model to not eval twice
+        if !@model
           @model = RailsAdmin::Config::Model.new(@entity)
-          @block_already_evaluated = false
+          @model.instance_eval(&@deferred_block) if @deferred_block
         end
-        @block = block
+
+        @model.send(method, *args, &block)
       end
     end
   end

--- a/spec/rails_admin/config/lazy_model_spec.rb
+++ b/spec/rails_admin/config/lazy_model_spec.rb
@@ -1,41 +1,27 @@
 require 'spec_helper'
 
 describe RailsAdmin::Config::LazyModel do
-  let(:lazy_model) { RailsAdmin::Config::LazyModel.new(:Team) }
-
   describe "#store" do
     let(:block) { Proc.new { register_instance_option('parameter') } } # an arbitrary instance method we can spy on
     let(:other_block) { Proc.new { register_instance_option('other parameter') } }
 
-    it "doesn't execute the block immediately" do
+    it "doesn't evaluate the block immediately" do
       RailsAdmin::Config::Model.any_instance.should_not_receive(:register_instance_option)
-      lazy_model.store(block)
+
+      RailsAdmin::Config::LazyModel.new(:Team, &block)
     end
 
-    it "executes only when reading" do
+    it "evaluates block when reading" do
       RailsAdmin::Config::Model.any_instance.should_receive(:register_instance_option).with('parameter')
-      lazy_model.store(block)
+
+      lazy_model = RailsAdmin::Config::LazyModel.new(:Team, &block)
       lazy_model.groups # an arbitrary instance method on RailsAdmin::Config::Model to wake up lazy_model
-    end
-
-    it "evaluates only last block" do
-      RailsAdmin::Config::Model.any_instance.should_not_receive(:register_instance_option).with('parameter')
-      RailsAdmin::Config::Model.any_instance.should_receive(:register_instance_option).with('other parameter')
-      lazy_model.store(block)
-      lazy_model.store(other_block)
-      lazy_model.groups
-    end
-
-    it "resets models when a new block is given" do
-      lazy_model.store(block)
-      lazy_model.groups
-      RailsAdmin::Config::Model.should_receive(:new)
-      lazy_model.store(other_block)
     end
 
     it "evaluates config block only once" do
       RailsAdmin::Config::Model.any_instance.should_receive(:register_instance_option).once.with('parameter')
-      lazy_model.store(block)
+
+      lazy_model = RailsAdmin::Config::LazyModel.new(:Team, &block)
       lazy_model.groups
       lazy_model.groups
     end


### PR DESCRIPTION
Here's the small refactor discussed in 4da98396a4a8a95a.

Notes:
- I had to delete the tests `it "evaluates only last block"` and `it "resets models when a new block is given"` since it's no longer possible to pass a LazyModel more than one block. These tests should be rewritten at the RailsAdmin::Config level, but I've run out of time--I have to get on a plane.
- I think passing the blocks in as `&block` instead of `do ...something... end` in the tests is getting a little weird. Had I a little more time I probably would've tried to clean that up.

Thanks.
