### PR TITLE
Add the original encoding at CSV Export

### DIFF
--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -5,6 +5,7 @@ module RailsAdmin
 
   CSVClass = RUBY_VERSION < '1.9' ? ::FasterCSV : ::CSV
   NON_ASCII_ENCODINGS = /(UTF\-16)|(UTF\-32)|(ISO\-2022\-JP)|(Big5\-HKSCS)|(UTF\-7)/
+  UTF8_ENCODINGS = [nil, '', 'utf8', 'utf-8', 'unicode', 'UTF8', 'UTF-8', 'UNICODE']
 
   class CSVConverter
 
@@ -42,11 +43,7 @@ module RailsAdmin
       return '' if @objects.blank?
 
       # encoding shenanigans first
-      @encoding_from = if [nil, '', 'utf8', 'utf-8', 'UTF8', 'UTF-8'].include?(encoding = @abstract_model.encoding)
-        'UTF-8'
-      else
-        encoding
-      end
+      @encoding_from = UTF8_ENCODINGS.include?(@abstract_model.encoding) ? 'UTF-8' : @abstract_model.encoding
 
       unless options[:encoding_to].blank?
         @encoding_to = options[:encoding_to]
@@ -106,4 +103,3 @@ module RailsAdmin
     end
   end
 end
-


### PR DESCRIPTION
exception will occur in iconv if you set the unicode to "encoding" of database.yml, you specify a non-UTF8 encoding at CSVExport.

the problem is I do not happen to be set to "unicode".
