### PR TITLE
Fix safe_yaml depercation message

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -10,8 +10,8 @@ require 'rails_admin'
 require 'remotipart'
 require 'safe_yaml'
 
-YAML.enable_arbitrary_object_deserialization!
 SafeYAML::OPTIONS[:suppress_warnings] = true
+SafeYAML::OPTIONS[:default_mode] = :unsafe
 
 module RailsAdmin
   class Engine < Rails::Engine


### PR DESCRIPTION
There is a depercation message `The method 'YAML.enable_arbitrary_object_deserialization!' is deprecated and will be removed in the next release of SafeYAML -- set the SafeYAML::OPTIONS[:default_mode] to either :safe or :unsafe.`, this commit fixes it.
