### PR TITLE
added includes method to enable explicit join with associated tables

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -110,9 +110,13 @@ module RailsAdmin
         end
 
         def build
-          scope = @scope.where(@statements.join(' OR '), *@values)
-          scope = scope.references(*(@tables.uniq)) if @tables.any?
-          scope
+          join_tables = @tables.uniq
+          join_tables.delete(@scope.name.tableize) # exclude the scope table itself
+          if join_tables.any?
+            @scope.includes(*join_tables).where(@statements.join(' OR '), *@values).references(*join_tables)
+          else
+            @scope.where(@statements.join(' OR '), *@values)
+          end
         end
       end
 


### PR DESCRIPTION
added `includes(*join_tables)` to include the associated tables explicitly because `references` doesn't know whether the associated tables are being loaded.

otherwise, a ERROR will be thrown for undefined tables. For example

```
class Person
    has_many :phone_numbers

   rails_admin do
     configure :phone_numbers, :has_many_association
     list do
      field :phone_numbers do
        searchable ['phone_numbers.number']
      end
     end
   end
end
```

will throw an error

```
`SELECT  "people".* FROM "people"  WHERE ((LOWER(phone_numbers.location) ILIKE '%13%'))  ORDER BY people.id desc LIMIT 20 OFFSET 0`
```
