### PR TITLE
Automatically determine read only on has_many through association

### DIFF
--- a/lib/rails_admin/adapters/active_record/association.rb
+++ b/lib/rails_admin/adapters/active_record/association.rb
@@ -58,7 +58,9 @@ module RailsAdmin
         end
 
         def read_only?
-          (klass.all.instance_eval(&scope).readonly_value if scope.is_a? Proc) || false
+          (klass.all.instance_eval(&scope).readonly_value if scope.is_a? Proc) ||
+            association.nested? ||
+            false
         end
 
         def nested_options

--- a/spec/dummy_app/app/active_record/league.rb
+++ b/spec/dummy_app/app/active_record/league.rb
@@ -1,6 +1,7 @@
 class League < ActiveRecord::Base
   has_many :divisions, foreign_key: 'custom_league_id'
   has_many :teams, -> { readonly }, through: :divisions
+  has_many :players, through: :teams
 
   validates_presence_of(:name)
 

--- a/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
+++ b/spec/integration/basic/edit/rails_admin_basic_edit_spec.rb
@@ -50,6 +50,15 @@ describe 'RailsAdmin Basic Edit', type: :request do
     end
   end
 
+  describe 'has many associations through more than one association' do
+    it 'is not editable' do
+      @league = FactoryGirl.create :league
+      visit edit_path(model_name: 'league', id: @league.id)
+      expect(page).to have_selector('select#league_division_ids')
+      expect(page).to_not have_selector('select#league_player_ids')
+    end
+  end
+
   describe 'edit with has-and-belongs-to-many association' do
     before do
       @teams = 3.times.collect { FactoryGirl.create :team }

--- a/spec/rails_admin/adapters/active_record/association_spec.rb
+++ b/spec/rails_admin/adapters/active_record/association_spec.rb
@@ -93,6 +93,40 @@ describe 'RailsAdmin::Adapters::ActiveRecord::Association', active_record: true 
     end
   end
 
+  describe 'has_many association' do
+    let(:league) { RailsAdmin::AbstractModel.new(League) }
+
+    context 'for direct has many' do
+      let(:association) { league.associations.detect { |a| a.name == :divisions } }
+
+      it 'returns correct values' do
+        expect(association.type).to eq :has_many
+        expect(association.klass).to eq Division
+        expect(association.read_only?).to be_falsey
+      end
+    end
+
+    context 'for has many through marked as readonly' do
+      let(:association) { league.associations.detect { |a| a.name == :teams } }
+
+      it 'returns correct values' do
+        expect(association.type).to eq :has_many
+        expect(association.klass).to eq Team
+        expect(association.read_only?).to be_truthy
+      end
+    end
+
+    context 'for has many through multiple associations' do
+      let(:association) { league.associations.detect { |a| a.name == :players } }
+
+      it 'returns correct values' do
+        expect(association.type).to eq :has_many
+        expect(association.klass).to eq Player
+        expect(association.read_only?).to be_truthy
+      end
+    end
+  end
+
   describe 'has_and_belongs_to_many association' do
     subject { @post.associations.select { |a| a.name == :a_r_categories }.first }
 


### PR DESCRIPTION
Fixes https://github.com/sferik/rails_admin/issues/1467.  Automatically determine that has many through associations that go through multiple associations are readonly.  This will prevent those inputs from being generated in the form and an error getting raised when the form is submitted.
