### PR TITLE
Column#primary was removed at Rails4.2

### DIFF
--- a/lib/rails_admin/adapters/active_record/property.rb
+++ b/lib/rails_admin/adapters/active_record/property.rb
@@ -34,7 +34,7 @@ module RailsAdmin
         end
 
         def serial?
-          property.primary
+          model.primary_key == property.name
         end
 
         def association?


### PR DESCRIPTION
https://github.com/rails/rails/commit/05dd3df35db8b2d39ed177f4ccfe112bdfe7726d

Column#primary is undefined method at Rails4.2.
Use ActiveRecord::Base.primary_key Instead of Column#primary
