### PR TITLE
Remove unnecessary parentheses around keyword `raise`

### DIFF
--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -25,13 +25,13 @@ module RailsAdmin
 
     def get_model
       @model_name = to_model_name(params[:model_name])
-      raise(RailsAdmin::ModelNotFound) unless (@abstract_model = RailsAdmin::AbstractModel.new(@model_name))
-      raise(RailsAdmin::ModelNotFound) if (@model_config = @abstract_model.config).excluded?
+      raise RailsAdmin::ModelNotFound unless (@abstract_model = RailsAdmin::AbstractModel.new(@model_name))
+      raise RailsAdmin::ModelNotFound if (@model_config = @abstract_model.config).excluded?
       @properties = @abstract_model.properties
     end
 
     def get_object
-      raise(RailsAdmin::ObjectNotFound) unless (@object = @abstract_model.get(params[:id]))
+      raise RailsAdmin::ObjectNotFound unless (@object = @abstract_model.get(params[:id]))
     end
 
     def to_model_name(param)

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -146,7 +146,7 @@ module RailsAdmin
       end
 
       def build_statement_for_type
-        raise('You must override build_statement_for_type in your StatementBuilder')
+        raise 'You must override build_statement_for_type in your StatementBuilder'
       end
 
       def build_statement_for_integer_decimal_or_float
@@ -184,11 +184,11 @@ module RailsAdmin
       end
 
       def unary_operators
-        raise('You must override unary_operators in your StatementBuilder')
+        raise 'You must override unary_operators in your StatementBuilder'
       end
 
       def range_filter(_min, _max)
-        raise('You must override range_filter in your StatementBuilder')
+        raise 'You must override range_filter in your StatementBuilder'
       end
 
       class FilteringDuration

--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -209,7 +209,7 @@ module RailsAdmin
         when String
           field_name, collection_name = options[:sort].split('.').reverse
           if collection_name && collection_name != table_name
-            raise('sorting by associated model column is not supported in Non-Relational databases')
+            raise 'sorting by associated model column is not supported in Non-Relational databases'
           end
         when Symbol
           field_name = options[:sort].to_s

--- a/lib/rails_admin/adapters/mongoid/association.rb
+++ b/lib/rails_admin/adapters/mongoid/association.rb
@@ -30,7 +30,7 @@ module RailsAdmin
           when :has_and_belongs_to_many, :references_and_referenced_in_many
             :has_and_belongs_to_many
           else
-            raise("Unknown association type: #{macro.inspect}")
+            raise "Unknown association type: #{macro.inspect}"
           end
         end
 

--- a/lib/rails_admin/bootstrap-sass.rb
+++ b/lib/rails_admin/bootstrap-sass.rb
@@ -14,7 +14,7 @@ module RailsAdmin
       require 'sassc-rails' if rails?
 
       unless rails? || compass?
-        raise(Bootstrap::FrameworkNotFound.new('bootstrap-sass requires either Rails > 3.1 or Compass, neither of which are loaded'))
+        raise Bootstrap::FrameworkNotFound.new('bootstrap-sass requires either Rails > 3.1 or Compass, neither of which are loaded')
       end
 
       if defined?(::Sass) && ::Sass.respond_to?(:load_paths)

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -221,7 +221,7 @@ module RailsAdmin
         if %w(default like not_like starts_with ends_with is =).include? operator
           @default_search_operator = operator
         else
-          raise(ArgumentError.new("Search operator '#{operator}' not supported"))
+          raise ArgumentError.new("Search operator '#{operator}' not supported")
         end
       end
 

--- a/lib/rails_admin/config/configurable.rb
+++ b/lib/rails_admin/config/configurable.rb
@@ -87,7 +87,7 @@ module RailsAdmin
             elsif block_given?
               yield
             else
-              raise("The #{option_name} configuration option is removed without replacement.")
+              raise "The #{option_name} configuration option is removed without replacement."
             end
           end
         end

--- a/lib/rails_admin/config/fields/types.rb
+++ b/lib/rails_admin/config/fields/types.rb
@@ -9,7 +9,7 @@ module RailsAdmin
         @@registry = {}
 
         def self.load(type)
-          @@registry[type.to_sym] || raise("Unsupported field datatype: #{type}")
+          @@registry.fetch(type.to_sym) { raise "Unsupported field datatype: #{type}" }
         end
 
         def self.register(type, klass = nil)

--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -66,7 +66,7 @@ module RailsAdmin
 
           # virtual class
           def resource_url
-            raise('not implemented')
+            raise 'not implemented'
           end
 
           def virtual?

--- a/lib/rails_admin/config/fields/types/multiple_file_upload.rb
+++ b/lib/rails_admin/config/fields/types/multiple_file_upload.rb
@@ -50,7 +50,7 @@ module RailsAdmin
             end
 
             def resource_url(_thumb = false)
-              raise('not implemented')
+              raise 'not implemented'
             end
           end
 

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -57,7 +57,7 @@ module RailsAdmin
         EOS
 
         def self.setup
-          raise('PaperTrail not found') unless defined?(::PaperTrail)
+          raise 'PaperTrail not found' unless defined?(::PaperTrail)
           RailsAdmin::Extensions::ControllerExtension.send(:include, ControllerExtension)
         end
 

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
 
   describe '#check_for_cancel' do
     before do
-      allow(controller).to receive(:back_or_index) { raise(StandardError.new('redirected back')) }
+      allow(controller).to receive(:back_or_index) { raise StandardError.new('redirected back') }
     end
 
     it 'redirects to back if params[:bulk_ids] is nil when params[:bulk_action] is present' do

--- a/spec/integration/fields/base_spec.rb
+++ b/spec/integration/fields/base_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe 'Base field', type: :request do
       RailsAdmin.config(Team) do
         field :name do
           render do
-            bindings[:object].persisted? ? 'Custom Name' : raise(ZeroDivisionError)
+            raise ZeroDivisionError unless bindings[:object].persisted?
+
+            'Custom Name'
           end
         end
       end


### PR DESCRIPTION
`raise` is a keyword, not a function. In general, it should not have
parentheses unless they are required for expression evaluation or
precedence. These have been removed to better match the examples in the
Ruby style guide.

https://rubystyle.guide/#exceptions