### PR TITLE
Point carrierwave-mongoid and mongoid-grid_fs to master branches to reso...

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,9 +28,10 @@ group :active_record do
 end
 
 group :mongoid do
-  gem 'mongoid', '>= 3.0'
+  gem 'mongoid', github: 'mongoid/mongoid'
   gem 'mongoid-paperclip', '>= 0.0.8', :require => 'mongoid_paperclip'
-  gem 'carrierwave-mongoid', '>= 0.4', :require => 'carrierwave/mongoid'
+  gem 'mongoid-grid_fs', github: 'ahoward/mongoid-grid_fs'
+  gem 'carrierwave-mongoid', github: 'jnicklas/carrierwave-mongoid', :require => 'carrierwave/mongoid'
 end
 
 group :development do


### PR DESCRIPTION
...lve activemodel dependency error

When running `bundle install` I got the following error:

```
Bundler could not find compatible versions for gem "activemodel":
  In Gemfile:
    carrierwave-mongoid (>= 0.4) ruby depends on
      activemodel (~> 3.1) ruby

    rails_admin (>= 0) ruby depends on
      activemodel (4.0.0.beta1)
```

I did some research and figured out the solution was to point carrierwave-mongoid and mongoid-grid_fs to their master branches. carrierwave-mongoid has a recent update to support Rails 4, but it requires explicitly adding the mongoid-grid_fs dependency in the rails_admin Gemfile.

I'm not sure if anyone else is able to run `bundle install` without this fix on the rails 4 branch, but I wasn't able to.
