### PR TITLE
Don't perform string scan when using "is exactly" query

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -223,6 +223,8 @@ module RailsAdmin
         def build_statement_for_string_or_text
           return if @value.blank?
 
+          return ["(#{@column} = ?)", @value] if @operator == 'is' || @operator == '='
+
           unless ['postgresql', 'postgis'].include? ar_adapter
             @value = @value.mb_chars.downcase
           end
@@ -235,8 +237,6 @@ module RailsAdmin
               "#{@value}%"
             when 'ends_with'
               "%#{@value}"
-            when 'is', '='
-              @value
             else
               return
             end

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -208,7 +208,7 @@ describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
         expect(build_statement(:string, 'foo', 'like')).to eq([@like, '%foo%'])
         expect(build_statement(:string, 'foo', 'starts_with')).to eq([@like, 'foo%'])
         expect(build_statement(:string, 'foo', 'ends_with')).to eq([@like, '%foo'])
-        expect(build_statement(:string, 'foo', 'is')).to eq([@like, 'foo'])
+        expect(build_statement(:string, 'foo', 'is')).to eq(['(field = ?)', 'foo'])
       end
 
       it 'performs case-insensitive searches' do


### PR DESCRIPTION
Right now, rails_admin will try to do a string comparison when a user tries to select a value with "is exactly" on all the rows in the DB. This is extremely costly in large tables, especially since you know exactly what value you are looking for. Additionally, you could argue previous behavior was incorrect, in that "is exactly" queries would not respect case sensitivity. This PR fixes this behavior by simply returning an equality statement when "is exactly" is used.