### PR TITLE
Introduce Turbo Drive

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -35,6 +35,7 @@ appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
   gem 'sassc-rails', '~> 2.1'
   gem 'devise', '~> 4.7'
+  gem 'turbo-rails', platform: :jruby, github: 'mshibuya/turbo-rails', branch: 'fix/breaking-in-non-zeitwerk-env'
 
   group :test do
     gem 'cancancan', '~> 3.2'

--- a/app/assets/javascripts/rails_admin.js
+++ b/app/assets/javascripts/rails_admin.js
@@ -1,4 +1,5 @@
 //=  require 'rails-ujs'
+//=  require 'turbo'
 //=  require 'rails_admin/jquery3'
 //=  require 'jquery_nested_form'
 //=  require 'rails_admin/jquery-ui/effect'

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -8,6 +8,7 @@ gem "rails", "~> 6.1.0"
 gem "webpacker", require: false
 gem "webrick", "~> 1.7"
 gem "sassc-rails", "~> 2.1"
+gem "turbo-rails", platform: :jruby, github: "mshibuya/turbo-rails", branch: "fix/breaking-in-non-zeitwerk-env"
 
 group :active_record do
   gem "paper_trail", ">= 12.0"

--- a/lib/rails_admin/config/fields/types/action_text.rb
+++ b/lib/rails_admin/config/fields/types/action_text.rb
@@ -9,7 +9,7 @@ module RailsAdmin
           RailsAdmin::Config::Fields::Types.register(self)
 
           register_instance_option :version do
-            '1.1.1'
+            '1.3.1'
           end
 
           register_instance_option :css_location do

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -2,6 +2,7 @@ require 'kaminari'
 require 'nested_form'
 require 'rails'
 require 'rails_admin'
+require 'turbo-rails'
 
 module RailsAdmin
   class Engine < Rails::Engine

--- a/lib/rails_admin/support/esmodule_preprocessor.rb
+++ b/lib/rails_admin/support/esmodule_preprocessor.rb
@@ -13,7 +13,6 @@ module RailsAdmin
     def call(input)
       data = input[:data]
 
-      # only process files under rails_admin/src
       if input[:filename].start_with? RailsAdmin::Engine.root.join('src').to_s
         data.gsub!(/^(import .+)$/) { "// #{Regexp.last_match(1)}" }
         data.gsub!(/^(export +default +{)$/) do
@@ -24,6 +23,8 @@ module RailsAdmin
             raise "Unable to preprocess file: #{input[:filename]}"
           end
         end
+      elsif input[:filename] =~ %r{turbo-rails.+/turbo\.js$}
+        data.gsub!(/^(export .+)$/) { "// #{Regexp.last_match(1)}" }
       end
 
       {data: data}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
     "format": "prettier -w ."
   },
   "dependencies": {
+    "@babel/runtime": "^7.16.7",
     "@fortawesome/fontawesome-free": "^5.15.4",
+    "@hotwired/turbo-rails": "^7.1.0",
     "@popperjs/core": "^2.11.0",
     "@rails/ujs": "^6.1.4-1",
     "bootstrap": "^5.1.3",

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'kaminari', '>= 0.14', '< 2.0'
   spec.add_dependency 'nested_form', '~> 0.3'
   spec.add_dependency 'rails', ['>= 6.0', '< 8']
+  spec.add_dependency 'turbo-rails', '~> 1.0'
   spec.add_development_dependency 'bundler', '>= 1.0'
   spec.authors = ['Erik Michaels-Ober', 'Bogdan Gaza', 'Petteri Kaapa', 'Benoit Benezech', 'Mitsuhiro Shibuya']
   spec.description = 'RailsAdmin is a Rails engine that provides an easy-to-use interface for managing your data.'

--- a/spec/integration/fields/multiple_carrierwave_spec.rb
+++ b/spec/integration/fields/multiple_carrierwave_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe 'MultipleCarrierwave field', type: :request, active_record: true 
     visit new_path(model_name: 'field_test')
     attach_file 'Carrierwave assets', [file_path('test.jpg'), file_path('test.png')]
     click_button 'Save'
+    is_expected.to have_content 'Field test successfully created'
     expect(FieldTest.first.carrierwave_assets.map { |image| File.basename(image.url) }).to match_array ['test.jpg', 'test.png']
   end
 

--- a/spec/integration/fields/polymorphic_assosiation_spec.rb
+++ b/spec/integration/fields/polymorphic_assosiation_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
       expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
       page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
       click_button 'Save'
+      is_expected.to have_content 'Comment successfully created'
       expect(Comment.first.commentable).to eq @players[0]
     end
 
@@ -40,6 +41,7 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
 
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
         click_button 'Save'
+        is_expected.to have_content 'Comment successfully created'
         expect(Comment.first.commentable).to eq polymorphic_association_tests.first
       end
     end
@@ -65,6 +67,7 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
       expect(all('ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to eq ['Rob Wooten', 'Jackie Robinson']
       page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
       click_button 'Save'
+      is_expected.to have_content 'Comment successfully updated'
       expect(comment.reload.commentable).to eq players[0]
     end
 

--- a/src/rails_admin/base.js
+++ b/src/rails_admin/base.js
@@ -1,4 +1,5 @@
 import Rails from "@rails/ujs";
+import "@hotwired/turbo-rails";
 import jQuery from "jquery";
 import "./vendor/jquery_nested_form";
 import "bootstrap";

--- a/src/rails_admin/ui.js
+++ b/src/rails_admin/ui.js
@@ -51,7 +51,7 @@ import I18n from "./i18n";
     }
   );
 
-  $(document).ready(function () {
+  document.addEventListener("turbo:load", function () {
     I18n.init($("html").attr("lang"), $("#admin-js").data("i18nOptions"));
 
     const event = new CustomEvent("rails_admin.dom_ready");


### PR DESCRIPTION
Refs. https://github.com/railsadminteam/rails_admin/pull/3435#issuecomment-983566296

To test the significance of the performance improvement made by Turbo Drive, I performed a benchmark simulating site navigation with and without Turbo Drive.

### Preconditions
- The benchmark was performed using Chrome DevTools Performance panel, with CPU throttled to `6x slowdown` to make significance.
- Ran [dummy_app](https://github.com/railsadminteam/rails_admin/tree/master/spec/dummy_app) locally, with Webpack assets precompiled and CSSes extracted
- To test both page load and navigation in a time-precise way, these snippets are added to `src/rails_admin/ui.js`:
  - For non Turbo Drive version:
      ```diff
         $(document).ready(function () {
           I18n.init($("html").attr("lang"), $("#admin-js").data("i18nOptions"));

           const event = new CustomEvent("rails_admin.dom_ready");
           document.dispatchEvent(event);
         });
      +  window.addEventListener('load', function() {
      +    window.setTimeout(function () {
      +      if (window.performance.getEntriesByType('navigation').map((nav) => nav.type).includes('reload') && window.location.pathname == '/admin/') {
      +        window.location.href = '/admin/player';
      +      } else if (window.location.pathname == '/admin/player') {
      +        window.location.href = '/admin/player/752/edit';
      +      }
      +    }, 200);
      +  });
      ```
  - For Turbo Drive version:
      ```diff
         document.addEventListener("turbo:load", function () {
           I18n.init($("html").attr("lang"), $("#admin-js").data("i18nOptions"));
       
           const event = new CustomEvent("rails_admin.dom_ready");
           document.dispatchEvent(event);
         });
      +  window.addEventListener('load', function() {
      +    window.setTimeout(function () {
      +      if (window.location.pathname == '/admin/') {
      +        window.Turbo.visit('/admin/player');
      +      }
      +    }, 200);
      +  });
      +  window.addEventListener('turbo:render', function() {
      +    window.setTimeout(function () {
      +      if (window.location.pathname == '/admin/player') {
      +        window.Turbo.visit('/admin/player/752/edit');
      +      }
      +    }, 200);
      +  });
      ```

### Result

(I tried my best to roughly align the charts to represent the same timeframe per width, though it may be somewhat inaccurate...)

#### Without Turbo Drive
![image](https://user-images.githubusercontent.com/486678/151687652-79bf61ae-5ea7-434e-b7ac-57e3795f26d0.png)

#### With Turbo Drive
![image](https://user-images.githubusercontent.com/486678/151687709-3d5917d4-50f6-488f-88b8-9e9ffaad92aa.png)

I can roughly say that while the benchmark without Turbo Drive took roughly 1.1s to finish rendering the `edit` page, Turbo Drive one was reduced to 0.9s. In a real usage there will be more page transitions than the initial page load, so this difference will be more significant.

Based on this, my assumption is that introducing Turbo Drive will improve the UX.