### PR TITLE
Reproduce steps for breaking the view bindings after applying filter:

### DIFF
--- a/spec/dummy_app/config/initializers/rails_admin.rb
+++ b/spec/dummy_app/config/initializers/rails_admin.rb
@@ -5,4 +5,12 @@ RailsAdmin.config do |c|
     include_all_fields
     field :color, :color
   end
+
+  c.model User do
+    field :email do
+      pretty_value do
+        bindings[:view].tag(:a, { href: "#" }) << value
+      end
+    end
+  end
 end


### PR DESCRIPTION
Use dummy app from pull request
1. Go to /admin/user
2. Click filter's "Refresh" button
Emails are are not links anymore, but if you reload the page emails are links again.
I'm using chrome 29.0.1547.65

html source
before filter

``` html
<td class="email_field string_type" title="email@example.com">
  <a href="#">email@example.com</a>
</td>
```

after filter:

``` html
<td class="email_field string_type" title="email@example.com">
  <a href="#"></a>email@example.com
</td>
```

response of pjax filter is

``` html
<td class='email_field string_type' title='email@example.com'>
  <a href="#" />email@example.com
</td>
```
