### PR TITLE
Add ability to inherit custom fields from RailsAdmin::Config::Fields::Association

### DIFF
--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -19,8 +19,12 @@ module RailsAdmin
         # Register a custom field type if one is provided and it is different from
         # one found in default stack
         elsif !type.nil? && type != (field.nil? ? nil : field.type)
-          _fields.delete(field) unless field.nil?
-          properties = abstract_model.properties.find {|p| name == p[:name] }
+          if !field.nil?
+            properties = field.properties
+            _fields.delete(field)
+          else
+            properties = abstract_model.properties.find {|p| name == p[:name] }
+          end
           field = (_fields <<  RailsAdmin::Config::Fields::Types.load(type).new(self, name, properties)).last
         end
 


### PR DESCRIPTION
I'm writing new custom field for globalize3 integration and I noticed that you get `undefined method [] for nil:NilClass` error due to empty `@properties` variable that `association` method returns in `label` method:

``` ruby
register_instance_option :label do
  (@label ||= {})[::I18n.locale] ||= abstract_model.model.human_attribute_name association[:name]
end
```

`field.properties` instance variable is lost when rails_admin calls `configure` method inside edit block:

``` ruby
edit do
  configure :translations, :globalize3_tabs
end
```

`field` method is called inside `configure` method, which removes this field from `_fields` array (because its type hasn't been found in the default stack), and creates it again as my custom type.

In the process, it gets `properties` for this field from an `abstract_model.properties`, but it's `nil`, because it's not a abstract_model's property, but it's an association.
