### PR TITLE
Use default label if object label would be blank

### DIFF
--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -44,7 +44,8 @@ module RailsAdmin
       end
 
       def object_label
-        bindings[:object].send object_label_method
+        bindings[:object].send(object_label_method).presence ||
+          bindings[:object].send(:rails_admin_default_object_label_method)
       end
 
       # The display for a model instance (i.e. a single database record).

--- a/spec/rails_admin/config/model_spec.rb
+++ b/spec/rails_admin/config/model_spec.rb
@@ -26,6 +26,13 @@ describe RailsAdmin::Config::Model do
       c = Comment.new(content: 'test')
       expect(RailsAdmin.config(Comment).with(object: c).object_label).to eq('test')
     end
+
+    context 'when the object_label_method is blank' do
+      it 'uses the rails admin default' do
+        c = Comment.create(content: '', id: '1')
+        expect(RailsAdmin.config(Comment).with(object: c).object_label).to eq('Comment #1')
+      end
+    end
   end
 
   describe '#object_label_method' do


### PR DESCRIPTION
This is sort of similar to how the `#object_infos` method works. If the object_label is present, use that, but otherwise use the default method provided by rails admin.  Right now, if the object_label is blank, it prevents a lot of behavior, such as being able to click on the link for the associated object to view the details.

I thought about being a little more specific with this, iterating through the object_label_methods and returning the first value that was present, but decided against it for performance reasons.  
