### PR TITLE
convert object_label to string

### DIFF
--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -77,7 +77,7 @@ module RailsAdmin
       else
         object.send(model_config.object_label_method).presence || "#{model_config.label} ##{object.id}"
       end
-      %{<span style="display:none" class="object-infos" data-model-label="#{model_label}" data-object-label="#{CGI.escapeHTML(object_label)}"></span>}.html_safe
+      %{<span style="display:none" class="object-infos" data-model-label="#{model_label}" data-object-label="#{CGI.escapeHTML(object_label.to_s)}"></span>}.html_safe
     end
 
     def jquery_namespace(field)


### PR DESCRIPTION
Will exception If object have label as id
For example i have 2 models

class Product < ActiveRecord::Base
  has_many :photos, dependent: :destroy
  accepts_nested_attributes_for :photos, allow_destroy: true
  .....

class Photo
  belongs_to :product
  ....

model Photo have only two attributes: id, image
We get the following exception when open editing Product model

undefined method `gsub' for 1:Fixnum
