### PR TITLE
Allow middleware that extends ActionDispatch::Session::AbstractSecureStore

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -49,6 +49,7 @@ module RailsAdmin
     config.after_initialize do |app|
       has_session_store = app.config.middleware.to_a.any? do |m|
         m.klass.try(:<=, ActionDispatch::Session::AbstractStore) ||
+          m.klass.try(:<=, ActionDispatch::Session::AbstractSecureStore) ||
           m.klass.name =~ /^ActionDispatch::Session::/
       end
       loaded = app.config.middleware.to_a.map(&:name)


### PR DESCRIPTION
After upgrading to version 0.11.4 of [`redis-session-store`](https://github.com/roidrage/redis-session-store), our application started failing to initialize due to the middleware check in `rails_admin`.

The failure is due to the [security fix](https://github.com/roidrage/redis-session-store/pull/125) in `redis-session-store` that changes the middleware to inherit from `ActionDispatch::Session::AbstractSecureStore` instead of `ActionDispatch::Session::AbstractStore`.

This PR simply changes the check in `engine.rb` to also allow middlewares that inherit from `ActionDispatch::Session::AbstractSecureStore`.

Would love to get this in the next 3.x beta.