### PR TITLE
Rails 4: ActiveModel::Name is not a String anymore.

### DIFF
--- a/lib/generators/rails_admin/templates/initializer.erb
+++ b/lib/generators/rails_admin/templates/initializer.erb
@@ -57,7 +57,7 @@ RailsAdmin.config do |config|
 
   # config.model '<%= abstract_model.model.model_name %>' do
 
-  #   # You can copy this to a 'rails_admin do ... end' block inside your <%= abstract_model.model.model_name.underscore %>.rb model definition
+  #   # You can copy this to a 'rails_admin do ... end' block inside your <%= abstract_model.model.model_name.to_s.underscore %>.rb model definition
 
   #   # Found associations:
 

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -32,7 +32,7 @@ module RailsAdmin
             end
           end
         end
-        @@polymorphic_parents[adapter.to_sym][[model_name.underscore, name].join('_').to_sym]
+        @@polymorphic_parents[adapter.to_sym][[model_name.to_s.underscore, name].join('_').to_sym]
       end
 
       # For testing

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -56,7 +56,7 @@ module RailsAdmin
       end
 
       register_instance_option :label do
-        (@label ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human(:default => abstract_model.model.model_name.demodulize.underscore.humanize)
+        (@label ||= {})[::I18n.locale] ||= abstract_model.model.model_name.human
       end
 
       register_instance_option :label_plural do


### PR DESCRIPTION
This changes can be applied directly to `master`.
