### PR TITLE
Fix inheritance of parent_controller when controllers were eagerly loaded

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -269,9 +269,15 @@ module RailsAdmin
 
       def parent_controller=(name)
         @parent_controller = name
+
         if defined?(RailsAdmin::ApplicationController)
           RailsAdmin.send(:remove_const, :ApplicationController)
           load RailsAdmin::Engine.root.join('app/controllers/rails_admin/application_controller.rb')
+        end
+
+        if defined?(RailsAdmin::MainController)
+          RailsAdmin.send(:remove_const, :MainController)
+          load RailsAdmin::Engine.root.join('app/controllers/rails_admin/main_controller.rb')
         end
       end
 

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -283,6 +283,11 @@ RSpec.describe RailsAdmin::Config do
 
   describe '.parent_controller=' do
     context 'if RailsAdmin::ApplicationController is already loaded' do
+      before do
+        # preload cotrollers (e.g. when config.eager_load = true)
+        RailsAdmin::MainController
+      end
+
       after do
         RailsAdmin::Config.reset
         RailsAdmin.send(:remove_const, :ApplicationController)
@@ -292,6 +297,7 @@ RSpec.describe RailsAdmin::Config do
       it 'can be changed' do
         RailsAdmin.config.parent_controller = 'ApplicationController'
         expect(RailsAdmin::ApplicationController.superclass).to eq ApplicationController
+        expect(RailsAdmin::MainController.superclass.superclass).to eq ApplicationController
       end
     end
   end


### PR DESCRIPTION
Follow up on https://github.com/railsadminteam/rails_admin/issues/2790

https://github.com/railsadminteam/rails_admin/commit/5bd980564a565906a6fda87d2ef31590d3e3b0a5 fixes the inheritance of the `RailsAdmin::ApplicationController`, nevertheless `RailsAdmin::MainController.superclass.superclass` is `ActionController::Base` instead of the configured `::ApplicationController`, when accessing the main controller first (happens with eager loading).

Before the fix:

```
  1) RailsAdmin::Config.parent_controller= if RailsAdmin::ApplicationController is already loaded can be changed
     Failure/Error: expect(RailsAdmin::MainController.superclass.superclass).to eq ApplicationController

       expected: ApplicationController
            got: ActionController::Base

       (compared using ==)

       Diff:
       @@ -1 +1 @@
       -ApplicationController
       +ActionController::Base
```