### PR TITLE
Fix disabling of array column type in AR adapter

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -5,7 +5,6 @@ module RailsAdmin
   module Adapters
     module ActiveRecord
       DISABLED_COLUMN_TYPES = [:tsvector, :blob, :binary, :spatial, :hstore, :geometry]
-      DISABLED_COLUMN_MATCHERS = [/_array$/]
 
       def new(params = {})
         AbstractObject.new(model.new(params))
@@ -57,7 +56,7 @@ module RailsAdmin
         columns = model.columns.reject do |c|
           c.type.blank? ||
             DISABLED_COLUMN_TYPES.include?(c.type.to_sym) ||
-            DISABLED_COLUMN_MATCHERS.any? { |matcher| matcher.match(c.type.to_s) }
+            c.try(:array)
         end
         columns.collect do |property|
           Property.new(property, model)


### PR DESCRIPTION
Previously column types that matched `_array` were disabled as a Postgres specific workaround. ActiveRecord stopped using those column type names though.

Now a text array, for example, has column type of `text` and the `array` boolean attribute set to `true`. Instead of using the `DISABLED_COLUMN_MATCHERS`, we're now checking the `array` attribute.

Here's an example of a model's array column:

```
#<ActiveRecord::ConnectionAdapters::PostgreSQLColumn:0x007fd542a81af0
  @array=true,
  @coder=nil,
  @default=[],
  @default_function=nil,
  @limit=nil,
  @name="alternate_titles",
  @null=false,
  @oid_type=
   #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::Array:0x007fd542b52628
    @subtype=
     #<ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::OID::Identity:0x007fd5424a2aa8>>,
  @precision=nil,
  @primary=false,
  @scale=nil,
  @sql_type="text",
  @type=:text>
```

You can see `@array=true` and  `@type=:text`.

I know this has previously been brought up (#1919, #1222, etc) which you've dismissed because you don't want RDBMS specific features, but this code is already in rails_admin it just doesn't work.
