### PR TITLE
Auto generated migration file not needed if you already have an admin us...

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ See [#715](https://github.com/sferik/rails_admin/issues/715) for more details.
 
 It will also add an intializer that will help you getting started. (head for config/initializers/rails_admin.rb)
 
+Note: If you already have an admin user class generated with Devise, be sure to delete the migration file add_fields_to_admin that's automatically generated when you installed rails_admin. Do that before proceeding with the next step of migrating your database.
+
 Finally run:
 
     bundle exec rake db:migrate


### PR DESCRIPTION
...er class with Devise

For those who have an Devise admin user class already, you want to let people know that they need to delete the auto generated migration file which adds fields to your admin table before doing the migration.
