### PR TITLE
Remove support for EOL Ruby 2.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
         orm: [active_record]
         adapter: [sqlite3]
         include:
-          - ruby: 2.5
+          - ruby: 2.6
             gemfile: gemfiles/rails_6.0.gemfile
             orm: active_record
             adapter: sqlite3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,7 +8,6 @@ AllCops:
     - "spec/dummy_app/tmp/**/*"
     - "vendor/bundle/**/*"
   NewCops: disable
-  TargetRubyVersion: 2.5
 
 Gemspec/DateAssignment:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -98,7 +98,6 @@ If you think you found a bug in RailsAdmin, you can [submit an issue](https://gi
 
 This library aims to support and is [tested against][ghactions] the following Ruby implementations:
 
-- Ruby 2.5
 - Ruby 2.6
 - Ruby 2.7
 - Ruby 3.0

--- a/lib/rails_admin/bootstrap-sass/sass_functions.rb
+++ b/lib/rails_admin/bootstrap-sass/sass_functions.rb
@@ -8,7 +8,7 @@ module Sass
         assert_type color, :Color
         alpha = (color.alpha * 255).round
         alphastr = alpha.to_s(16).rjust(2, '0')
-        Sass::Script::String.new("##{alphastr}#{color.send(:hex_str)[1..-1]}".upcase)
+        Sass::Script::String.new("##{alphastr}#{color.send(:hex_str)[1..]}".upcase)
       end
       declare :ie_hex_str, [:color] if respond_to?(:declare)
     end

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/railsadminteam/rails_admin'
   spec.name = 'rails_admin'
   spec.require_paths = %w[lib]
-  spec.required_ruby_version     = '>= 2.5.0'
+  spec.required_ruby_version     = '>= 2.6.0'
   spec.required_rubygems_version = '>= 1.8.11'
   spec.summary = 'Admin for Rails'
   spec.version = RailsAdmin::Version

--- a/spec/integration/actions/export_spec.rb
+++ b/spec/integration/actions/export_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe 'Export action', type: :request do
     click_button 'Export to csv'
     csv = CSV.parse page.driver.response.body
     expect(csv[0]).to match_array ['Id', 'Commentable', 'Commentable type', 'Content', 'Created at', 'Updated at']
-    csv[1..-1].each do |line|
+    csv[1..].each do |line|
       expect(line[csv[0].index('Commentable')]).to eq(@player.id.to_s)
       expect(line[csv[0].index('Commentable type')]).to eq(@player.class.to_s)
     end

--- a/spec/integration/actions/index_spec.rb
+++ b/spec/integration/actions/index_spec.rb
@@ -898,7 +898,7 @@ RSpec.describe 'Index action', type: :request do
           end
         end
       end
-      visit index_path(model_name: 'player', query: player.name[1..-1])
+      visit index_path(model_name: 'player', query: player.name[1..])
       is_expected.to have_no_content(player.name)
     end
   end
@@ -1141,7 +1141,7 @@ RSpec.describe 'Index action', type: :request do
       visit index_path(model_name: 'team')
       cols = all('th').collect(&:text)
       expect(cols[0..3]).to eq(all_team_columns[1..4])
-      expect(cols).to contain_exactly(*all_team_columns[1..-1])
+      expect(cols).to contain_exactly(*all_team_columns[1..])
       expect(page).to have_selector('.ra-sidescroll[data-ra-sidescroll=2]')
     end
 
@@ -1225,7 +1225,7 @@ RSpec.describe 'Index action', type: :request do
       visit index_path(model_name: 'team')
       cols = all('th').collect(&:text)
       expect(cols[0..3]).to eq(all_team_columns[1..4])
-      expect(cols).to contain_exactly(*all_team_columns[1..-1])
+      expect(cols).to contain_exactly(*all_team_columns[1..])
       expect(page).to have_selector('.ra-sidescroll[data-ra-sidescroll=3]')
     end
   end

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
 
     it '#destroy destroys multiple items' do
       abstract_model.destroy(@players[0..1])
-      expect(Player.all).to eq(@players[2..-1])
+      expect(Player.all).to eq(@players[2..])
     end
 
     it '#where returns filtered results' do


### PR DESCRIPTION
Ruby 2.5 went EOL 2021-03-31. It is no longer supported upstream and so
is not receiving bug fixes, including for security issues. Reduce the
testing resources on RailsAdmin.

https://www.ruby-lang.org/en/downloads/branches/

Dropping EOL Ruby versions allows the project to begin taking advantage
of newer syntax and library features.

TargetRubyVersion was removed from .rubocop.yml as this value is
determined automatically from the gemspec.