### PR TITLE
Move navigation out into partial so it can be easily overridden

### DIFF
--- a/app/views/layouts/rails_admin/_navigation.html.haml
+++ b/app/views/layouts/rails_admin/_navigation.html.haml
@@ -1,0 +1,7 @@
+.navbar-inner
+  .container-fluid
+    %a.brand.pjax{href: dashboard_path}
+      = _get_plugin_name[0] || 'Rails'
+      %small= _get_plugin_name[1] || 'Admin'
+    .nav-collapse
+      = render partial: 'layouts/rails_admin/secondary_navigation'

--- a/app/views/layouts/rails_admin/application.html.haml
+++ b/app/views/layouts/rails_admin/application.html.haml
@@ -12,13 +12,7 @@
   %body.rails_admin
     #loading.label.label-warning{style: 'display:none; position:fixed; right:20px; bottom:20px; z-index:100000'}= t('admin.loading')
     .navbar.navbar-fixed-top
-      .navbar-inner
-        .container-fluid
-          %a.brand.pjax{href: dashboard_path}
-            = _get_plugin_name[0] || 'Rails'
-            %small= _get_plugin_name[1] || 'Admin'
-          .nav-collapse
-            = render partial: 'layouts/rails_admin/secondary_navigation'
+      = render "layouts/rails_admin/navigation"
     .container-fluid
       .row-fluid
         .span3


### PR DESCRIPTION
This provides an easy way of overriding the existing header if you should choose to.

Just add a file `app/views/layouts/rails_admin/_navigation.html.haml`
