### PR TITLE
Fix navbar height.

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -17,6 +17,7 @@ body.rails_admin {
     small {
       color:$red;
       font-weight:bold;
+      line-height: 1;
     }
   }
 


### PR DESCRIPTION
the `<small>` element in the brand link adds unwanted space to the navbar height, hence the actual height differs from $navbarHeight set in variables.scss. in order to fix it the `<small>` element's line-height has to be set to '1' (will no longer be required in bootstrap 3). 
