### PR TITLE
CodeMirror allow all config to be passed to JS from Ruby

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.widgets.coffee
+++ b/app/assets/javascripts/rails_admin/ra.widgets.coffee
@@ -176,7 +176,7 @@ $(document).on 'rails_admin.dom_ready', (e, content) ->
         textarea = this
         $.getScript options['locations']['mode'], (script, textStatus, jqXHR) ->
           $('head').append('<link href="' + options['locations']['theme'] + '" rel="stylesheet" media="all" type="text\/css">')
-          CodeMirror.fromTextArea(textarea,{mode:options['options']['mode'],theme:options['options']['theme']})
+          CodeMirror.fromTextArea(textarea,options['options'])
           $(textarea).addClass('codemirrored')
 
     array = content.find('[data-richtext=codemirror]').not('.codemirrored')


### PR DESCRIPTION
Pass all of the config keys to the JS widget to allow you to pass ANY codeMirror config that you would like not limited to theme and mode.

https://github.com/sferik/rails_admin/blob/master/lib/rails_admin/config/fields/types/code_mirror.rb#L12 exposes a config option that can be set on a per app level but ANY config option that is set is ignored.

This patch fixes that.
