### PR TITLE
Fixed wysihtml5 asset links (broken on Rails4)

### DIFF
--- a/lib/rails_admin/config/fields/types/wysihtml5.rb
+++ b/lib/rails_admin/config/fields/types/wysihtml5.rb
@@ -16,11 +16,11 @@ module RailsAdmin
           end
 
           register_instance_option :css_location do
-            '/assets/bootstrap-wysihtml5.css'
+            ActionController::Base.helpers.asset_path('bootstrap-wysihtml5.css')
           end
 
           register_instance_option :js_location do
-            '/assets/bootstrap-wysihtml5.js'
+            ActionController::Base.helpers.asset_path('bootstrap-wysihtml5.js')
           end
 
           register_instance_option :html_attributes do


### PR DESCRIPTION
Submitting pull request for wysihtml5, other types probably need a similar fix
