### PR TITLE
Fix "Uncaught TypeError" in ui.autocomplete. 

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filtering-select.js
+++ b/app/assets/javascripts/rails_admin/ra.filtering-select.js
@@ -91,9 +91,9 @@
       if(select.attr('placeholder'))
         input.attr('placeholder', select.attr('placeholder'))
 
-      input.data("autocomplete")._renderItem = function(ul, item) {
+      input.data("ui-autocomplete")._renderItem = function(ul, item) {
         return $("<li></li>")
-          .data("item.autocomplete", item)
+          .data("ui-autocomplete-item", item)
           .append( $( "<a></a>" ).html( item.label || item.id ) )
           .appendTo(ul);
       };


### PR DESCRIPTION
Because certain naming conventions relating to autocomplete have been removed in jQuery UI v1.10, the `autocomplete` data tag has been renamed to `ui-autocomplete`, and the `item.autocomplete` has been renamed to `ui-autocomplete-item`.

see: http://jqueryui.com/upgrade-guide/1.10/#autocomplete

and this question: http://stackoverflow.com/questions/9513251/cannot-set-property-renderitem-of-undefined-jquery-ui-autocomplete-with-html
