### PR TITLE
Fix model plural to use other or many plural form

### DIFF
--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -60,7 +60,7 @@ module RailsAdmin
       end
 
       register_instance_option :label_plural do
-        (@label_plural ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human(:count => 2, :default => label.pluralize)
+        (@label_plural ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human(:count => 20, :default => label.pluralize)
       end
 
       def pluralize(count)


### PR DESCRIPTION
Some languages (slavic, for example) have several plural forms (one, few and many). For example (Russian): “1 гулаг”, “2 гулага”, “5 гулагов”.

In models list in left main navigation RailsAdmin use `count: 2`, but in East Slavic, Romanian, Czech and Slovak languages it will use `few` plural form, which is wrong.

I investigate in Rails I18n locales, which plural rules used in another languages and choose `count: 20`, which will use `many`/`other` plural forms in all locales.
