### PR TITLE
Modify history feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ RailsAdmin is a Rails engine that provides an easy-to-use interface for managing
 * Export data to CSV/JSON/XML
 * Authentication (via [Devise](https://github.com/plataformatec/devise) or other)
 * Authorization (via [Cancan](https://github.com/ryanb/cancan))
-* User action history (internally or via [PaperTrail](https://github.com/airblade/paper_trail))
+* User action history (via [PaperTrail](https://github.com/airblade/paper_trail))
 * Supported ORMs
   * ActiveRecord
   * Mongoid


### PR DESCRIPTION
Because internal history feature is deprecated. 1aed17d05b6d83f238354e000e5806e2195bf3b8
