### PR TITLE
Switch from font-awesome-sass-rails to font-awesome-rails

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -1,5 +1,5 @@
 require 'bootstrap-sass'
-require 'font-awesome-sass-rails'
+require 'font-awesome-rails'
 require 'jquery-rails'
 require 'jquery-ui-rails'
 require 'kaminari'

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bootstrap-sass', '~> 2.2'
   spec.add_dependency 'builder', '~> 3.0'
   spec.add_dependency 'coffee-rails', '~> 3.1'
-  spec.add_dependency 'font-awesome-sass-rails', ['~> 3.0', '>= 3.0.0.1']
+  spec.add_dependency 'font-awesome-rails', ['~> 3.0']
   spec.add_dependency 'haml', '~> 4.0'
   spec.add_dependency 'jquery-rails', '~> 2.1'
   spec.add_dependency 'jquery-ui-rails', '~> 3.0'


### PR DESCRIPTION
- Font-Awesome dropped core sass support in
  3.1.x. font-awesome-sass-rails is stuck on 3.0 and is unlikely to be
  kept up to date
- The [font-awesome-rails](https://github.com/bokmann/font-awesome-rails) gem tracks Font-Awesome core very closely.
- font-awesome-rails gem works with Rails 4 and has a test suite
- font-awesome-rails works with sass imports just the same (though if you're using Rails 4, you'll need to track sass-rails master at the moment)

Closes #1651
