### PR TITLE
jQuery 1.9 compatibility

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -101,7 +101,7 @@
     }
   }
 
-  $("#filters a").live('click', function(e) {
+  $(document).on('click', "#filters a", function(e) {
     e.preventDefault();
     $.filters.append(
       $(this).data('field-label'),
@@ -114,14 +114,14 @@
     );
   });
 
-  $('#filters_box .delete').live('click', function(e) {
+  $(document).on('click', "#filters_box .delete", function(e) {
     e.preventDefault();
     form = $(this).parents('form');
     $(this).parents('.filter').remove();
     !$("#filters_box").children().length && $("hr.filters_box:visible").hide('slow');
   });
 
-  $('#filters_box .switch-select').live('click', function(e) {
+  $(document).on('click', "#filters_box .switch-select", function(e) {
     e.preventDefault();
     var selected_select = $(this).siblings('select:visible');
     var not_selected_select = $(this).siblings('select:hidden');
@@ -130,7 +130,7 @@
     $(this).find('i').toggleClass("icon-plus icon-minus")
   });
 
-  $('#filters_box .switch-additionnal-fieldsets').live('change', function() {
+  $(document).on('change', "#filters_box .switch-additionnal-fieldsets", function(e) {
     var selected_option = $(this).find('option:selected');
     if(klass = $(selected_option).data('additional-fieldset')) {
       $(this).siblings('.additional-fieldset:not(.' + klass + ')').hide('slow');

--- a/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
+++ b/app/assets/javascripts/rails_admin/ra.nested-form-hooks.coffee
@@ -6,7 +6,7 @@ $(document).ready ->
     tab_content.append content
     tab_content.children().last()
 
-$('form').live 'nested:fieldAdded', (content) ->
+$(document).on 'nested:fieldAdded', 'form', (content) ->
   field = content.field.addClass('tab-pane').attr('id', 'unique-id-' + (new Date().getTime()))
   new_tab = $('<li><a data-toggle="tab" href="#' + field.attr('id') + '">' + field.children('.object-infos').data('object-label') + '</a></li>')
   parent_group = field.closest('.control-group')
@@ -22,7 +22,7 @@ $('form').live 'nested:fieldAdded', (content) ->
   # toggler 'on' if inactive
   toggler.addClass('active').removeClass('disabled').children('i').addClass('icon-chevron-down').removeClass('icon-chevron-right')
 
-$('form').live 'nested:fieldRemoved', (content) ->
+$(document).on 'nested:fieldRemoved', 'form', (content) ->
   field = content.field
   nav = field.closest(".control-group").children('.controls').children('.nav')
   current_li = nav.children('li').has('a[href=#' + field.attr('id') + ']')

--- a/app/assets/javascripts/rails_admin/ra.remote-form.js
+++ b/app/assets/javascripts/rails_admin/ra.remote-form.js
@@ -19,7 +19,7 @@
 
       var edit_url = dom_widget.find('select').first().data('options') && dom_widget.find('select').first().data('options')['edit-url'];
       if(typeof(edit_url) != 'undefined' && edit_url.length) {
-        dom_widget.find('.ra-multiselect option').live('dblclick', function(e){
+        $(document).on('dblclick', dom_widget.find('.ra-multiselect option'), function(e){
           widget._bindModalOpening(e, edit_url.replace('__ID__', this.value))
         });
       }

--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -1,4 +1,4 @@
-$(document).live 'rails_admin.dom_ready', ->
+$(document).on 'rails_admin.dom_ready', ->
 
   if $('form').length # don't waste time otherwise
 
@@ -35,7 +35,7 @@ $(document).live 'rails_admin.dom_ready', ->
 
     $('form [data-fileupload]').each ->
       input = this
-      $(this).find(".delete input[type='checkbox']").live 'click', ->
+      $(document).on 'click', $(this).find(".delete input[type='checkbox']"), ->
         $(input).children('.toggle').toggle('slow')
 
     # fileupload-preview

--- a/app/assets/javascripts/rails_admin/ui.js.coffee
+++ b/app/assets/javascripts/rails_admin/ui.js.coffee
@@ -1,9 +1,9 @@
 $ = jQuery
 
-$("#list input.toggle").live "click", ->
+$(document).on "click", "#list input.toggle", ->
   $("#list [name='bulk_ids[]']").attr "checked", $(this).is(":checked")
 
-$('.pjax').live 'click', (event) ->
+$(document).on 'click', '.pjax', (event) ->
   if event.which > 1 || event.metaKey || event.ctrlKey
     return
   else if $.support.pjax
@@ -15,7 +15,7 @@ $('.pjax').live 'click', (event) ->
   else if $(this).data('href') # not a native #href, need some help
     window.location = $(this).data('href')
 
-$('.pjax-form').live 'submit', (event) ->
+$(document).on 'submit', '.pjax-form', (event) ->
   if $.support.pjax
     event.preventDefault()
     $.pjax
@@ -29,7 +29,7 @@ $(document)
   .on 'pjax:end', ->
     $('#loading').hide()
 
-$('[data-target]').live 'click', ->
+$(document).on 'click', '[data-target]', ->
   if !$(this).hasClass('disabled')
     if $(this).has('i.icon-chevron-down').length
       $(this).removeClass('active').children('i').toggleClass('icon-chevron-down icon-chevron-right')
@@ -39,7 +39,7 @@ $('[data-target]').live 'click', ->
         $(this).addClass('active').children('i').toggleClass('icon-chevron-down icon-chevron-right')
         $($(this).data('target')).select(':hidden').show('slow')
 
-$('.form-horizontal legend').live 'click', ->
+$(document).on 'click', '.form-horizontal legend', ->
   if $(this).has('i.icon-chevron-down').length
     $(this).siblings('.control-group:visible').hide('slow')
     $(this).children('i').toggleClass('icon-chevron-down icon-chevron-right')
@@ -51,10 +51,10 @@ $('.form-horizontal legend').live 'click', ->
 $(document).ready ->
   $(document).trigger('rails_admin.dom_ready')
 
-$(document).live 'pjax:end', ->
+$(document).on 'pjax:end', ->
   $(document).trigger('rails_admin.dom_ready')
 
-$(document).live 'rails_admin.dom_ready', ->
+$(document).on 'rails_admin.dom_ready', ->
   $('.animate-width-to').each ->
     length = $(this).data("animate-length")
     width = $(this).data("animate-width-to")


### PR DESCRIPTION
jQuery doesn’t support `$.fn.live` anymore. We should use `$.fn.on(event, selector, callback)`.

Rails Admin use Remotipart, I send [jQuery 1.9 fixes](https://github.com/JangoSteve/remotipart/pull/50) to them to.
