### PR TITLE
Ensure `open` can be used as a field name

### DIFF
--- a/spec/dummy_app/app/mongoid/field_test.rb
+++ b/spec/dummy_app/app/mongoid/field_test.rb
@@ -31,6 +31,7 @@ class FieldTest
   field :time_field, type: Time
 
   field :format, type: String
+  field :open, type: Boolean
   field :restricted_field, type: String
   field :protected_field, type: String
   has_mongoid_attached_file :paperclip_asset, styles: {thumb: '100x100>'}

--- a/spec/dummy_app/db/migrate/20211011235734_add_bool_field_open.rb
+++ b/spec/dummy_app/db/migrate/20211011235734_add_bool_field_open.rb
@@ -1,0 +1,5 @@
+class AddBoolFieldOpen < ActiveRecord::Migration[6.0]
+  def change
+    add_column :field_tests, :open, :boolean
+  end
+end

--- a/spec/integration/actions/edit_spec.rb
+++ b/spec/integration/actions/edit_spec.rb
@@ -828,4 +828,20 @@ RSpec.describe 'Edit action', type: :request do
       expect(@record.format).to eq('test for format')
     end
   end
+
+  context "with a field with 'open' as a name" do
+    it 'is updatable without any error' do
+      RailsAdmin.config FieldTest do
+        edit do
+          field :open
+        end
+      end
+      record = FieldTest.create
+      visit edit_path(model_name: 'field_test', id: record.id)
+      expect do
+        check 'field_test[open]'
+        click_button 'Save'
+      end.to change { record.reload.open }.from(nil).to(true)
+    end
+  end
 end


### PR DESCRIPTION
Backfilling test coverage as requested in https://github.com/sferik/rails_admin/issues/1536#issuecomment-940697529, closes https://github.com/sferik/rails_admin/issues/1536