### PR TITLE
Friendlier error if filter is not found

### DIFF
--- a/app/views/rails_admin/main/index.html.haml
+++ b/app/views/rails_admin/main/index.html.haml
@@ -38,6 +38,9 @@
     filter_name = filter_for_field.keys.first
     filter_hash = filter_for_field.values.first
     field = @filterable_fields.find{ |field| field.name == filter_name.to_sym }
+    unless field
+      fail "#{filter_name} is not currently filterable; filterable fields are #{@filterable_fields.map(&:name).join(', ')}"
+    end
     field_options = case field.type
     when :enum
       options_for_select(field.with(object: @abstract_model.model.new).enum, filter_hash['v'])


### PR DESCRIPTION
If user sets, e.g., `filters [:name, :manager]`,
and manager is not set to `filterable true`,
RailsAdmin currently raises a NoMethodError
when trying to call `.type` on nil.

This change raises a more descriptive error
to help the user find the problem
