### PR TITLE
adds Mongoid geospatial points to list of disabled columns

### DIFF
--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -6,7 +6,7 @@ module RailsAdmin
   module Adapters
     module Mongoid
       STRING_TYPE_COLUMN_NAMES = [:name, :title, :subject]
-      DISABLED_COLUMN_TYPES = ['Range', 'Moped::BSON::Binary', "BSON::Binary"]
+      DISABLED_COLUMN_TYPES = ['Range', 'Moped::BSON::Binary', "BSON::Binary", "Mongoid::Geospatial::Point"]
       ObjectId = defined?(Moped::BSON) ? Moped::BSON::ObjectId : BSON::ObjectId
 
 


### PR DESCRIPTION
cf. https://github.com/sferik/rails_admin/issues/1531

(for use with this gem: https://github.com/kristianmandrup/mongoid_geospatial)
