### PR TITLE
no reason to explicitly assign an id to a new object

### DIFF
--- a/app/views/rails_admin/main/new.html.haml
+++ b/app/views/rails_admin/main/new.html.haml
@@ -1,2 +1,2 @@
-= rails_admin_form_for @object, :url => new_path(:model_name => @abstract_model.to_param, :id => @object.id), :as => @abstract_model.param_key, :html => { :multipart => true, :class => "form-horizontal denser", :data => { :title => @page_name } } do |form|
+= rails_admin_form_for @object, :url => new_path(:model_name => @abstract_model.to_param), :as => @abstract_model.param_key, :html => { :multipart => true, :class => "form-horizontal denser", :data => { :title => @page_name } } do |form|
   = form.generate :action => :create


### PR DESCRIPTION
We found a bug when creating new records via the "new" form. Objects were not able to be saved because the id was already in the database. There's no need in Rails to explicitly set an id on create, and since it causes bugs, is there any reason not to remove it?
