### PR TITLE
js localization for filters

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.filter-box.js
+++ b/app/assets/javascripts/rails_admin/ra.filter-box.js
@@ -18,26 +18,26 @@
         case 'boolean':
           var control = '<select class="input-small" name="' + value_name + '">' +
             '<option value="_discard">...</option>' +
-            '<option value="true"' + (field_value == "true" ? 'selected="selected"' : '') + '>True</option>' +
-            '<option value="false"' + (field_value == "false" ? 'selected="selected"' : '') + '>False</option>' +
+            '<option value="true"' + (field_value == "true" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("true") + '</option>' +
+            '<option value="false"' + (field_value == "false" ? 'selected="selected"' : '') + '>' + RailsAdmin.I18n.t("false") + '</option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">Is present</option>' +
-            '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank"  >Is blank</option>' +
+            '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+            '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank"  >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
           '</select>';
           break;
         case 'date':
         case 'datetime':
         case 'timestamp':
           var control = '<select class="switch-additionnal-fieldsets input-small" name="' + operator_name + '">' +
-            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">Date ...</option>' +
-            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">Between ... and ...</option>' +
-            '<option ' + (field_operator == "today"   ? 'selected="selected"' : '') + ' value="today">Today</option>' +
-            '<option ' + (field_operator == "yesterday"   ? 'selected="selected"' : '') + ' value="yesterday">Yesterday</option>' +
-            '<option ' + (field_operator == "this_week"   ? 'selected="selected"' : '') + ' value="this_week">This week</option>' +
-            '<option ' + (field_operator == "last_week"   ? 'selected="selected"' : '') + ' value="last_week">Last week</option>' +
+            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("date") + '</option>' +
+            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("between_and_") + '</option>' +
+            '<option ' + (field_operator == "today"   ? 'selected="selected"' : '') + ' value="today">' + RailsAdmin.I18n.t("today") + '</option>' +
+            '<option ' + (field_operator == "yesterday"   ? 'selected="selected"' : '') + ' value="yesterday">' + RailsAdmin.I18n.t("yesterday") + '</option>' +
+            '<option ' + (field_operator == "this_week"   ? 'selected="selected"' : '') + ' value="this_week">' + RailsAdmin.I18n.t("this_week") + '</option>' +
+            '<option ' + (field_operator == "last_week"   ? 'selected="selected"' : '') + ' value="last_week">' + RailsAdmin.I18n.t("last_week") + '</option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">Is present</option>' +
-            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >Is blank</option>' +
+            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
           '</select>'
           var additional_control =
           '<input class="date additional-fieldset default input-small" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="text" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' +
@@ -48,8 +48,8 @@
           var multiple_values = ((field_value instanceof Array) ? true : false)
           var control = '<select style="display:' + (multiple_values ? 'none' : 'inline-block') + '" ' + (multiple_values ? '' : 'name="' + value_name + '"') + ' data-name="' + value_name + '" class="select-single input-small">' +
               '<option value="_discard">...</option>' +
-              '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">Is present</option>' +
-              '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank">Is blank</option>' +
+              '<option ' + (field_value == "_present" ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+              '<option ' + (field_value == "_blank"   ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
               '<option disabled="disabled">---------</option>' +
               field_options +
             '</select>' +
@@ -62,13 +62,13 @@
         case 'text':
         case 'belongs_to_association':
           var control = '<select class="switch-additionnal-fieldsets input-small" value="' + field_operator + '" name="' + operator_name + '">' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "like"        ? 'selected="selected"' : '') + ' value="like">Contains</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "is"          ? 'selected="selected"' : '') + ' value="is">Is exactly</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">Starts with</option>' +
-            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "ends_with"   ? 'selected="selected"' : '') + ' value="ends_with">Ends with</option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "like"        ? 'selected="selected"' : '') + ' value="like">' + RailsAdmin.I18n.t("contains") + '</option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "is"          ? 'selected="selected"' : '') + ' value="is">' + RailsAdmin.I18n.t("is_exactly") + '</option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "starts_with" ? 'selected="selected"' : '') + ' value="starts_with">' + RailsAdmin.I18n.t("starts_with") + '</option>' +
+            '<option data-additional-fieldset="additional-fieldset"'  + (field_operator == "ends_with"   ? 'selected="selected"' : '') + ' value="ends_with">' + RailsAdmin.I18n.t("ends_with") + '</option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_present"    ? 'selected="selected"' : '') + ' value="_present">Is present</option>' +
-            '<option ' + (field_operator == "_blank"      ? 'selected="selected"' : '') + ' value="_blank">Is blank</option>' +
+            '<option ' + (field_operator == "_present"    ? 'selected="selected"' : '') + ' value="_present">' + RailsAdmin.I18n.t("is_present") + '</option>' +
+            '<option ' + (field_operator == "_blank"      ? 'selected="selected"' : '') + ' value="_blank">' + RailsAdmin.I18n.t("is_blank") + '</option>' +
           '</select>'
           var additional_control = '<input class="additional-fieldset input-small" style="display:' + (field_operator == "_blank" || field_operator == "_present" ? 'none' : 'inline-block') + ';" type="text" name="' + value_name + '" value="' + field_value + '" /> ';
           break;
@@ -76,11 +76,11 @@
         case 'decimal':
         case 'float':
           var control = '<select class="switch-additionnal-fieldsets input-small" name="' + operator_name + '">' +
-            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">Number ...</option>' +
-            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">Between ... and ...</option>' +
+            '<option ' + (field_operator == "default"   ? 'selected="selected"' : '') + ' data-additional-fieldset="default" value="default">' + RailsAdmin.I18n.t("Number ...") + '</option>' +
+            '<option ' + (field_operator == "between"   ? 'selected="selected"' : '') + ' data-additional-fieldset="between" value="between">' + RailsAdmin.I18n.t("Between ... and ...") + '</option>' +
             '<option disabled="disabled">---------</option>' +
-            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">Is present</option>' +
-            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >Is blank</option>' +
+            '<option ' + (field_operator == "_not_null" ? 'selected="selected"' : '') + ' value="_not_null">' + RailsAdmin.I18n.t("is_present") +'</option>' +
+            '<option ' + (field_operator == "_null"     ? 'selected="selected"' : '') + ' value="_null" >' + RailsAdmin.I18n.t("is_blank") + '</option>' +
           '</select>'
           var additional_control =
           '<input class="additional-fieldset default input-small" style="display:' + ((!field_operator || field_operator == "default") ? 'inline-block' : 'none') + ';" type="' + field_type + '" name="' + value_name + '[]" value="' + (field_value[0] || '') + '" /> ' +

--- a/app/assets/javascripts/rails_admin/ra.i18n.coffee
+++ b/app/assets/javascripts/rails_admin/ra.i18n.coffee
@@ -1,0 +1,6 @@
+class @RailsAdmin
+@RailsAdmin.I18n = class Locale
+  @init: (@locale)->
+  @t:(key) ->
+    humanize = key.charAt(0).toUpperCase() + key.replace("_", " ").slice(1)
+    @locale[key] || humanize

--- a/app/assets/javascripts/rails_admin/rails_admin.js
+++ b/app/assets/javascripts/rails_admin/rails_admin.js
@@ -15,6 +15,7 @@
 //=  require 'rails_admin/jquery.pjax'
 //=  require 'jquery_nested_form'
 //=  require 'rails_admin/ra.nested-form-hooks'
+//=  require 'rails_admin/ra.i18n'
 //=  require 'bootstrap'
 //=  require 'rails_admin/ra.widgets'
 //=  require 'rails_admin/ui'

--- a/app/views/layouts/rails_admin/application.html.haml
+++ b/app/views/layouts/rails_admin/application.html.haml
@@ -6,6 +6,10 @@
     = csrf_meta_tag
     = stylesheet_link_tag "rails_admin/rails_admin.css", :media => :all
     = javascript_include_tag "rails_admin/rails_admin.js"
+    = javascript_include_tag "rails_admin/ra.i18n.js"
+    -# Initialize JS simple i18n
+    :javascript
+      RailsAdmin.I18n.init(JSON.parse("#{j I18n.t("admin.js").to_json}"))
   %body.rails_admin
     #loading.label.label-warning{:style => 'display:none; position:fixed; right:20px; bottom:20px; z-index:100000'}= t('admin.loading')
     .navbar.navbar-fixed-top

--- a/config/locales/rails_admin.en.yml
+++ b/config/locales/rails_admin.en.yml
@@ -1,5 +1,21 @@
 en:
   admin:
+    js:
+      true: True
+      false: False
+      is_present: Is present
+      is_blank: Is blank
+      date: Date ...
+      between_and_: Between ... and ...
+      today: Today
+      yesterday: Yesterday
+      this_week: This week
+      last_week: Last week
+      number: Number ...
+      contains: Contains
+      is_exactly: Is exactly
+      starts_with: Starts with
+      ends_with: Ends with
     loading: "Loading..."
     home:
       name: "Home"


### PR DESCRIPTION
I create specific coffeescript class for translating js. It's take translation from locale.yml file from "admin.js" translations. Now you can add your custom translations to this file and it will be able in RailsAdmin.I18n.t("key") method. For example i translate select options for filtering. 
