### PR TITLE
Don't support models that aren't properly namespaced.

### DIFF
--- a/spec/dummy_app/app/active_record/cms/unscoped_page.rb
+++ b/spec/dummy_app/app/active_record/cms/unscoped_page.rb
@@ -1,3 +1,0 @@
-class UnscopedPage < ActiveRecord::Base
-
-end

--- a/spec/dummy_app/app/mongoid/cms/unscoped_page.rb
+++ b/spec/dummy_app/app/mongoid/cms/unscoped_page.rb
@@ -1,5 +1,0 @@
-class UnscopedPage
-  include Mongoid::Document
-  field :title, :type => String
-  include Mongoid::Timestamps
-end

--- a/spec/dummy_app/db/migrate/20111103174459_create_unscoped_pages.rb
+++ b/spec/dummy_app/db/migrate/20111103174459_create_unscoped_pages.rb
@@ -1,9 +1,0 @@
-class CreateUnscopedPages < ActiveRecord::Migration
-  def change
-    create_table :unscoped_pages do |t|
-      t.string :title
-
-      t.timestamps
-    end
-  end
-end


### PR DESCRIPTION
When running the specs, I got the following exception:

```
Circular dependency detected while autoloading constant Cms::UnscopedPage
```

I investigated, and this is what I found:
- Issue #770 asks for unconventionally-named models to be autoloaded. For example, `Product` can be defined in `app/models/some_subfolder/product.rb`.
- 854240f5c792dcd8615d6b7b2104be53b037b6f0 attempted to fix this issue.
- I don't think 854240f5c792dcd8615d6b7b2104be53b037b6f0 actually changed anything. With the added `UnscopedPage` model in `app/models/cms/unscoped_page.rb`, all specs passed before and after the change. Also, I manually checked to see that the return value of `all_models` didn't change before and after the fix.
- The reason for the exception with Rails 4 is this change in the ActiveSupport code: https://github.com/rails/rails/commit/b33700f5580b4cd85379a1dc60fa341ac4d8deb2. Somehow, `Cms::UnscopedPage` is trying to be loaded twice, and on the second time ActiveSupport throws an exception believing there to be a circular dependency. Cms::UnscopedPage doesn't exist but the file where it would be defined does exist.
- I think it was purely by chance that unconventionally-named models were autoloaded. With the Rails 4 change, it doesn't work.

**Bottom Line** I don't see a reason to support unconventionally-named models, so I got rid of `UnscopedPage`. There's a reason for conventions. At the very least, this issue can be returned to once rails_admin is fully working with Rails 4.

According to my count the number of failing specs is down to 19 now.
