### PR TITLE
Use AR::Base.connection instead of database_configuration

### DIFF
--- a/app/views/rails_admin/main/export.html.haml
+++ b/app/views/rails_admin/main/export.html.haml
@@ -47,7 +47,7 @@
       %i.icon-chevron-down
       = t('admin.export.options_for', name: 'csv')
     .control-group
-      - guessed_encoding = (Rails.configuration.database_configuration[Rails.env]['encoding'].presence rescue 'UTF-8') || 'UTF-8'
+      - guessed_encoding = @abstract_model.encoding
       %label.control-label{for: "csv_options_encoding_to"}= t('admin.export.csv.encoding_to')
       .controls
         -# from http://books.google.com/support/partner/bin/answer.py?answer=30990 :

--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -73,7 +73,9 @@ module RailsAdmin
       delegate :primary_key, :table_name, to: :model, prefix: false
 
       def encoding
-        Rails.configuration.database_configuration[Rails.env]['encoding']
+        encoding = ::ActiveRecord::Base.connection.try(:encoding)
+        encoding ||= ::ActiveRecord::Base.connection.try(:charset) # mysql2
+        encoding || 'UTF-8'
       end
 
       def embedded?
@@ -297,7 +299,7 @@ module RailsAdmin
         end
 
         def ar_adapter
-          Rails.configuration.database_configuration[Rails.env]['adapter']
+          ::ActiveRecord::Base.connection.adapter_name.downcase
         end
 
         def like_operator

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -275,7 +275,21 @@ describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
         collect { |h| FactoryGirl.create :team, h }
     end
 
-    it 'makes conrrect query' do
+    context 'without configuration' do
+      before do
+        Rails.configuration.stub(:database_configuration) { nil }
+      end
+
+      after do
+        Rails.configuration.unstub(:database_configuration)
+      end
+
+      it 'does not raise error' do
+        expect { @abstract_model.all(filters: {'name' => {'0000' => {o: 'like', v: 'foo'}}}) }.to_not raise_error
+      end
+    end
+
+    it 'makes correct query' do
       expect(@abstract_model.all(filters: {'name' => {'0000' => {o: 'like', v: 'foo'}}, 'division' => {'0001' => {o: 'like', v: 'bar'}}}, include: :division)).to eq([@teams[2]])
     end
   end


### PR DESCRIPTION
Sometimes the `database.yml` configuration isn't avaliable for a given environment. 
For example heroku uses a environment variable called DATABASE_URL, instead of `production: ...` in `database.yml`. This PR changes the occurrences of `Rails.configuration.database_configuration` to `ActiveRecord::Base.connection`.

Closes #1579
