### PR TITLE
Fix inverse of check related to nested fields

### DIFF
--- a/app/views/rails_admin/main/_form_nested_one.html.haml
+++ b/app/views/rails_admin/main/_form_nested_one.html.haml
@@ -14,4 +14,4 @@
   = form.fields_for field.name do |nested_form|
     - if field.nested_form[:allow_destroy]
       = nested_form.link_to_remove '<span class="btn btn-small btn-danger"><i class="icon-trash icon-white"></i></span>'.html_safe
-    = nested_form.generate({action: :nested, model_config: field.associated_model_config, nested_in: field.name })
+    = nested_form.generate({action: :nested, model_config: field.associated_model_config, nested_in: field })


### PR DESCRIPTION
This fixes the bug I introduced in #1962.

That pull request did not make the necessary change for the view partial for has_one/belongs_to associations with inverse_of and as a result, there's currently an error with those associations.
