### PR TITLE
Disable root for json output

### DIFF
--- a/lib/rails_admin/config/actions/index.rb
+++ b/lib/rails_admin/config/actions/index.rb
@@ -46,7 +46,7 @@ module RailsAdmin
                 if params[:send_data]
                   send_data output, :filename => "#{params[:model_name]}_#{DateTime.now.strftime("%Y-%m-%d_%Hh%Mm%S")}.json"
                 else
-                  render :json => output
+                  render :json => output, :root => false
                 end
               end
 


### PR DESCRIPTION
We had a specific issue in our project. When we're using active_model_serializers gem with rails_admin - it breaks some rails_admin functionality, because it includes "root" option to json output (by default). So when we're trying to fetch records for select field we get json with root set in "main" and then javascript function can't process this output correctly. So maybe it would be better to set root option to false by default? 
