### PR TITLE
RailsAdmin::Config::Sections::Base should require RailsAdmin::Config::HasDescription

### DIFF
--- a/lib/rails_admin/config/sections/base.rb
+++ b/lib/rails_admin/config/sections/base.rb
@@ -2,6 +2,7 @@ require 'rails_admin/config/proxyable'
 require 'rails_admin/config/configurable'
 require 'rails_admin/config/has_fields'
 require 'rails_admin/config/has_groups'
+require 'rails_admin/config/has_description'
 
 module RailsAdmin
   module Config


### PR DESCRIPTION
I'm having an issues with a my custom action. 

I require the `rails_admin/config/sections/base` to create a custom configuration section: https://github.com/dalpo/rails_admin_clone/blob/master/lib/rails_admin_clone/section.rb

But with the latest version of rails_admin through the following error:

```
/Users/adalponte/.rvm/gems/ruby-2.1.2/gems/rails_admin-0.6.3/lib/rails_admin/config/sections/base.rb:16:in `<class:Base>': uninitialized constant RailsAdmin::Config::HasDescription (NameError)    
from /Users/adalponte/.rvm/gems/ruby-.1.2/gems/rails_admin-.6.3/lib/rails_admin/config/sections/base.rb:10:in `<module:Sections>'
```

So the `RailsAdmin::Config::Sections::Base` module should require `RailsAdmin::Config::HasDescription` to preserve the class integrity.
