### PR TITLE
Model plural label fix: Count must be 'other' to apply :other key with every locale. 

### DIFF
--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -60,7 +60,7 @@ module RailsAdmin
       end
 
       register_instance_option :label_plural do
-        (@label_plural ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human(:count => 2, :default => label.pluralize)
+        (@label_plural ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human(:count => 'other', :default => label.pluralize)
       end
 
       def pluralize(count)


### PR DESCRIPTION
Two for count doesn't apply right plural key (:other) for some languages.
For example, in russian locale it calls :few key and applies wrong translation.

```
 >> I18n.locale = :ru
 >> I18n.t 'activerecord.models.user', count: 2
 => "Пользователя"  #wrong
 >> I18n.t 'activerecord.models.user', count: 'other'
 => "Пользователи"  #right
 >> I18n.t.locale = :en 
 => I18n.t 'activerecord.models.user', count: 'other'
 => "Users"
```
