### PR TITLE
Fix ra.filtering-select.js ui.autocomplete implementation bug 

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filtering-select.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-select.js
@@ -72,7 +72,7 @@
                 // remove invalid value, as it didn't match anything
                 $(this).val(null);
                 select.html($('<option value="" selected="selected"></option>'));
-                input.data("autocomplete").term = "";
+                input.data("uiAutocomplete").term = "";
                 $(self.element.parents('.controls')[0]).find('.update').addClass('disabled');
                 return false;
               }
@@ -91,7 +91,7 @@
       if(select.attr('placeholder'))
         input.attr('placeholder', select.attr('placeholder'))
 
-      input.data("autocomplete")._renderItem = function(ul, item) {
+      input.data("uiAutocomplete")._renderItem = function(ul, item) {
         return $("<li></li>")
           .data("item.autocomplete", item)
           .append( $( "<a></a>" ).html( item.label || item.id ) )


### PR DESCRIPTION
I had a bug with the `ra.filtering-select.js` plugin which tried to call :

``` javascript
input.data("autocomplete")._renderItem = function(ul, item) { ... }
```

which lead to undefined method errors in javascript console.

By inspecting the `ui.autocomplete` behavior, I noticed the data field name may have been changed to `uiAutocomplete`

Changing the name of the data field in both `ra.filtering-select.js` calls worked so I thought submitting this patch could be useful.
