### PR TITLE
Fix sidebar not scrollable when models exceeds the height of the window

### DIFF
--- a/app/assets/stylesheets/rails_admin/base/theming.scss
+++ b/app/assets/stylesheets/rails_admin/base/theming.scss
@@ -29,7 +29,9 @@ body.rails_admin {
     padding: 9px 9px 9px 9px;
     position: fixed;
     width: 14%;
-    height: 100%;
+    overflow-y: scroll;
+    top: 50px;
+    bottom: 0;
     background: #eaf0f1;
   }
 


### PR DESCRIPTION
This fixes it by setting the overflow-y to scroll, height 100% will go over because it sets to the window height with no regard of the top bar.
