### PR TITLE
Improve yell message specified role

### DIFF
--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -215,10 +215,28 @@ module RailsAdmin
 
         def editable?
           return false if @properties && @properties[:read_only]
-          active_model_attr_accessible = !bindings[:object].class.active_authorizer[bindings[:view].controller.send(:_attr_accessible_role)].deny?(self.method_name)
+          role = bindings[:view].controller.send(:_attr_accessible_role)
+          active_model_attr_accessible = !bindings[:object].class.active_authorizer[role].deny?(self.method_name)
+
           return true if active_model_attr_accessible
           if RailsAdmin::Config.yell_for_non_accessible_fields
-            Rails.logger.debug "\n\n[RailsAdmin] Please add 'attr_accessible :#{self.method_name}' in your '#{bindings[:object].class}' model definition if you want to make it editable.\nYou can also explicitely mark this field as read-only: \n\nconfig.model #{bindings[:object].class} do\n  field :#{self.name} do\n    read_only true\n  end\nend\n\nAdd 'config.yell_for_non_accessible_fields = false' in your 'rails_admin.rb' initializer if you do not want to see these warnings\n\n"
+            accessible = "attr_accessible :#{self.method_name}#{role == :default ? '' : ", :as => :#{role}"}"
+
+            Rails.logger.debug <<-MESSAGE.strip_heredoc
+
+
+            [RailsAdmin] Please add '#{accessible}' in your '#{bindings[:object].class}' model definition if you want to make it editable.
+            You can also explicitely mark this field as read-only:
+
+            config.model #{bindings[:object].class} do
+              field :#{self.name} do
+                read_only true
+              end
+            end
+
+            Add 'config.yell_for_non_accessible_fields = false' in your 'rails_admin.rb' initializer if you do not want to see these warnings
+
+            MESSAGE
           end
           false
         end

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -394,6 +394,18 @@ describe RailsAdmin::Config::Fields::Base do
       expect(editable).to be_false
     end
 
+    it "yells for non attr_accessible fields specified role if config.yell_for_non_accessible_fields is true" do
+      RailsAdmin.config do |config|
+        config.yell_for_non_accessible_fields = true
+        config.model FieldTest do
+          field :protected_field
+        end
+      end
+      Rails.logger.should_receive(:debug).with {|msg| msg =~ /Please add 'attr_accessible :protected_field, :as => :admin'/ }
+      editable = RailsAdmin.config(FieldTest).field(:protected_field).with(:object => FactoryGirl.create(:field_test), :view => double(:controller => double(:_attr_accessible_role => :admin))).editable?
+      expect(editable).to be_false
+    end
+
     it "does not yell for non attr_accessible fields if config.yell_for_non_accessible_fields is false" do
       RailsAdmin.config do |config|
         config.yell_for_non_accessible_fields = false


### PR DESCRIPTION
It is kindness for users what the message about `attr_accessible`
contains example about its role.
