### PR TITLE
use &times; instead of hardcoded unicode times

### DIFF
--- a/app/views/layouts/rails_admin/pjax.html.haml
+++ b/app/views/layouts/rails_admin/pjax.html.haml
@@ -7,7 +7,7 @@
   %h1= @page_name
 - flash && flash.each do |key, value|
   .alert{class: "alert-#{key}"}
-    %a.close{href: '#', :'data-dismiss' => "alert"}×
+    %a.close{href: '#', :'data-dismiss' => "alert"} &times;
     = value
 = breadcrumb
 %ul.nav.nav-tabs


### PR DESCRIPTION
This very simple PR corrects a UTF-8 compatibility issue: after logging in you may get "incompatible character encodings: UTF-8 and ASCII-8BIT".  I haven't found a solution to this problem in Rails.  If there's a clear solution, please let me know.

I tracked the problem down to the hard coded UTF-8 character for times used in the pjax layout for dismissing messages.  Elsewhere in the code, the HTML entity is used, so I replaced the UTF-8 character with this.
