### PR TITLE
Deduce Devise scope from _current user. Fixes #1386, partly.

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -31,6 +31,13 @@ module RailsAdmin
       link_to _current_user.email, url_for(:action => edit_action.action_name, :model_name => abstract_model.to_param, :id => _current_user.id, :controller => 'rails_admin/main')
     end
 
+    def logout_path
+      if defined?(Devise)
+        scope = Devise::Mapping.find_scope!(_current_user)
+        main_app.send("destroy_#{scope}_session_path") rescue false
+      end
+    end
+
     def wording_for(label, action = @action, abstract_model = @abstract_model, object = @object)
       model_config = abstract_model.try(:config)
       object = abstract_model && object.is_a?(abstract_model.model) ? object : nil

--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -6,7 +6,7 @@
   - if _current_user
     - if user_link = edit_user_link
       %li= user_link
-    - if defined?(Devise) && (devise_scope = request.env["warden"].config[:default_scope] rescue false) && (logout_path = main_app.send("destroy_#{devise_scope}_session_path") rescue false)
+    - if logout_path.present?
       %li= link_to content_tag('span', t('admin.misc.log_out'), :class => 'label label-important'), logout_path, :method => Devise.sign_out_via
     - if _current_user.respond_to?(:email) && _current_user.email.present?
       %li= image_tag "#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", :style => 'padding-top:5px'

--- a/spec/integration/rails_admin_spec.rb
+++ b/spec/integration/rails_admin_spec.rb
@@ -140,5 +140,11 @@ describe RailsAdmin do
       visit dashboard_path
       should have_selector("body.rails_admin")
     end
+
+    it "shows a log out link" do
+      visit dashboard_path
+      click_link "Log out"
+      should have_content("Sign in")
+    end
   end
 end


### PR DESCRIPTION
If you configure Devise with sign_out_all_scopes = false,
and authenticate with a scope that's different from the default one (like :admin) the sign out link did not work. This fixes that.

Unfortunately i could not figure out how to add a helper spec for this. So i added a new integration spec to ensure that things do not explode.
