### PR TITLE
Set colorpicker line-height to normal

### DIFF
--- a/app/assets/stylesheets/rails_admin/jquery.colorpicker.css.scss
+++ b/app/assets/stylesheets/rails_admin/jquery.colorpicker.css.scss
@@ -100,6 +100,7 @@
 	padding: 0 !important;
 	height: 11px !important;
 	width: auto !important;
+  line-height: normal !important;
 }
 .colorpicker_hex {
 	position: absolute;


### PR DESCRIPTION
This prevents later styles from overriding the line-height.

I found this when looking to fix #1298
