### PR TITLE
upgrade to capybara 2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -34,7 +34,7 @@ end
 group :development, :test do
   gem 'strong_parameters', '~> 0.1.5'
   gem 'cancan', '~> 1.6'
-  gem 'capybara', '~> 1.1'
+  gem 'capybara', '~> 2.0'
   gem 'carrierwave', '~> 0.6'
   gem 'database_cleaner', '~> 0.8'
   gem 'devise', '~> 2.1'

--- a/spec/integration/authorization/cancan_spec.rb
+++ b/spec/integration/authorization/cancan_spec.rb
@@ -76,9 +76,9 @@ describe "RailsAdmin CanCan Authorization" do
 
     it "GET /admin should show Player but not League" do
       visit dashboard_path
-      expect(body).to have_content("Player")
-      expect(body).not_to have_content("League")
-      expect(body).not_to have_content("Add new")
+      should have_content("Player")
+      should_not have_content("League")
+      should_not have_content("Add new")
     end
 
     it "GET /admin/player should render successfully but not list retired players and not show new, edit, or delete actions" do
@@ -132,7 +132,7 @@ describe "RailsAdmin CanCan Authorization" do
       fill_in "player[name]", :with   => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
       fill_in "player[position]", :with => "Second baseman"
-      click_button "Save"
+      first(:button, "Save").click
       should_not have_content("Edit")
 
       @player = RailsAdmin::AbstractModel.new("Player").first
@@ -165,7 +165,7 @@ describe "RailsAdmin CanCan Authorization" do
       should_not have_content("History")
       should_not have_content("Show in app")
       fill_in "player[name]", :with => "Jackie Robinson"
-      click_button "Save"
+      first(:button, "Save").click
       @player.reload
       expect(@player.name).to eq("Jackie Robinson")
     end
@@ -276,17 +276,17 @@ describe "RailsAdmin CanCan Authorization" do
       active_player = FactoryGirl.create :player, :retired => false
       retired_player = FactoryGirl.create :player, :retired => true
 
-      page.driver.post(bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id)))
+      post bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id))
 
-      should have_content(active_player.name)
-      should_not have_content(retired_player.name)
+      expect(response.body).to include(active_player.name)
+      expect(response.body).not_to include(retired_player.name)
     end
 
     it "POST /admin/player/bulk_destroy should destroy records which are authorized to" do
       active_player = FactoryGirl.create :player, :retired => false
       retired_player = FactoryGirl.create :player, :retired => true
 
-      page.driver.delete(bulk_delete_path(:model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id)))
+      delete bulk_delete_path(:model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id))
       expect(@player_model.get(active_player.id)).to be_nil
       expect(@player_model.get(retired_player.id)).not_to be_nil
     end
@@ -298,10 +298,10 @@ describe "RailsAdmin CanCan Authorization" do
       active_player = FactoryGirl.create :player, :retired => false
       retired_player = FactoryGirl.create :player, :retired => true
 
-      page.driver.post(bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id)))
+      post bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id))
 
-      should have_content(active_player.name)
-      should_not have_content(retired_player.name)
+      expect(response.body).to include(active_player.name)
+      expect(response.body).not_to include(retired_player.name)
     end
 
     it "POST /admin/player/bulk_destroy should destroy records which are authorized to" do
@@ -309,7 +309,7 @@ describe "RailsAdmin CanCan Authorization" do
       active_player = FactoryGirl.create :player, :retired => false
       retired_player = FactoryGirl.create :player, :retired => true
 
-      page.driver.delete(bulk_delete_path(:model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id)))
+      delete bulk_delete_path(:model_name => "player", :bulk_ids => [active_player, retired_player].map(&:id))
       expect(@player_model.get(active_player.id)).to be_nil
       expect(@player_model.get(retired_player.id)).not_to be_nil
     end

--- a/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
+++ b/spec/integration/basic/bulk_action/rails_admin_basic_bulk_action_spec.rb
@@ -10,8 +10,8 @@ describe "RailsAdmin Basic Bulk Action" do
 
   describe "bulk_delete" do
     it "shows names of to-be-deleted players" do
-      page.driver.post(bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => @players.map(&:id)))
-      @players.each { |player| should have_content(player.name) }
+      post(bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => @players.map(&:id)))
+      @players.each { |player| expect(response.body).to include(player.name) }
     end
   end
 

--- a/spec/integration/basic/bulk_destroy/rails_admin_basic_bulk_destroy_spec.rb
+++ b/spec/integration/basic/bulk_destroy/rails_admin_basic_bulk_destroy_spec.rb
@@ -9,8 +9,13 @@ describe "RailsAdmin Basic Bulk Destroy" do
       RailsAdmin.config { |c| c.audit_with :history }
       @players = 3.times.map { FactoryGirl.create(:player) }
       @delete_ids = @players[0..1].map(&:id)
-      page.driver.post(bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => @delete_ids))
 
+      # NOTE: This uses an internal, unsupported capybara API which could break at any moment. We
+      # should refactor this test so that it either A) uses capybara's supported API (only GET
+      # requests via visit) or B) just uses Rack::Test (and doesn't use capybara for browser
+      # interaction like click_button).
+      page.driver.browser.reset_host!
+      page.driver.browser.process :post, bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => @delete_ids, '_method' => 'post')
       click_button "Yes, I'm sure"
     end
 
@@ -31,7 +36,13 @@ describe "RailsAdmin Basic Bulk Destroy" do
     before do
       @players = 3.times.map { FactoryGirl.create(:player) }
       @delete_ids = @players[0..1].map(&:id)
-      page.driver.post(bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => @delete_ids))
+
+      # NOTE: This uses an internal, unsupported capybara API which could break at any moment. We
+      # should refactor this test so that it either A) uses capybara's supported API (only GET
+      # requests via visit) or B) just uses Rack::Test (and doesn't use capybara for browser
+      # interaction like click_button).
+      page.driver.browser.reset_host!
+      page.driver.browser.process :post, bulk_action_path(:bulk_action => 'bulk_delete', :model_name => "player", :bulk_ids => @delete_ids, '_method' => 'post')
       click_button "Cancel"
     end
 

--- a/spec/integration/basic/create/rails_admin_basic_create_spec.rb
+++ b/spec/integration/basic/create/rails_admin_basic_create_spec.rb
@@ -9,7 +9,7 @@ describe "RailsAdmin Basic Create" do
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
       fill_in "player[position]", :with => "Second baseman"
-      click_button "Save"
+      first(:button, "Save").click
       @player = RailsAdmin::AbstractModel.new("Player").first
     end
 
@@ -62,7 +62,7 @@ describe "RailsAdmin Basic Create" do
     before(:each) do
       @draft = FactoryGirl.create :draft
 
-      page.driver.post new_path(:model_name => "player", :player => {:name => "Jackie Robinson", :number => 42, :position => 'Second baseman', :draft_id => @draft.id})
+      post new_path(:model_name => "player", :player => {:name => "Jackie Robinson", :number => 42, :position => 'Second baseman', :draft_id => @draft.id})
 
       @player = RailsAdmin::AbstractModel.new("Player").all.last # first is created by FactoryGirl
     end
@@ -76,7 +76,7 @@ describe "RailsAdmin Basic Create" do
   describe "create with has-many association" do
     before(:each) do
       @divisions = 3.times.map { Division.create!(:name => "div #{Time.now.to_f}", :league => League.create!(:name => "league #{Time.now.to_f}")) }
-      page.driver.post new_path(:model_name => "league", :league => {:name => "National League", :division_ids =>[@divisions[0].id]})
+      post new_path(:model_name => "league", :league => {:name => "National League", :division_ids =>[@divisions[0].id]})
       @league = RailsAdmin::AbstractModel.new("League").all.last
     end
 
@@ -91,7 +91,7 @@ describe "RailsAdmin Basic Create" do
   describe "create with has-and-belongs-to-many association" do
     before(:each) do
       @teams = 3.times.map { FactoryGirl.create :team }
-      page.driver.post new_path(:model_name => "fan", :fan => {:name => "John Doe", :team_ids => [@teams[0].id] })
+      post new_path(:model_name => "fan", :fan => {:name => "John Doe", :team_ids => [@teams[0].id] })
       @fan = RailsAdmin::AbstractModel.new("Fan").first
     end
 
@@ -108,22 +108,21 @@ describe "RailsAdmin Basic Create" do
       @team = FactoryGirl.create :team
       @player = FactoryGirl.create :player, :team => @team
 
-      page.driver.post new_path(:model_name => "player", :player => {:name => @player.name, :number => @player.number.to_s, :position => @player.position, :team_id => @team.id})
+      post new_path(:model_name => "player", :player => {:name => @player.name, :number => @player.number.to_s, :position => @player.position, :team_id => @team.id})
     end
 
     it "shows an error message" do
-      should have_content("There is already a player with that number on this team")
+      expect(response.body).to include("There is already a player with that number on this team")
     end
   end
 
   describe "create with invalid object" do
     before(:each) do
-      page.driver.post(new_path(:model_name => "player", :id => 1), :params => {:player => {}})
+      post new_path(:model_name => "player", :player => {:id => 1})
     end
 
     it "shows an error message" do
-      should have_content("Player failed to be created")
-      should have_selector "form", :action => "/admin/players"
+      expect(response.body).to include("Player failed to be created")
     end
   end
 

--- a/spec/integration/basic/create/rails_admin_namespaced_model_create_spec.rb
+++ b/spec/integration/basic/create/rails_admin_namespaced_model_create_spec.rb
@@ -10,7 +10,7 @@ describe "RailsAdmin Namespaced Model Create" do
     fill_in "cms_basic_page[title]", :with => "Hello"
     fill_in "cms_basic_page[content]", :with => "World"
     expect {
-      click_button "Save"
+      first(:button, "Save").click
     }.to change(Cms::BasicPage, :count).by(1)
   end
 end

--- a/spec/integration/basic/destroy/rails_admin_basic_destroy_spec.rb
+++ b/spec/integration/basic/destroy/rails_admin_basic_destroy_spec.rb
@@ -53,11 +53,11 @@ describe "RailsAdmin Basic Destroy" do
 
   describe "destroy with missing object" do
     before(:each) do
-      page.driver.delete(delete_path(:model_name => "player", :id => 1))
+      delete delete_path(:model_name => "player", :id => 1)
     end
 
     it "raises NotFound" do
-      expect(page.driver.status_code).to eq(404)
+      expect(response.code).to eq("404")
     end
   end
 
@@ -65,7 +65,7 @@ describe "RailsAdmin Basic Destroy" do
     it "redirects to the index instead of trying to show the deleted object" do
       @player = FactoryGirl.create :player
       visit show_path(:model_name => 'player', :id => @player.id)
-      visit delete_path(:model_name => "player", :id => @player.id)
+      click_link "Delete"
       click_button "Yes, I'm sure"
 
       expect(URI.parse(page.current_url).path).to eq(index_path(:model_name => 'player'))
@@ -75,7 +75,7 @@ describe "RailsAdmin Basic Destroy" do
       Player.any_instance.stub(:destroy_hook).and_return false
       @player = FactoryGirl.create :player
       visit show_path(:model_name => 'player', :id => @player.id)
-      visit delete_path(:model_name => "player", :id => @player.id)
+      click_link "Delete"
       click_button "Yes, I'm sure"
 
       expect(URI.parse(page.current_url).path).to eq(show_path(:model_name => 'player', :id => @player.id))

--- a/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
@@ -30,13 +30,13 @@ describe "RailsAdmin Basic Edit" do
     it "adds a related id to the belongs_to create team link" do
       @player = FactoryGirl.create :player
       visit edit_path(:model_name => "player", :id => @player.id)
-      should have_selector("a", :href => 'admin/teams/new?associations[players]=' + @player.id.to_s)
+      should have_selector("a[data-link='/admin/team/new?associations%5Bplayers%5D=#{@player.id.to_s}&modal=true']")
     end
 
     it "adds a related id to the has_many create team link" do
       @team = FactoryGirl.create :team
       visit edit_path(:model_name => "team", :id => @team.id)
-      should have_selector("a", :href => 'admin/players/new?associations[team]=' + @team.id.to_s)
+      should have_selector("a[data-link='/admin/player/new?associations%5Bteam%5D=#{@team.id.to_s}&modal=true']")
     end
   end
 

--- a/spec/integration/basic/export/rails_admin_basic_export_spec.rb
+++ b/spec/integration/basic/export/rails_admin_basic_export_spec.rb
@@ -46,7 +46,7 @@ describe "RailsAdmin Export" do
       should have_content 'Select fields to export'
       select "<comma> ','", :from => "csv_options_generator_col_sep"
       click_button 'Export to csv'
-      csv = CSV.parse find('body').text
+      csv = CSV.parse page.driver.response.body.force_encoding("utf-8") # comes through as us-ascii on some platforms
       expect(csv[0]).to match_array ["Id", "Created at", "Updated at", "Deleted at", "Name", "Position",
         "Number", "Retired", "Injured", "Born on", "Notes", "Suspended", "Id [Team]", "Created at [Team]",
         "Updated at [Team]", "Name [Team]", "Logo url [Team]", "Team Manager [Team]", "Ballpark [Team]",
@@ -87,7 +87,7 @@ describe "RailsAdmin Export" do
       visit export_path(:model_name => 'comment')
       select "<comma> ','", :from => "csv_options_generator_col_sep"
       click_button 'Export to csv'
-      csv = CSV.parse find('body').text
+      csv = CSV.parse page.driver.response.body
       expect(csv[0]).to match_array ["Id", "Commentable", "Commentable type", "Content", "Created at", "Updated at"]
       csv[1..-1].each do |line|
         expect(line[csv[0].index('Commentable')]).to eq(@player.id.to_s)

--- a/spec/integration/basic/list/rails_admin_basic_list_spec.rb
+++ b/spec/integration/basic/list/rails_admin_basic_list_spec.rb
@@ -37,9 +37,9 @@ describe "RailsAdmin Basic List" do
       should have_content("Updated at")
 
       # it "shows the show, edit and delete links" do
-      should have_selector("td a", :text => 'Show')
-      should have_selector("td a", :text => 'Edit')
-      should have_selector("td a", :text => 'Delete')
+      should have_selector("li[title='Show'] a")
+      should have_selector("li[title='Edit'] a")
+      should have_selector("li[title='Delete'] a")
 
       # it "has the search box with some prompt text" do
       should have_selector("input[placeholder='Filter']")
@@ -278,9 +278,9 @@ describe "RailsAdmin Basic List" do
         end
       end
 
-      visit index_path(:model_name => "player")
-      should have_content(%{$.filters.append("Name", "name", "string", "", null, "", 1);})
-      should have_content(%{$.filters.append("Team", "team", "belongs_to_association", "", null, "", 2);})
+      get index_path(:model_name => "player")
+      expect(response.body).to include(%{$.filters.append("Name", "name", "string", "", null, "", 1);})
+      expect(response.body).to include(%{$.filters.append("Team", "team", "belongs_to_association", "", null, "", 2);})
     end
   end
 
@@ -361,7 +361,7 @@ describe "RailsAdmin Basic List" do
   describe "list as compact json" do
     it "has_content an array with 2 elements and contain an array of elements with keys id and label" do
       2.times.map { FactoryGirl.create :player }
-      response = page.driver.get(index_path(:model_name => "player", :compact => true, :format => :json))
+      get index_path(:model_name => "player", :compact => true, :format => :json)
       expect(ActiveSupport::JSON.decode(response.body).length).to eq(2)
       ActiveSupport::JSON.decode(response.body).each do |object|
         expect(object).to have_key("id")

--- a/spec/integration/basic/update/rails_admin_basic_update_spec.rb
+++ b/spec/integration/basic/update/rails_admin_basic_update_spec.rb
@@ -12,9 +12,9 @@ describe "RailsAdmin Basic Update" do
 
     it "returns to edit page" do
       fill_in "player[name]", :with => ""
-      click_button "Save"
+      first(:button, "Save").click
       expect(page.driver.status_code).to eq(406)
-      should have_selector "form", :action => "/admin/players/#{@player.id}"
+      should have_selector "form[action='#{edit_path(:model_name => "player", :id => @player.id)}']"
     end
   end
 
@@ -27,7 +27,7 @@ describe "RailsAdmin Basic Update" do
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "42"
       fill_in "player[position]", :with => "Second baseman"
-      click_button "Save"
+      first(:button, "Save").click
 
       @player = RailsAdmin::AbstractModel.new("Player").first
     end
@@ -65,7 +65,7 @@ describe "RailsAdmin Basic Update" do
       @player = FactoryGirl.create :player
       @draft = FactoryGirl.create :draft
       @number = @draft.player.number + 1 # to avoid collision
-      page.driver.put edit_path(:model_name => "player", :id => @player.id, :player => {:name => "Jackie Robinson", :draft_id => @draft.id, :number => @number, :position => "Second baseman"})
+      put edit_path(:model_name => "player", :id => @player.id, :player => {:name => "Jackie Robinson", :draft_id => @draft.id, :number => @number, :position => "Second baseman"})
       @player.reload
     end
 
@@ -90,7 +90,7 @@ describe "RailsAdmin Basic Update" do
       @league = FactoryGirl.create :league
       @divisions = 3.times.map { Division.create!(:name => "div #{Time.now.to_f}", :league => League.create!(:name => "league #{Time.now.to_f}")) }
 
-      page.driver.put edit_path(:model_name => "league", :id => @league.id, :league => {:name => "National League", :division_ids => [@divisions[0].id] })
+      put edit_path(:model_name => "league", :id => @league.id, :league => {:name => "National League", :division_ids => [@divisions[0].id] })
 
       old_name = @league.name
       @league.reload
@@ -102,7 +102,7 @@ describe "RailsAdmin Basic Update" do
 
       expect(RailsAdmin::History.where(:item => @league.id).collect(&:message)).to include("name: \"#{old_name}\" -> \"National League\"")
 
-      page.driver.put edit_path(:model_name => "league", :id => @league.id, :league => {:division_ids => [""]})
+      put edit_path(:model_name => "league", :id => @league.id, :league => {:division_ids => [""]})
 
       @league.reload
       expect(@league.divisions).to be_empty
@@ -111,11 +111,11 @@ describe "RailsAdmin Basic Update" do
 
   describe "update with missing object" do
     before(:each) do
-      page.driver.put(edit_path(:model_name => "player", :id => 1), :params => {:player => {:name => "Jackie Robinson", :number => 42, :position => "Second baseman"}})
+      put edit_path(:model_name => "player", :id => 1), :params => {:player => {:name => "Jackie Robinson", :number => 42, :position => "Second baseman"}}
     end
 
     it "raises NotFound" do
-      expect(page.driver.status_code).to eq(404)
+      expect(response.code).to eq("404")
     end
   end
 
@@ -128,7 +128,7 @@ describe "RailsAdmin Basic Update" do
       fill_in "player[name]", :with => "Jackie Robinson"
       fill_in "player[number]", :with => "a"
       fill_in "player[position]", :with => "Second baseman"
-      click_button "Save"
+      first(:button, "Save").click
 
       @player.reload
     end
@@ -137,7 +137,7 @@ describe "RailsAdmin Basic Update" do
       # TODO: Mongoid 3.0.0 lacks ability of numericality validation on Integer field.
       # This is caused by change in https://github.com/mongoid/mongoid/pull/1698
       # I believe this should be a bug in Mongoid.
-      expect(body).to have_content("Player failed to be updated") unless CI_ORM == :mongoid && Mongoid::VERSION >= '3.0.0'
+      expect(Capybara.string(body)).to have_content("Player failed to be updated") unless CI_ORM == :mongoid && Mongoid::VERSION >= '3.0.0'
     end
   end
 
@@ -154,7 +154,7 @@ describe "RailsAdmin Basic Update" do
       visit edit_path(:model_name => "user", :id => @user.id)
 
       fill_in "user[roles]", :with => %{['admin', 'user']}
-      click_button "Save"
+      first(:button, "Save").click
 
       @user.reload
     end
@@ -174,7 +174,7 @@ describe "RailsAdmin Basic Update" do
     it "saves the serialized data" do
       fill_in "field_test[array_field]", :with => "[4, 2]"
       fill_in "field_test[hash_field]", :with => "{ a: 6, b: 2 }"
-      click_button "Save"
+      first(:button, "Save").click
 
       @field_test.reload
       expect(@field_test.array_field).to eq([4, 2])
@@ -184,7 +184,7 @@ describe "RailsAdmin Basic Update" do
     it "clears data when empty string is passed" do
       fill_in "field_test[array_field]", :with => ""
       fill_in "field_test[hash_field]", :with => ""
-      click_button "Save"
+      first(:button, "Save").click
 
       @field_test.reload
       expect(@field_test.array_field).to eq(nil)

--- a/spec/integration/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/integration/config/edit/rails_admin_config_edit_spec.rb
@@ -16,7 +16,7 @@ describe "RailsAdmin Config DSL Edit Section" do
       end
       visit new_path(:model_name => "field_test")
       fill_in "field_test[format]", :with => "test for format"
-      click_button "Save"
+      first(:button, "Save").click
       @record = RailsAdmin::AbstractModel.new("FieldTest").first
       expect(@record.format).to eq("test for format")
     end
@@ -93,7 +93,7 @@ describe "RailsAdmin Config DSL Edit Section" do
       fill_in "field_test[string_field]", :with => "No problem here"
       fill_in "field_test[restricted_field]", :with => "I'm allowed to do that as :custom_role only"
       should have_no_selector "field_test[protected_field]"
-      click_button "Save"
+      first(:button, "Save").click
       @field_test = FieldTest.first
       expect(@field_test.string_field).to eq("No problem here")
       expect(@field_test.restricted_field).to eq("I'm allowed to do that as :custom_role only")
@@ -161,7 +161,10 @@ describe "RailsAdmin Config DSL Edit Section" do
         end
       end
       visit new_path(:model_name => "team")
-      should have_selector("legend", :text => "Renamed group")
+      # NOTE: capybara 2.0 is exceedingly reluctant to reveal the text of invisible elements. This was
+      # the least terrible option I was able to find. It would probably be better to refactor the test
+      # so the label we're looking for is displayed.
+      expect(find("legend", :visible => false).native.text).to include("Renamed group")
     end
 
     describe "help" do
@@ -309,12 +312,8 @@ describe "RailsAdmin Config DSL Edit Section" do
         end
       end
       visit new_path(:model_name => "team")
-      should have_selector("legend", :text => "Basic info")
-      all("legend", :text => "Basic info").tap do |nodes|
-        expect(nodes.count).to eq(2)
-        expect(nodes.first.visible?).to be_false
-        expect(nodes.last.visible?).to be_true
-      end
+      should have_selector("legend", :text => "Basic info", :visible => false)
+      should have_selector("legend", :text => "Basic info", :visible => true)
       should have_selector("legend", :text => "Belong's to associations")
       should have_selector("label", :text => "Name")
       should have_selector("label", :text => "Logo url")
@@ -611,10 +610,10 @@ describe "RailsAdmin Config DSL Edit Section" do
 
       visit new_path(:model_name => 'category')
       should have_no_css('#category_parent_category_id')
-      click_button 'Save'
+      first(:button, "Save").click
       visit edit_path(:model_name => 'category', :id => Category.first)
       should have_css('#category_parent_category_id')
-      click_button 'Save'
+      first(:button, "Save").click
       should have_content('Category successfully updated')
     end
   end
@@ -627,7 +626,7 @@ describe "RailsAdmin Config DSL Edit Section" do
       fill_in "field_test_comment_attributes_content", :with => 'nested comment content'
       fill_in "field_test_nested_field_tests_attributes_0_title", :with => 'nested field test title 1 edited'
       page.find('#field_test_nested_field_tests_attributes_1__destroy').set('true')
-      click_button "Save"
+      first(:button, "Save").click
       @record.reload
       expect(@record.comment.content).to eq('nested comment content')
       expect(@record.nested_field_tests.length).to eq(1)
@@ -706,7 +705,7 @@ describe "RailsAdmin Config DSL Edit Section" do
       visit edit_path(:model_name => "field_test", :id => @record.id)
       fill_in "field_test_embeds_attributes_0_name", :with => 'embed 1 edited'
       page.find('#field_test_embeds_attributes_1__destroy').set('true')
-      click_button "Save"
+      first(:button, "Save").click
       @record.reload
       expect(@record.embeds.length).to eq(1)
       expect(@record.embeds[0].name).to eq('embed 1 edited')

--- a/spec/integration/config/list/rails_admin_config_list_spec.rb
+++ b/spec/integration/config/list/rails_admin_config_list_spec.rb
@@ -290,8 +290,10 @@ describe "RailsAdmin Config DSL List Section" do
       end
       @fans = 2.times.map { FactoryGirl.create :fan }
       visit index_path(:model_name => "fan")
-      expect(find('style')).to have_content("#list th.#{PK_COLUMN}_field")
-      expect(find('style')).to have_content("#list td.#{PK_COLUMN}_field")
+      # NOTE: Capybara really doesn't want us to look at invisible text. This test
+      # could break at any moment.
+      expect(find('style').native.text).to include("#list th.#{PK_COLUMN}_field")
+      expect(find('style').native.text).to include("#list td.#{PK_COLUMN}_field")
     end
 
     it "has option to customize output formatting" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -55,6 +55,8 @@ RSpec.configure do |config|
 
   config.include Warden::Test::Helpers
 
+  config.include Capybara::DSL, type: :request
+
   config.before(:each) do
     DatabaseCleaner.start
     RailsAdmin::Config.reset


### PR DESCRIPTION
Fixes #1441

Notes:
- `page.driver.post` and other similar methods have never been supported, and are broken in Capybara 2.0. Where possible I replaced them with straight Rack::Test methods (which is the official recommendation for api tests); otherwise I used the new unsupported hack from http://stackoverflow.com/questions/13583375/testing-specific-post-requests-form-hacking-permissions-protection-with-capyb
- Couldn't just move our integration tests to /features, because then Rack::Test isn't available, and it seemed simpler to config.include Capybara in /integration than move /integration to /features and config.include Rack::Test in /features. 

Please let me know if you have any questions or concerns. This was somewhat more involved than I anticipated. And happy holidays.
