### PR TITLE
fixed error for viable_models method

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -314,7 +314,7 @@ module RailsAdmin
                   end
                 end
               end
-            end.reject { |m| m.starts_with?('Concerns::') } # rubocop:disable MultilineBlockChain
+            end.flatten.reject { |m| m.starts_with?('Concerns::') } # rubocop:disable MultilineBlockChain
           )
       end
 


### PR DESCRIPTION
there are three nested levels
and the `m` in reject block is an array
which will throw `NoMethodError` for
undefined method `starts_with?' for #Array:0x007fc424a31a98
