### PR TITLE
Update bundle environment after devise is added

### DIFF
--- a/lib/generators/rails_admin/install_generator.rb
+++ b/lib/generators/rails_admin/install_generator.rb
@@ -27,6 +27,9 @@ module RailsAdmin
         display "Adding devise gem to your Gemfile:"
         append_file "Gemfile", "\n", :force => true
         gem 'devise'
+        Bundler.with_clean_env do
+          run "bundle install"
+        end
       else
         display "Found it!"
       end


### PR DESCRIPTION
This is a fix for issue #1380 

Since devise is not listed as a gem dependency, rails_admin will have problems installing when it's missing from the gemset.

Steps to reproduce issue:

```
gem uninstall devise
rails new Issue1380
cd Issue1380
echo 'gem "rails_admin"' >> Gemfile
bundle install
rails g rails_admin:install
```

This patch calls `bundle install` after devise is appended to the Gemfile. It will make the install process slower when devise is not listed, but results in a more stable install environment.
