### PR TITLE
Fix when newrelic_ignore is not present

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -8,7 +8,7 @@ module RailsAdmin
   end
 
   class ApplicationController < ::ApplicationController
-    newrelic_ignore if defined?(NewRelic)
+    newrelic_ignore if defined?(NewRelic) && respond_to?(:newrelic_ignore)
 
     before_filter :_authenticate!
     before_filter :_authorize!


### PR DESCRIPTION
If `newrelic_rpm` gem is included only in production environment, `newrelic_ignore` method is not available for development env.

Fixes https://github.com/sferik/rails_admin/issues/1502
