### PR TITLE
Fix flakey MultipleCarrierwave field spec

### DIFF
--- a/spec/integration/fields/multiple_carrierwave_spec.rb
+++ b/spec/integration/fields/multiple_carrierwave_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'MultipleCarrierwave field', type: :request, active_record: true 
     end
   end
 
-  it 'supports uploading multiple files' do
+  it 'supports uploading multiple files', js: true do
     visit new_path(model_name: 'field_test')
     attach_file 'Carrierwave assets', [file_path('test.jpg'), file_path('test.png')]
     click_button 'Save'


### PR DESCRIPTION
Was able to reproduce failure using the seed of [a recent CI run](https://github.com/codealchemy/rails_admin/runs/4543403935?check_suite_focus=true)

` bundle exec appraisal rails-7.0 rspec --seed 47623 --bisect`

produces

```
The minimal reproduction command is:
  rspec './spec/integration/fields/multiple_carrierwave_spec.rb[1:1]' --seed 47623
```

Adding `js: true` to the spec block (which is already set for other tests in this file) resolved failures for that seed, which did not return when running the full suite. Verified fix [against another failing CI run of the same issue](https://github.com/railsadminteam/rails_admin/runs/4543853874).