### PR TITLE
Use label instead of badge for boolean elements as per ...

### DIFF
--- a/lib/rails_admin/config/fields/types/boolean.rb
+++ b/lib/rails_admin/config/fields/types/boolean.rb
@@ -13,7 +13,7 @@ module RailsAdmin
           register_instance_option :pretty_value do
             case value
             when nil
-              %(<span class='label label-default'>-</span>)
+              %(<span class='label label-default'>‒</span>)
             when false
               %(<span class='label label-danger'>&#x2718;</span>)
             when true


### PR DESCRIPTION
A solution for sferik/rails_admin#2131 may be to use `label` instead of badges, the result is a little less rounded.

Up to you guys.
![screenshot-20141209-004032](https://cloud.githubusercontent.com/assets/207895/5349720/1af0e428-7f3c-11e4-9b70-b70babe5456c.jpg)
