### PR TITLE
Export with Encoding is not work

### DIFF
--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -113,10 +113,18 @@ module RailsAdmin
 
     def output(str)
       # Can't use the CSV generator with encodings that are not supersets of ASCII-7
-      return str.to_s if @encoding_to =~ NON_ASCII_ENCODINGS || !@iconv
+      return str.to_s if @encoding_to =~ NON_ASCII_ENCODINGS
 
       # Convert piece by piece
-      @iconv.iconv(str.to_s) rescue str.to_s
+      if @iconv
+        @iconv.iconv(str.to_s) rescue str.to_s
+      else
+        if @encoding_from != @encoding_to
+          str.to_s.encode(@encoding_to, @encoding_from, invalid: :replace, undef: :replace, replace: '?')
+        else
+          str.to_s
+        end
+      end
     end
   end
 end

--- a/spec/rails_admin/support/csv_converter_spec.rb
+++ b/spec/rails_admin/support/csv_converter_spec.rb
@@ -14,4 +14,43 @@ describe RailsAdmin::CSVConverter do
     schema = {only: [:number, :name]}
     expect(RailsAdmin::CSVConverter.new(objects, schema).to_csv({})[2]).to match(/Number,Name/)
   end
+
+
+  describe '#to_csv' do
+    before do
+      RailsAdmin.config(Player) do
+        export do
+          field :number
+          field :name
+        end
+      end
+
+      FactoryGirl.create :player, name: 'なまえ'
+    end
+
+    let(:objects) { Player.all }
+    let(:schema) { {only: [:number, :name]} }
+
+    subject { RailsAdmin::CSVConverter.new(objects, schema).to_csv({encoding_to: encoding}) }
+
+    context 'encoding to UTF-8' do
+      let(:encoding) { 'UTF-8' }
+
+      it 'should export to UTR-8 with BOM' do
+        expect(subject[1]).to eq 'UTF-8'
+        expect(subject[2].encoding).to eq Encoding::UTF_8
+        expect(subject[2]).to match(/\A\xEF\xBB\xBF/)  # have BOM
+      end
+    end
+
+    context 'encoding to Shift_JIS' do
+      let(:encoding) { 'Shift_JIS' }
+
+      it 'should export to Shift_JIS' do
+        expect(subject[1]).to eq 'Shift_JIS'
+        expect(subject[2].encoding).to eq Encoding::Shift_JIS
+      end
+    end
+
+  end
 end


### PR DESCRIPTION
When except `NON_ASCII_ENCODINGS`, 
`@iconv` is not defined in `#output(str)` and convert do not convert anything. 
