### PR TITLE
Fix #1386 by removing dependency of Devise for logout_path and logout_method.

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -39,6 +39,11 @@ module RailsAdmin
       end
     end
 
+    def logout_method
+      return Devise.sign_out_via if defined?(Devise)
+      :delete
+    end
+
     def wording_for(label, action = @action, abstract_model = @abstract_model, object = @object)
       model_config = abstract_model.try(:config)
       object = abstract_model && object.is_a?(abstract_model.model) ? object : nil

--- a/app/views/layouts/rails_admin/_secondary_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.haml
@@ -7,6 +7,6 @@
     - if user_link = edit_user_link
       %li= user_link
     - if logout_path.present?
-      %li= link_to content_tag('span', t('admin.misc.log_out'), class: 'label label-important'), logout_path, method: Devise.sign_out_via
+      %li= link_to content_tag('span', t('admin.misc.log_out'), class: 'label label-important'), logout_path, method: logout_method
     - if _current_user.respond_to?(:email) && _current_user.email.present?
       %li= image_tag "#{(request.ssl? ? 'https://secure' : 'http://www')}.gravatar.com/avatar/#{Digest::MD5.hexdigest _current_user.email}?s=30", style: 'padding-top:5px'


### PR DESCRIPTION
This way the main app can define a logout path on its routes and it will just work.

Also, logout_method is now an application helper and have a fallback to a
default value of :delete. It will just work (showing a logout link and all)
if you just add a route like the following:

  delete 'sign_out', :to => 'sessions#destroy', as: 'logout'
