### PR TITLE
History order

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -44,6 +44,9 @@ module RailsAdmin
       # Default association limit
       attr_accessor :default_associated_collection_limit
 
+      # Default order for history versions model in dashboard
+      attr_accessor :default_versions_order
+
       attr_reader :default_search_operator
 
       # Configuration option to specify which method names will be searched for
@@ -292,6 +295,7 @@ module RailsAdmin
         @navigation_static_links = {}
         @navigation_static_label = nil
         @parent_controller = '::ActionController::Base'
+        @default_versions_order = {id: :desc}
         @forgery_protection_settings = {with: :exception}
         RailsAdmin::Config::Actions.reset
       end

--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -18,7 +18,7 @@ module RailsAdmin
 
         register_instance_option :controller do
           proc do
-            @history = @auditing_adapter && @auditing_adapter.latest(@action.auditing_versions_limit) || []
+            @history = @auditing_adapter && @auditing_adapter.latest(@action.auditing_versions_limit, RailsAdmin::Config.default_versions_order) || []
             if @action.statistics?
               @abstract_models = RailsAdmin::Config.visible_models(controller: self).collect(&:abstract_model)
 

--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -31,7 +31,8 @@ module RailsAdmin
                 @max = current_count > @max ? current_count : @max
                 @count[t.model.name] = current_count
                 next unless t.properties.detect { |c| c.name == :created_at }
-                @most_recent_created[t.model.name] = t.model.last.try(:created_at)
+                sort_field = t.properties.detect { |c| c.name == t.config.dashboard_sort_by} ? t.config.dashboard_sort_by : :id
+                @most_recent_created[t.model.name] = t.model.order(sort_field).last.try(:created_at)
               end
             end
             render @action.template_name, status: @status_code || :ok

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -97,6 +97,10 @@ module RailsAdmin
         nil
       end
 
+      register_instance_option :dashboard_sort_by do
+        nil
+      end
+
       # Act as a proxy for the base section configuration that actually
       # store the configurations.
       def method_missing(m, *args, &block)

--- a/lib/rails_admin/extensions/history/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/history/auditing_adapter.rb
@@ -8,8 +8,8 @@ module RailsAdmin
           require 'rails_admin/extensions/history/history'
         end
 
-        def latest(count = 100)
-          ::RailsAdmin::History.latest(count)
+        def latest(count = 100, order = {id: :desc})
+          ::RailsAdmin::History.latest(count, order)
         end
 
         def delete_object(object, model, user)

--- a/lib/rails_admin/extensions/history/history.rb
+++ b/lib/rails_admin/extensions/history/history.rb
@@ -11,8 +11,8 @@ module RailsAdmin
     default_scope { order('id DESC') }
 
     class << self
-      def latest(count = 100)
-        limit(count)
+      def latest(count = 100, order = {id: :desc})
+        order(order).limit(count)
       end
 
       def create_history_item(message, object, abstract_model, user)

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -73,9 +73,9 @@ module RailsAdmin
           end
         end
 
-        def latest(count = 100)
+        def latest(count = 100, order = {id: :desc})
           @version_class.
-            order(id: :desc).includes(:item).limit(count).
+            order(order).includes(:item).limit(count).
             collect { |version| VersionProxy.new(version, @user_class) }
         end
 


### PR DESCRIPTION
Add custom order for history in dashboard. Fixes sorting when UUID used

```
RailsAdmin.config do |config|
  config.default_versions_order = {created_at: :desc}
end
```