### PR TITLE
Hide association input for deeply nested fields

### DIFF
--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -33,8 +33,7 @@ module RailsAdmin
     def field_wrapper_for(field, nested_in)
       if field.label
         # do not show nested field if the target is the origin
-        unless field.inverse_of.presence && field.inverse_of == nested_in &&
-          @template.instance_variable_get(:@model_config).abstract_model == field.associated_model_config.abstract_model
+        unless nested_field_association?(field, nested_in)
           @template.content_tag(:div, class: "control-group #{field.type_css_class} #{field.css_class} #{'error' if field.errors.present?}", id: "#{dom_id(field)}_field") do
             label(field.method_name, field.label, class: 'control-label') +
             (field.nested_form ? field_for(field) : input_for(field))
@@ -126,6 +125,14 @@ module RailsAdmin
       ensure
         ::ActionView::Base.field_error_proc = default_field_error_proc
       end
+    end
+
+  private
+
+    def nested_field_association?(field, nested_in)
+      field.inverse_of.presence && nested_in.presence && field.inverse_of == nested_in.name &&
+        (@template.instance_variable_get(:@model_config).abstract_model == field.associated_model_config.abstract_model ||
+         field.name == nested_in.inverse_of)
     end
   end
 end

--- a/app/views/rails_admin/main/_form_nested_many.html.haml
+++ b/app/views/rails_admin/main/_form_nested_many.html.haml
@@ -11,4 +11,4 @@
   = form.fields_for field.name do |nested_form|
     - if field.nested_form[:allow_destroy] || nested_form.options[:child_index] == "new_#{field.name}"
       = nested_form.link_to_remove '<span class="btn btn-small btn-danger"><i class="icon-trash icon-white"></i></span>'.html_safe
-    = nested_form.generate({action: :nested, model_config: field.associated_model_config, nested_in: field.name })
+    = nested_form.generate({action: :nested, model_config: field.associated_model_config, nested_in: field })

--- a/spec/dummy_app/app/active_record/deeply_nested_field_test.rb
+++ b/spec/dummy_app/app/active_record/deeply_nested_field_test.rb
@@ -1,0 +1,3 @@
+class DeeplyNestedFieldTest < ActiveRecord::Base
+  belongs_to :nested_field_test, inverse_of: :deeply_nested_field_tests
+end

--- a/spec/dummy_app/app/active_record/nested_field_test.rb
+++ b/spec/dummy_app/app/active_record/nested_field_test.rb
@@ -2,5 +2,7 @@ class NestedFieldTest < ActiveRecord::Base
   belongs_to :field_test, inverse_of: :nested_field_tests
   belongs_to :another_field_test, inverse_of: :nested_field_tests
   has_one :comment, as: :commentable
+  has_many :deeply_nested_field_tests, inverse_of: :nested_field_test
   accepts_nested_attributes_for :comment, allow_destroy: true, reject_if: proc { |attributes| attributes['content'].blank? }
+  accepts_nested_attributes_for :deeply_nested_field_tests, allow_destroy: true
 end

--- a/spec/dummy_app/app/mongoid/deeply_nested_field_test.rb
+++ b/spec/dummy_app/app/mongoid/deeply_nested_field_test.rb
@@ -1,0 +1,7 @@
+class DeeplyNestedFieldTest
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :title, type: String
+  belongs_to :nested_field_test, inverse_of: :deeply_nested_field_tests
+end

--- a/spec/dummy_app/app/mongoid/nested_field_test.rb
+++ b/spec/dummy_app/app/mongoid/nested_field_test.rb
@@ -6,6 +6,8 @@ class NestedFieldTest
   belongs_to :another_field_test, inverse_of: :nested_field_tests
   include Mongoid::Timestamps
 
+  has_many :deeply_nested_field_tests, inverse_of: :nested_field_test
+  accepts_nested_attributes_for :deeply_nested_field_tests, allow_destroy: true
   has_one :comment, as: :commentable, autosave: true
   accepts_nested_attributes_for :comment, allow_destroy: true, reject_if: proc { |attributes| attributes['content'].blank? }
 end

--- a/spec/dummy_app/db/migrate/20140412075608_create_deeply_nested_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20140412075608_create_deeply_nested_field_tests.rb
@@ -1,0 +1,9 @@
+class CreateDeeplyNestedFieldTests < ActiveRecord::Migration
+  def change
+    create_table :deeply_nested_field_tests do |t|
+      t.belongs_to :nested_field_test
+      t.string :title
+      t.timestamps
+    end
+  end
+end

--- a/spec/integration/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/integration/config/edit/rails_admin_config_edit_spec.rb
@@ -751,6 +751,13 @@ describe 'RailsAdmin Config DSL Edit Section' do
         expect(find('div#nested_field_tests_fields_blueprint', visible: false)[:'data-blueprint']).to match(
           /<select[^>]* id="field_test_nested_field_tests_attributes_new_nested_field_tests_another_field_test_id"[^>]*>/)
       end
+
+      it 'hides fields that are deeply nested with inverse_of' do
+        visit new_path(model_name: 'field_test')
+        expect(page.body).to_not include('field_test_nested_field_tests_attributes_new_nested_field_tests_deeply_nested_field_tests_attributes_new_deeply_nested_field_tests_nested_field_test_id_field')
+        expect(page.body).to include('field_test_nested_field_tests_attributes_new_nested_field_tests_deeply_nested_field_tests_attributes_new_deeply_nested_field_tests_title')
+      end
+
     end
   end
 


### PR DESCRIPTION
This allows deeply nested fields to behave the same as nested fields  in a form. If there's an inverse_of option on the association, do not show the association input in the nested field.

Here's an example:

```
class Field
  has_many :nested_fields, inverse_of: :field
  accepts_nested_attributes_for :nested_fields
end

class NestedField
  belongs_to :field, inverse_of: :nested_field
  has_many :deeply_nested_fields, inverse_of: :nested_field
  accepts_nested_attributes_for :deeply_nested_fields
end

class DeeplyNestedField
  belongs_to :nested_field, inverse_of: :deeply_nested_field
end
```

In the past, on the form for field, you could add nested fields and deeply nested fields.  However, the nested form for nested fields would not show the input option for field, but the deeply nested form for deeply nested fields would show the input option for nested fields.  This pull request fixes the latter case so that it automatically sets the nested field on the deeply nested field and does not show the input.
