### PR TITLE
Fix history pagination with paper_trail, specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ group :test do
   gem 'rubocop', '>= 0.25'
   gem 'simplecov', '>= 0.9', require: false
   gem 'timecop', '>= 0.5'
+  gem 'paper_trail', '~> 3.0.3'
 end
 
 gemspec

--- a/spec/dummy_app/Gemfile
+++ b/spec/dummy_app/Gemfile
@@ -42,6 +42,7 @@ gem 'dragonfly', '~> 1.0'
 gem 'mini_magick', '>= 3.4'
 gem 'mlb', '>= 0.7'
 gem 'paperclip', '3.5.4'
+gem 'paper_trail', '~> 3.0.3'
 gem 'rails_admin', path: '../../'
 
 # Gems used only for assets and not required

--- a/spec/dummy_app/app/active_record/paper_trail_test.rb
+++ b/spec/dummy_app/app/active_record/paper_trail_test.rb
@@ -1,0 +1,3 @@
+class PaperTrailTest < ActiveRecord::Base
+  has_paper_trail
+end

--- a/spec/dummy_app/db/migrate/20140826093220_create_paper_trail_tests.rb
+++ b/spec/dummy_app/db/migrate/20140826093220_create_paper_trail_tests.rb
@@ -1,0 +1,9 @@
+class CreatePaperTrailTests < ActiveRecord::Migration
+  def change
+    create_table :paper_trail_tests do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/dummy_app/db/migrate/20140826093552_create_versions.rb
+++ b/spec/dummy_app/db/migrate/20140826093552_create_versions.rb
@@ -1,0 +1,13 @@
+class CreateVersions < ActiveRecord::Migration
+  def change
+    create_table :versions do |t|
+      t.string :item_type, null: false
+      t.integer :item_id, null: false
+      t.string :event, null: false
+      t.string :whodunnit
+      t.text :object
+      t.datetime :created_at
+    end
+    add_index :versions, [:item_type, :item_id]
+  end
+end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -72,4 +72,8 @@ FactoryGirl.define do
   factory :image do
     file File.open(Rails.root.join('public', 'robots.txt'))
   end
+
+  factory :paper_trail_test do
+    sequence(:name) { |n| "name #{n}" }
+  end
 end

--- a/spec/integration/history/rails_admin_paper_trail_spec.rb
+++ b/spec/integration/history/rails_admin_paper_trail_spec.rb
@@ -1,0 +1,94 @@
+require 'spec_helper'
+
+describe 'RailsAdmin PaperTrail history', active_record: true do
+  describe 'model history fetch' do
+    before(:all) do
+      RailsAdmin.config do |config|
+        config.audit_with :paper_trail, 'User', 'PaperTrail::Version'
+      end
+    end
+
+    before(:each) do
+      PaperTrail::Version.delete_all
+      @model = RailsAdmin::AbstractModel.new('PaperTrailTest')
+      @user = FactoryGirl.create :user
+      @paper_trail_test = FactoryGirl.create :paper_trail_test
+      with_versioning do
+        PaperTrail.whodunnit = @user.id
+        30.times do |i|
+          @paper_trail_test.update!(name: "updated name #{i}")
+        end
+      end
+    end
+
+    it 'creates versions' do
+      expect(PaperTrail::Version.count).to eq(30)
+    end
+
+    describe 'model history fetch with auditing adapter' do
+      before(:all) do
+        @adapter = RailsAdmin::Extensions::PaperTrail::AuditingAdapter.new(nil, 'User', 'PaperTrail::Version')
+      end
+
+      it 'fetches on page of history' do
+        versions = @adapter.listing_for_model @model, nil, false, false, false, nil, 20
+        expect(versions.total_count).to eq(30)
+        expect(versions.count).to eq(20)
+      end
+
+      it 'respects RailsAdmin::Config.default_items_per_page' do
+        RailsAdmin.config.default_items_per_page = 15
+        versions = @adapter.listing_for_model @model, nil, false, false, false, nil
+        expect(versions.total_count).to eq(30)
+        expect(versions.count).to eq(15)
+      end
+
+      it 'sets correct next page' do
+        versions = @adapter.listing_for_model @model, nil, false, false, false, 2, 10
+        expect(versions.next_page).to eq(3)
+      end
+
+      describe 'returned version objects' do
+        before(:each) do
+          @padinated_listing = @adapter.listing_for_model @model, nil, false, false, false, nil
+          @version = @padinated_listing.first
+        end
+
+        it '#username returns user email' do
+          expect(@version.username).to eq(@user.email)
+        end
+
+        it '#message returns event' do
+          expect(@version.message).to eq('update')
+        end
+
+        describe 'changed item attributes' do
+          it '#item returns item.id' do
+            expect(@version.item).to eq(@paper_trail_test.id)
+          end
+
+          it '#table returns item class name' do
+            expect(@version.table.to_s).to eq('PaperTrailTest')
+          end
+        end
+
+        context 'with Kaminari' do
+          before do
+            @paged = @adapter.listing_for_model @model, nil, false, false, false, nil
+            Kaminari.config.page_method_name = :per_page_kaminari
+          end
+
+          after do
+            Kaminari.config.page_method_name = :page
+          end
+
+          it "supports pagination when Kaminari's page_method_name is customized" do
+            expect(PaperTrail::Version).to receive(:per_page_kaminari).twice.and_return(@paged)
+            @adapter.listing_for_model @model, nil, false, false, false, nil
+            @adapter.listing_for_object @model, @paper_trail_test, nil, false, false, false, nil
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi!
When using PaperTrail extension, RailsAdmin::Extensions::PaperTrail::AuditingAdapter was returning `VersionProxy` objects array:

```
versions.collect { |version| VersionProxy.new(version, @user_class) }
```

which is later used in `history` view:

```
- unless params[:all] || !@history.respond_to?(:current_page)
```

The array returned by `collect` obviously doesn't respond to `#current_page`, as a result history pages have no pagination. Fix, and PaperTrail integration specs
