### PR TITLE
updated routes to rm deprecation warning when running rake test

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,11 +1,11 @@
 RailsAdmin::Engine.routes.draw do
   controller 'main' do
-    RailsAdmin::Config::Actions.all(:root).each { |action| match "/#{action.route_fragment}", to: action.action_name, as: action.action_name, via: action.http_methods }
+    RailsAdmin::Config::Actions.all(:root).each { |action| match "/#{action.route_fragment}", action: action.action_name, as: action.action_name, via: action.http_methods }
     scope ':model_name' do
-      RailsAdmin::Config::Actions.all(:collection).each { |action| match "/#{action.route_fragment}", to: action.action_name, as: action.action_name, via: action.http_methods }
-      post '/bulk_action', to: :bulk_action, as: 'bulk_action'
+      RailsAdmin::Config::Actions.all(:collection).each { |action| match "/#{action.route_fragment}", action: action.action_name, as: action.action_name, via: action.http_methods }
+      post '/bulk_action', action: :bulk_action, as: 'bulk_action'
       scope ':id' do
-        RailsAdmin::Config::Actions.all(:member).each { |action| match "/#{action.route_fragment}", to: action.action_name, as: action.action_name, via: action.http_methods }
+        RailsAdmin::Config::Actions.all(:member).each { |action| match "/#{action.route_fragment}", action: action.action_name, as: action.action_name, via: action.http_methods }
       end
     end
   end


### PR DESCRIPTION
Got dep warning running rake test...

```
DEPRECATION WARNING: defining a route where `to` is a symbol is deprecated.  Please change "to: :dashboard" to "action: :dashboard". (called from block (3 levels) in <top (required)> at /Users/afxjzs/.rvm/gems/ruby-2.1.2/bundler/gems/rails_admin-24d64363e0f0/config/routes.rb:3)
DEPRECATION WARNING: defining a route where `to` is a symbol is deprecated.  Please change "to: :index" to "action: :index". (called from block (4 levels) in <top (required)> at /Users/afxjzs/.rvm/gems/ruby-2.1.2/bundler/gems/rails_admin-24d64363e0f0/config/routes.rb:5)
```

etc. 
So I followed the directions stated. warning went away. i was having issues running the test suite so not sure if tests are passing.
