### PR TITLE
Allow configuring multiple fields for a section at once

### DIFF
--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -39,9 +39,9 @@ module RailsAdmin
         field
       end
 
-      # configure a field without adding it.
+      # configure field(s) from the default group in a section without changing the original order.
       def configure(name, type = nil, &block)
-        field(name, type, false, &block)
+        [*name].each { |field_name| field(field_name, type, false, &block) }
       end
 
       # include fields by name and apply an optionnal block to each (through a call to fields),


### PR DESCRIPTION
This allows passing an array of field names to the `configure` block to simplify configuring multiple fields that share the same settings within a section.

Closes https://github.com/sferik/rails_admin/issues/2667