### PR TITLE
Dashboard throws `ambiguous column name: updated_at`

### DIFF
--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -27,7 +27,7 @@ module RailsAdmin
                 @max = current_count > @max ? current_count : @max
                 @count[t.pretty_name] = current_count
                 if t.properties.find{|c| c[:name] == :updated_at }
-                  @most_recent_changes[t.pretty_name] = t.first(:sort => :updated_at).try(:updated_at)
+                  @most_recent_changes[t.pretty_name] = t.first(:sort => "#{t.table_name}.updated_at").try(:updated_at)
                 end
               end
             end


### PR DESCRIPTION
Using `default_scope` with joined tables causes `ambiguous column name: updated_at` in dashboard.

P.S. Sorry for not respecting the guidelines for this quick fix.
