### PR TITLE
mongoid custom setter fix

### DIFF
--- a/lib/rails_admin/adapters/mongoid/abstract_object.rb
+++ b/lib/rails_admin/adapters/mongoid/abstract_object.rb
@@ -21,6 +21,7 @@ module RailsAdmin
                       item.update_attribute('#{association.foreign_key}', id)
                     end
                   end
+                  super __items__.map &:id
                 end
 RUBY
             elsif [:has_one, :references_one].include? association.macro
@@ -32,6 +33,7 @@ RUBY
                   else
                     item.update_attribute('#{association.foreign_key}', id) if item
                   end
+                  super item.id
                 end
 RUBY
             end

--- a/spec/dummy_app/app/mongoid/team.rb
+++ b/spec/dummy_app/app/mongoid/team.rb
@@ -23,6 +23,7 @@ class Team
   has_many :players, :inverse_of => :team, :order => :_id.asc
   has_and_belongs_to_many :fans
   has_many :comments, :as => :commentable
+  has_one :draft
 
   validates_presence_of :division_id, :only_integer => true
   validates_presence_of :manager
@@ -43,5 +44,13 @@ class Team
 
   def color_enum
     ['white', 'black', 'red', 'green', 'blu<e>é']
+  end
+
+  def player_ids= players_ids
+    self.custom_field = players_ids * ', '
+  end
+
+  def draft_id= draft_id
+    self.custom_field = draft_id.to_s
   end
 end

--- a/spec/rails_admin/adapters/mongoid/abstract_object_spec.rb
+++ b/spec/rails_admin/adapters/mongoid/abstract_object_spec.rb
@@ -4,6 +4,7 @@ require 'rails_admin/adapters/mongoid/abstract_object'
 describe "RailsAdmin::Adapters::Mongoid::AbstractObject", :mongoid => true do
   before(:each) do
     @players = FactoryGirl.create_list :player, 3
+    @draft = FactoryGirl.create :draft
     @team = RailsAdmin::Adapters::Mongoid::AbstractObject.new FactoryGirl.create :team
   end
 
@@ -26,6 +27,21 @@ describe "RailsAdmin::Adapters::Mongoid::AbstractObject", :mongoid => true do
       @team.reload
       @players.each &:reload
       expect(@team.players.map(&:id)).to match_array @players.map(&:id)
+    end
+
+    it 'calls the models custom setter' do
+      expect(@team.custom_field).to eq(nil)
+      @team.player_ids = @players.map(&:id)
+      expect(@team.custom_field).to eq(@players.map(&:id) * ', ')
+    end
+  end
+
+  describe "references_one association" do
+    it 'calls the models custom setter' do
+      expect(@draft.notes).to eq(nil)
+      puts @team.draft.inspect
+      @team.draft_id = @draft.id
+      expect(@team.custom_field).to eq(@draft.id.to_s)
     end
   end
 end


### PR DESCRIPTION
After taking a break and having a fresh look at this problem, I found this is an issue with Mongoid only.  Looking at the mongoid abstract_object I saw that the association setters were overriding any custom setter from the app's model.

Fixes #1422
