### PR TITLE
Fixed config.attr_accessible_role not work

### DIFF
--- a/lib/rails_admin/adapters/active_record/abstract_object.rb
+++ b/lib/rails_admin/adapters/active_record/abstract_object.rb
@@ -15,8 +15,8 @@ module RailsAdmin
           self.object = object
         end
 
-        def set_attributes(attributes, role = nil)
-          object.assign_attributes(attributes, :as => role)
+        def set_attributes(attributes, options = {})
+          object.assign_attributes(attributes, options)
         end
 
         def save(options = { :validate => true })


### PR DESCRIPTION
`RailsAdmin.config.attr_accessible_role` actually does not work because we don't use it! Fixed ;)
