### PR TITLE
Allow nested polymorphic has_many associations

### DIFF
--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -44,7 +44,7 @@ module RailsAdmin
       if field.label
         # do not show nested field if the target is the origin
         unless field.inverse_of.presence && field.inverse_of == nested_in &&
-          @template.instance_variable_get(:@model_config).abstract_model == field.associated_model_config.abstract_model
+          @template.instance_variable_get(:@model_config).abstract_model == (field.associated_model_config.is_a?(Array) ? field.associated_model_config.first.abstract_model : field.associated_model_config.abstract_model)
           @template.content_tag(:div, :class => "control-group #{field.type_css_class} #{field.css_class} #{'error' if field.errors.present?}", :id => "#{dom_id(field)}_field") do
             label(field.method_name, field.label, :class => 'control-label') +
             (field.nested_form ? field_for(field) : input_for(field))


### PR DESCRIPTION
Allows nested field type to handle polymorphic has_many associations, thus fixing #1338.

The only problem was in the :inverse_of presence checking, where the FormBuilder tried to access `field.associated_model_config` without checking if it was a 1..1 or 1..N association.

I don't really know where to write my test for that, if someone can give me some insights on where to write it I'll be pleased to add it.

I wait for any advice to enhance this request.
