### PR TITLE
Rails 4.2 has deprecated `serialized_attributes`

### DIFF
--- a/lib/rails_admin/adapters/active_record/property.rb
+++ b/lib/rails_admin/adapters/active_record/property.rb
@@ -18,7 +18,7 @@ module RailsAdmin
         end
 
         def type
-          if model.serialized_attributes[property.name.to_s]
+          if serialized?
             :serialized
           else
             property.type
@@ -43,6 +43,16 @@ module RailsAdmin
 
         def read_only?
           false
+        end
+
+      private
+
+        def serialized?
+          if Rails.version < '4.2'
+            model.serialized_attributes[property.name.to_s]
+          else
+            model.type_for_attribute(property.name).class == ::ActiveRecord::Type::Serialized
+          end
         end
       end
     end

--- a/spec/integration/config/edit/rails_admin_config_edit_spec.rb
+++ b/spec/integration/config/edit/rails_admin_config_edit_spec.rb
@@ -1017,7 +1017,7 @@ describe 'RailsAdmin Config DSL Edit Section', type: :request do
       end
 
       after do
-        Team.serialized_attributes.clear
+        Team.serialized_attributes.clear if Rails.version < '4.2'
         Team.instance_eval { undef :color_enum }
       end
 


### PR DESCRIPTION
- Use the new `type_for_attribute` method instead
- Green tests on Rails 4.0, 4.1, and 4.2 in my testing
