### PR TITLE
Issue 1241

### DIFF
--- a/app/assets/javascripts/rails_admin/ui.coffee
+++ b/app/assets/javascripts/rails_admin/ui.coffee
@@ -68,3 +68,10 @@ $(document).on 'rails_admin.dom_ready', ->
     $(this).siblings('.control-group').hide()
 
   $(".table").tooltip selector: "th[rel=tooltip]"
+
+$(document).on 'click', '#fields_to_export label input#check_all', () ->
+  elems = $('#fields_to_export label input')
+  if $('#fields_to_export label input#check_all').is ':checked'
+    $(elems).prop('checked', true)
+  else
+    $(elems).prop('checked',false)

--- a/app/views/rails_admin/main/export.html.haml
+++ b/app/views/rails_admin/main/export.html.haml
@@ -9,7 +9,7 @@
       %div.controls
         %label.checkbox{:for => 'check_all'}
           = 'Select All Fields'
-          = check_box_tag 'all', 'all', true, { :id => 'check_all', :onclick => "var is_checked = jQuery('#check_all').prop('checked');var elems = jQuery('#fields_to_export label input');is_checked ? jQuery(elems).prop('checked', true) : jQuery(elems).prop('checked',false);"}	
+          = check_box_tag 'all', 'all', true, { :id => 'check_all' }	
     %legend
       %i.icon-chevron-down
       = t('admin.export.select')


### PR DESCRIPTION
Improves Pull Request #1302 because $.attr('checked') does not work for reading checked state of a checkbox.
I think this feature is necessary because for large models (de)selecting all fields needs lots of clicks, even when using the existing feature (clicking on the model/relation name).
