### PR TITLE
Excluding test.log from test_files

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.3.5'
   spec.signing_key = File.expand_path("~/.gem/private_key.pem") if $0 =~ /gem\z/
   spec.summary = %q{Admin for Rails}
-  spec.test_files = Dir['spec/**/*']
+  spec.test_files = Dir['spec/**/*'].reject {|f| f.end_with? "log"}
   spec.version = RailsAdmin::Version
 end


### PR DESCRIPTION
Since the test.log generated by the dummy_app isn't necessary to run the tests (and in `0.4.9` and `0.5.0` it makes the gem a whopping 60MB big), excluding it form the list of test files.
