### PR TITLE
Added compability for Font-Awesome 4

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/font-awesome-4-compability.scss
+++ b/app/assets/stylesheets/rails_admin/base/font-awesome-4-compability.scss
@@ -1,0 +1,58 @@
+[class^="icon-"]{
+  @extend .fa;
+}
+.icon-info-sign{
+  @extend .fa-info-circle;
+}
+.icon-plus{
+  @extend .fa-plus;
+}
+.icon-minus{
+  @extend .fa-minus;
+}
+.icon-trash{
+  @extend .fa-trash-o;
+}
+.icon-chevron-right{
+  @extend .fa-chevron-right;
+}
+.icon-chevron-down{
+  @extend .fa-chevron-down;
+}
+.icon-check{
+  @extend .fa-check-square-o;
+}
+.icon-pencil{
+  @extend .fa-pencil;
+}
+.icon-ok{
+  @extend .fa-check;
+}
+.icon-remove{
+  //fa 4 dose'nt have none of cross, remove, delete
+  @extend .fa-times;
+}
+.icon-refresh{
+  @extend .fa-refresh;
+}
+.icon-question-sign{
+  @extend .fa-question-circle;
+}
+.icon-home{
+  @extend .fa-home;
+}
+.icon-share{
+  @extend .fa-share-square-o;
+}
+.icon-book{
+  @extend .fa-book;
+}
+.icon-th-list{
+  @extend .fa-th-list;
+}
+.icon-eye-open{
+  @extend .fa-eye;
+}
+.icon-white{
+  color:white;
+}

--- a/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
+++ b/app/assets/stylesheets/rails_admin/rails_admin.scss.erb
@@ -32,6 +32,7 @@
 /*** Font-awesome ***/
 
 @import 'font-awesome';
+@import 'rails_admin/base/font-awesome-4-compability';
 
 /***  Bootstrap Theming  ***/
 

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -8,7 +8,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bootstrap-sass', '~> 2.3'
   spec.add_dependency 'builder', '~> 3.1'
   spec.add_dependency 'coffee-rails', '~> 4.0'
-  spec.add_dependency 'font-awesome-rails', '~> 3.0'
+  spec.add_dependency 'font-awesome-rails', '>= 3.0'
   spec.add_dependency 'haml', '~> 4.0'
   spec.add_dependency 'jquery-rails', '~> 3.0'
   spec.add_dependency 'jquery-ui-rails', '~> 4.0'


### PR DESCRIPTION
Font awesome 4 introduced a new naming convention.
I did'nt use new naming convention because:
- It's backward incompatible and people still use old version of Font-Awesome
- rails_admin use old naming convention(icon-*) in javascripts.

I added a new scss file which add compability for Font-Awsome 4 uwing extend.
