### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,14 @@
 [![Dependency Status](https://img.shields.io/gemnasium/sferik/rails_admin.svg)][gemnasium]
 [![Code Climate](https://img.shields.io/codeclimate/github/sferik/rails_admin.svg)][codeclimate]
 [![Coverage Status](https://img.shields.io/coveralls/sferik/rails_admin.svg)][coveralls]
+[![Inline docs](http://inch-ci.org/github/sferik/rails_admin.svg)][inch]
 
 [gem]: https://rubygems.org/gems/rails_admin
 [travis]: http://travis-ci.org/sferik/rails_admin
 [gemnasium]: https://gemnasium.com/sferik/rails_admin
 [codeclimate]: https://codeclimate.com/github/sferik/rails_admin
 [coveralls]: https://coveralls.io/r/sferik/rails_admin
+[inch]: http://inch-ci.org/github/sferik/rails_admin
 
 RailsAdmin is a Rails engine that provides an easy-to-use interface for managing your data.
 


### PR DESCRIPTION
Hi Erik,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/sferik/rails_admin.png)](http://inch-pages.github.io/github/sferik/rails_admin)

It links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for RailsAdmin is http://inch-pages.github.io/github/sferik/rails_admin/

Inch Pages is still in it's infancy, but already used by projects like [Reek](https://github.com/troessner/reek) and [libnotify](https://github.com/splattael/libnotify).

What do you think? :man:

EDIT: Typos
