### PR TITLE
Fixed error when params passed into new

### DIFF
--- a/lib/rails_admin/config/actions/new.rb
+++ b/lib/rails_admin/config/actions/new.rb
@@ -23,7 +23,7 @@ module RailsAdmin
                 @object.send("#{name}=", value)
               end
               if object_params = params[@abstract_model.to_param]
-                @object.set_attributes(@object.attributes.merge(object_params), _attr_accessible_role)
+                @object.set_attributes(object_params, _attr_accessible_role)
               end
               respond_to do |format|
                 format.html { render @action.template_name }


### PR DESCRIPTION
Trying to pass parameters into a model's `new` action will currently fail if that model has any protected attributes.

This issue can be easily reproduced by visiting a link of the form `http://localhost:3000/rails_admin/some_model/new?some_model%5Bfoo%5D=bar` where `some_model` has protected attributes.

The previous implementation was trying to set the attributes using `@object.attributes.merge(object_params)`. Merging the params into the existing attributes isn't necessary because this is handled by `assign_attributes` anyway.

Any feedback welcomed!
