### PR TITLE
Getting ready for Teatro.io stage server

### DIFF
--- a/.teatro.yml
+++ b/.teatro.yml
@@ -1,0 +1,20 @@
+project:
+  platform: rails
+
+stage:
+  before:
+    - export CI_DB_ADAPTER=postgresql
+    - export CI_ORM=active_record
+    - cp Procfile.teatro Procfile
+    - cd spec/dummy_app
+    - cp ../../config/database.yml config/
+    - bundle install --without development --jobs=3 --retry=3
+    - ln -sf $PWD/public ../../public
+
+  database:
+    - bundle exec rake db:create db:migrate db:seed
+
+config:
+  database: postgresql
+  services:
+    - postgresql

--- a/Procfile.teatro
+++ b/Procfile.teatro
@@ -1,0 +1,1 @@
+web: cd spec/dummy_app && bundle exec rails server

--- a/spec/dummy_app/config/environments/production.rb
+++ b/spec/dummy_app/config/environments/production.rb
@@ -77,4 +77,6 @@ DummyApp::Application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  config.logger = Logger.new(STDOUT)
 end


### PR DESCRIPTION
Hey!

I am developer at Teatro.io and I want to offer you our service — it automatically creates a staging server for each opened pull request.

Seems like your demo app (https://github.com/sferik/rails_admin#demo) is out-of-date. That's what I want to help you with.

Teatro.io is free for open source projects — some large projects like GitLab (https://github.com/gitlabhq/gitlabhq/pull/7140 ), ErrBit (works out-of-the-box, @ndbroadbent approved Teatro) and others are already using Teatro as free stage servers.

Here's URL of Teatro stage server for my fork of Rails Admin: http://master.semenyukdmitriy-rails-admin-60b8886e18afbb982c35.ttrcloud.com/. Awesome, isn't it?

When you connect project to Teatro, we'll automatically post a comment (via @TeatroIO) with like to unique stage server that was made for this specific branch (see https://github.com/semenyukdmitriy/rails_admin/pull/1 for example).

To use Teatro you need:
— sign in using Github account on http://Teatro.io
— add your project

_Benefits_:
— demo for new users
— the way to test changes: each Pull Request gets separate stage server
— FREE for open source!

Have any questions? — Post a comment.
