### PR TITLE
added ra.i18n.js to the precompile list because it is being included in a javascript include tag

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -17,7 +17,7 @@ module RailsAdmin
   class Engine < Rails::Engine
     isolate_namespace RailsAdmin
     initializer "RailsAdmin precompile hook", :group => :all do |app|
-      app.config.assets.precompile += ['rails_admin/rails_admin.js', 'rails_admin/rails_admin.css', 'rails_admin/jquery.colorpicker.js', 'rails_admin/jquery.colorpicker.css']
+      app.config.assets.precompile += ['rails_admin/rails_admin.js', 'rails_admin/ra.i18n.js', 'rails_admin/rails_admin.css', 'rails_admin/jquery.colorpicker.js', 'rails_admin/jquery.colorpicker.css']
     end
 
     initializer "RailsAdmin pjax hook" do |app|


### PR DESCRIPTION
I noticed after upgrading to the latest version I was getting a JS include error:

```
GET https://d2x5gy2xai3ykv.cloudfront.net/javascripts/rails_admin/ra.i18n.js 403 (Forbidden) 
```

On inspection I was seeing the tags look like this:

```
<link href="https://d2x5gy2xai3ykv.cloudfront.net/assets/rails_admin/rails_admin-9c0ee978c98cd0a5c14cf623c8e615f3.css" media="all" rel="stylesheet" />
<script src="https://d2x5gy2xai3ykv.cloudfront.net/assets/rails_admin/rails_admin-b906bdb9c658f8fbe44f4ea9f201d493.js"></script>
<script src="https://d2x5gy2xai3ykv.cloudfront.net/javascripts/rails_admin/ra.i18n.js"></script>
```

After adding the ra.i18n.js to the precompile list the error went away
