### PR TITLE
Changed the default ActiveRecord model scope to be unscoped.

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -18,7 +18,7 @@ module RailsAdmin
       end
 
       def scoped
-        model.all
+        model.unscoped.all
       end
 
       def first(options = {}, scope = nil)


### PR DESCRIPTION
Changed default activerecord model scope to be unscoped as it simply makes more sense than to adhere to the default_scope provided by the model. Found the monkey-patches and quick-fixes very "over-reaching" compared to the actual fix of the unexpected behavior.
