### PR TITLE
Only run coveralls on the base repository

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Run tests
         run: bundle exec rake spec
       - name: Coveralls Parallel
+        if: ${{ github.repository_owner == 'railsadminteam' }}
         uses: coverallsapp/github-action@master
         continue-on-error: true
         with:
@@ -97,6 +98,7 @@ jobs:
 
   coveralls:
     name: Coveralls
+    if: ${{ github.repository_owner == 'railsadminteam' }}
     needs: rspec
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Allow contributors to run GitHub actions on their fork successfully.
Before this changed, local actions always fail on the coverall step as
the secret is unavailable. Now it only runs on the base
repository (railsadminteam/rails_admin).