### PR TITLE
Fix Twitter Bootstrap reference URLs

### DIFF
--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-affix.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-affix.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-affix.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#affix
+ * http://getbootstrap.com/2.3.2/javascript.html#affix
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-alert.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-alert.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-alert.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#alerts
+ * http://getbootstrap.com/2.3.2/javascript.html#alerts
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-button.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-button.js
@@ -1,6 +1,6 @@
 /* ============================================================
  * bootstrap-button.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#buttons
+ * http://getbootstrap.com/2.3.2/javascript.html#buttons
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-carousel.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-carousel.js
@@ -1,6 +1,6 @@
 /* ==========================================================
  * bootstrap-carousel.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#carousel
+ * http://getbootstrap.com/2.3.2/javascript.html#carousel
  * ==========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-collapse.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-collapse.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-collapse.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#collapse
+ * http://getbootstrap.com/2.3.2/javascript.html#collapse
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-dropdown.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-dropdown.js
@@ -1,6 +1,6 @@
 /* ============================================================
  * bootstrap-dropdown.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#dropdowns
+ * http://getbootstrap.com/2.3.2/javascript.html#dropdowns
  * ============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-modal.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-modal.js
@@ -1,6 +1,6 @@
 /* =========================================================
  * bootstrap-modal.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#modals
+ * http://getbootstrap.com/2.3.2/javascript.html#modals
  * =========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-popover.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-popover.js
@@ -1,6 +1,6 @@
 /* ===========================================================
  * bootstrap-popover.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#popovers
+ * http://getbootstrap.com/2.3.2/javascript.html#popovers
  * ===========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-scrollspy.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-scrollspy.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-scrollspy.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#scrollspy
+ * http://getbootstrap.com/2.3.2/javascript.html#scrollspy
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-tab.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-tab.js
@@ -1,6 +1,6 @@
 /* ========================================================
  * bootstrap-tab.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tabs
+ * http://getbootstrap.com/2.3.2/javascript.html#tabs
  * ========================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-tooltip.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-tooltip.js
@@ -1,6 +1,6 @@
 /* ===========================================================
  * bootstrap-tooltip.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#tooltips
+ * http://getbootstrap.com/2.3.2/javascript.html#tooltips
  * Inspired by the original jQuery.tipsy by Jason Frame
  * ===========================================================
  * Copyright 2012 Twitter, Inc.

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-transition.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-transition.js
@@ -1,6 +1,6 @@
 /* ===================================================
  * bootstrap-transition.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#transitions
+ * http://getbootstrap.com/2.3.2/javascript.html#transitions
  * ===================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/javascripts/rails_admin/bootstrap/bootstrap-typeahead.js
+++ b/app/assets/javascripts/rails_admin/bootstrap/bootstrap-typeahead.js
@@ -1,6 +1,6 @@
 /* =============================================================
  * bootstrap-typeahead.js v2.3.2
- * http://twitter.github.com/bootstrap/javascript.html#typeahead
+ * http://getbootstrap.com/2.3.2/javascript.html#typeahead
  * =============================================================
  * Copyright 2012 Twitter, Inc.
  *

--- a/app/assets/stylesheets/rails_admin/custom/theming.scss
+++ b/app/assets/stylesheets/rails_admin/custom/theming.scss
@@ -5,7 +5,7 @@
 
   Look at the markup in RailsAdmin and go there to get inspiration from:
 
-  http://twitter.github.com/bootstrap/
+  http://getbootstrap.com/2.3.2/
 
   Test me: (actual color should be the one defined in variables.css.scss if you did)
 

--- a/app/assets/stylesheets/rails_admin/themes/default/theming.scss
+++ b/app/assets/stylesheets/rails_admin/themes/default/theming.scss
@@ -3,7 +3,7 @@
 
   Look at the markup in RailsAdmin and go there to get inspiration from:
 
-  http://twitter.github.com/bootstrap/
+  http://getbootstrap.com/2.3.2/
 
   Test me: (actual color should be the one defined in variables.css.scss if you did)
 

--- a/lib/rails_admin/config/actions/base.rb
+++ b/lib/rails_admin/config/actions/base.rb
@@ -18,7 +18,7 @@ module RailsAdmin
           []
         end
 
-        # http://twitter.github.com/bootstrap/base-css.html#icons
+        # http://getbootstrap.com/2.3.2/base-css.html#icons
         register_instance_option :link_icon do
           'icon-question-sign'
         end


### PR DESCRIPTION
Since current rails_admin is using Twitter Bootstrap v. 2.3.2. I suggest to update these reference URL that does not get you to corresponding sections anymore.
