### PR TITLE
fix typo in _dashboard_history i18n key

### DIFF
--- a/app/views/rails_admin/main/_dashboard_history.html.haml
+++ b/app/views/rails_admin/main/_dashboard_history.html.haml
@@ -2,7 +2,7 @@
   %thead
     %tr
       %th.shrink.user= t("admin.table_headers.username")
-      %th.shrink.items= t("admin.table_headers.items")
+      %th.shrink.items= t("admin.table_headers.item")
       %th.changes= t("admin.table_headers.changes")
   %tbody
     - @history.each do |t|


### PR DESCRIPTION
the existing key is in singular. also in dashboard `item` is used
