### PR TITLE
Remove unnecessary IIFE from ra.sidescroll.js

### DIFF
--- a/app/assets/javascripts/rails_admin/ra.sidescroll.js
+++ b/app/assets/javascripts/rails_admin/ra.sidescroll.js
@@ -1,6 +1,6 @@
-(function ($) {
-  "use strict";
+"use strict";
 
+{
   document.addEventListener("rails_admin.dom_ready", () => {
     const listForm = document.getElementById("bulk_form");
     if (!listForm || !listForm.classList.contains("ra-sidescroll")) {
@@ -24,4 +24,4 @@
         });
     });
   });
-})(jQuery);
+}


### PR DESCRIPTION
The file no longer uses jQuery, so it doesn't need to be passed to the
IIFE (Immediately Invoked Function Expression).

The IIFE can be replaced by a simple block to continue to ensure the
global namespace is not polluted.

Refs #2893