### PR TITLE
Remove `builder` dependency

### DIFF
--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -1,5 +1,3 @@
-require 'builder'
-
 module RailsAdmin
   module MainHelper
     def rails_admin_form_for(*args, &block)

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -5,7 +5,6 @@ require 'rails_admin/version'
 
 Gem::Specification.new do |spec|
   # If you add a dependency, please maintain alphabetical order
-  spec.add_dependency 'builder', '~> 3.1'
   spec.add_dependency 'jquery-rails', ['>= 3.0', '< 5']
   spec.add_dependency 'jquery-ui-rails', ['>= 6.0', '< 7']
   spec.add_dependency 'kaminari', '>= 0.14', '< 2.0'


### PR DESCRIPTION
Added in https://github.com/railsadminteam/rails_admin/commit/61a7e196e3fb8ffc3ae2db5136d8e9019c807134 / https://github.com/railsadminteam/rails_admin/commit/0188a8a09ce18dfb5f7993030049b48a7b9ab3fd, this appears to no longer be used.

Digging through the `git` history since when this was added.
- [Moved from `app/helpers/rails_admin/main_helper.rb` to `lib/rails_admin/fields.rb`](https://github.com/railsadminteam/rails_admin/commit/35f47fc3e2aca3e490ed17e5e2d34a944fb6d696#diff-c3de22b2b5019683131056d8316f63b52e7eadf3ae729685e8b64228c2c3009b)
- [Moved from `lib/rails_admin/fields.rb` to `lib/rails_admin/config/fields/types/boolean.rb`]( https://github.com/railsadminteam/rails_admin/commit/ef9b182a485fb88981206613b0797cb90a89a212)
- [Removed from `lib/rails_admin/config/fields/types/boolean.rb`]( https://github.com/railsadminteam/rails_admin/commit/18fe8c2c9ff11c93b4c29d76de0e4dece3a16614#diff-bb6b7a37e8a94b560637907036373a5ab6310598cba826b49a25a0a51cc9d5ee)