### PR TITLE
Fixed issue with using numeric field types to store enums in postgres

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -123,7 +123,8 @@ module RailsAdmin
 
         fields.each do |field|
           field.searchable_columns.flatten.each do |column_infos|
-            statement, value1, value2 = build_statement(column_infos[:column], column_infos[:type], query, field.search_operator)
+            type = column_infos[:type] == :enum ? field.properties[:type] : column_infos[:type]
+            statement, value1, value2 = build_statement(column_infos[:column], type, query, field.search_operator)
             statements << statement if statement
             values << value1 unless value1.nil?
             values << value2 unless value2.nil?


### PR DESCRIPTION
If you are using PostgreSQL and have a DB column of type float to store an enum, an error will occur when using the search functionality. 

This is how the field is setup:

``` ruby
rails_admin do
  ...
  field :points, :enum do
    enum do
      [['10 pts', 10.0], ['20 pts', 20.0]]
    end
  end

end
```

And this is the error returned when running a query in the list view: `ActionView::Template::Error (PG::Error: ERROR:  invalid input syntax for type double precision: "query"`

It appears that the SQL that gets generated for the search assumes enums to be a string.

So this pull request changes the query builder to fallback to the database type for enum fields when constructing a query.
