### PR TITLE
Use safe_send instead of send for association's value

### DIFF
--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -90,7 +90,7 @@ module RailsAdmin
 
         # Reader for the association's value unformatted
         def value
-          bindings[:object].send(association[:name])
+          bindings[:object].safe_send(association[:name])
         end
 
         # has many?


### PR DESCRIPTION
With this change assocation values are treated the same way as fields values.

I hope you accept this commit without specs, but I couldn't work out how to write them for this change
