### PR TITLE
Add remove button for nested one form

### DIFF
--- a/app/assets/javascripts/rails_admin/ui.coffee
+++ b/app/assets/javascripts/rails_admin/ui.coffee
@@ -48,6 +48,10 @@ $(document).on 'click', '.form-horizontal legend', ->
       $(this).siblings('.control-group:hidden').show('slow')
       $(this).children('i').toggleClass('icon-chevron-down icon-chevron-right')
 
+$(document).on 'click', 'form .tab-content .tab-pane a.remove_nested_one_fields', ->
+  $(this).children('input[type="hidden"]').val($(this).hasClass('active')).
+    siblings('i').toggleClass('icon-check icon-trash')
+
 $(document).ready ->
   $(document).trigger('rails_admin.dom_ready')
 

--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -35,14 +35,14 @@ body.rails_admin {
     .control-group .hidden_type {
       display:none;
     }
-    
+
     legend {
       cursor:pointer;
       i {
         vertical-align: inherit !important;
       }
     }
-    
+
     &.denser {
       .controls .nav {
         margin-bottom:5px;
@@ -75,7 +75,7 @@ body.rails_admin {
         margin-bottom:0px;
       }
     }
-    
+
     /* We want input size to be used, unfixate input width */
     input, textarea {
       width:auto;
@@ -89,13 +89,16 @@ body.rails_admin {
 
     /* nested forms */
     .tab-content .tab-pane {
-      &>.remove_nested_fields {
+      &>.remove_nested_fields,
+      &>.remove_nested_one_fields {
         display:none;
       }
-      &:hover>.remove_nested_fields {
+      &:hover>.remove_nested_fields,
+      &:hover>.remove_nested_one_fields,
+      &>.remove_nested_one_fields.active {
         display:block;
       }
-      
+
       border-left:5px solid $blue;
       padding-left:5px;
       fieldset {

--- a/app/views/rails_admin/main/_form_nested_one.html.haml
+++ b/app/views/rails_admin/main/_form_nested_one.html.haml
@@ -7,4 +7,8 @@
 - form.object.send("build_#{field.name}") unless form.object.send(field.name)
 .tab-content
   = form.fields_for field.name do |nested_form|
+    - if field.nested_form[:allow_destroy] && nested_form.object.persisted?
+      = link_to "javascript:void(0)", :class => 'remove_nested_one_fields btn btn-small btn-danger', :'data-toggle' => 'button', :title => I18n.t('admin.misc.remove') do
+        = content_tag :i, nil, :class => 'icon-white icon-trash'
+        = nested_form.hidden_field :_destroy, :id => nil
     = nested_form.generate({:action => :nested, :model_config => field.associated_model_config, :nested_in => field.name })


### PR DESCRIPTION
Re-pull request #1496.
Allows destroy has-one association in the edit form.
