### PR TITLE
Show a configurable list of model scopes in list view

### DIFF
--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -99,6 +99,13 @@
       - if export_action
         %span{:style => 'float:right'}= link_to wording_for(:link, export_action), export_path(params.except('set').except('page')), :class => 'btn btn-info'
 
+  - unless @model_config.list.scopes.empty?
+    %ul.nav.nav-tabs#scope_selector
+      - @model_config.list.scopes.each_with_index do |scope, index|
+        - scope = '_all' if scope.nil?
+        %li{class: "#{'active' if scope.to_s == params[:scope] || (params[:scope].blank? && index == 0)}"}
+          %a{href: index_path(params.merge(:scope => scope, :page => nil))}= I18n.t("admin.scopes.#{@abstract_model.to_param}.#{scope}", :default => I18n.t("admin.scopes.#{scope}", :default => scope.to_s.titleize))
+
   = form_tag bulk_action_path(:model_name => @abstract_model.to_param), :method => :post, :id => "bulk_form", :class => "form" do
     = hidden_field_tag :bulk_action
     %table.table.table-condensed.table-striped

--- a/lib/rails_admin/config/actions/index.rb
+++ b/lib/rails_admin/config/actions/index.rb
@@ -29,6 +29,16 @@ module RailsAdmin
           Proc.new do
             @objects ||= list_entries
 
+            unless @model_config.list.scopes.empty?
+              if params[:scope].blank?
+                unless @model_config.list.scopes.first.nil?
+                  @objects = @objects.send(@model_config.list.scopes.first)
+                end
+              elsif @model_config.list.scopes.map(&:to_s).include?(params[:scope])
+                @objects = @objects.send(params[:scope].to_sym)
+              end
+            end
+
             respond_to do |format|
 
               format.html do

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -21,6 +21,10 @@ module RailsAdmin
         register_instance_option :sort_reverse? do
           true # By default show latest first
         end
+
+        register_instance_option :scopes do
+          []
+        end
       end
     end
   end

--- a/spec/dummy_app/app/active_record/team.rb
+++ b/spec/dummy_app/app/active_record/team.rb
@@ -22,4 +22,8 @@ class Team < ActiveRecord::Base
   def color_enum
     ['white', 'black', 'red', 'green', 'blu<e>é']
   end
+  
+  scope :green, -> { where(color: 'red') }
+  scope :red, -> { where(color: 'red') }
+  scope :white, -> { where(color: 'white') }
 end

--- a/spec/dummy_app/app/mongoid/team.rb
+++ b/spec/dummy_app/app/mongoid/team.rb
@@ -42,4 +42,8 @@ class Team
   def color_enum
     ['white', 'black', 'red', 'green', 'blu<e>é']
   end
+  
+  scope :green, -> { where(color: 'red') }
+  scope :red, -> { where(color: 'red') }
+  scope :white, -> { where(color: 'white') }
 end


### PR DESCRIPTION
This allows to display a configurable scoped list view.

Use cases: order state in ecommerce, list of new models that need to be moderated, etc
## Usage:

```
list do
  scopes [:not_cart, :cart, nil]
end
```

First will be the default, nil means no scope (also it is possible to disable non-scoped index)
## How it is displayed

![w64](https://f.cloud.github.com/assets/1041407/1712639/248c4ebe-6179-11e3-9ef0-6c63f3c5386d.png)

When no scopes are configured, tabs are not shown.

I18n key is admin.scopes.scope name
