### PR TITLE
respond_to?(:newrelic_ignore) always returns false

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -8,7 +8,7 @@ module RailsAdmin
   end
 
   class ApplicationController < ::ApplicationController
-    newrelic_ignore if defined?(NewRelic) && respond_to?(:newrelic_ignore)
+    newrelic_ignore if defined?(NewRelic)
 
     before_filter :_authenticate!
     before_filter :_authorize!


### PR DESCRIPTION
Reverting https://github.com/sferik/rails_admin/commit/7f1732bc4f160aad8668f828cfe182f7aaa1095b 

respond_to?(:newrelic_ignore) always returns false

defined?(NewRelic) is nil if the gem is in the production group & I'm running in development
