### PR TITLE
Allow adding HTML to  errors[:base] messages

### DIFF
--- a/app/views/layouts/rails_admin/pjax.html.haml
+++ b/app/views/layouts/rails_admin/pjax.html.haml
@@ -8,7 +8,7 @@
 - flash && flash.each do |key, value|
   .alert{:class => "alert-#{key}"}
     %a.close{:href => '#', :'data-dismiss' => "alert"}×
-    = value
+    = value.html_safe
 = breadcrumb
 %ul.nav.nav-tabs
   = menu_for((@abstract_model ? (@object.try(:persisted?) ? :member : :collection) : :root), @abstract_model, @object)


### PR DESCRIPTION
This will allow to use links in errors[:base] messages like this: 
errors[:base] << "Please fix this object first: <a href='/admin/channel/##{channel_id}/edit'>#{channel_name}</a>".html_safe

P.S. Simple adding .html_safe to the end of the message doesn't works
