### PR TITLE
Minor change to fix issue with number based enums

### DIFF
--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -126,7 +126,7 @@
               %td.other.left= link_to "...", @other_left_link, :class => 'pjax'
             - properties.map{ |property| property.bind(:object, object) }.each do |property|
               - value = property.pretty_value
-              %td{:class => "#{property.css_class} #{property.type_css_class}", :title => strip_tags(value)}= value
+              %td{:class => "#{property.css_class} #{property.type_css_class}", :title => strip_tags(value.to_s)}= value
             - if @other_right_link ||= other_right && index_path(params.merge(:set => (params[:set].to_i + 1)))
               %td.other.right= link_to "...", @other_right_link, :class => 'pjax'
             %td.last.links


### PR DESCRIPTION
Displaying a field populated with a non-string enum on index causes an "undefined method `empty?' for #:Fixnum" error.

See issue #1102
