### PR TITLE
[ActiveRecord] Fix DB connection issues during `assets:precompile`

### DIFF
--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -19,7 +19,7 @@ module RailsAdmin
       def new(m)
         m = m.constantize unless m.is_a?(Class)
         (am = old_new(m)).model && am.adapter ? am : nil
-      rescue *([LoadError, NameError] + (defined?(ActiveRecord) ? ['ActiveRecord::NoDatabaseError'.constantize] : []))
+      rescue *([LoadError, NameError] + (defined?(ActiveRecord) ? ['ActiveRecord::NoDatabaseError'.constantize, 'ActiveRecord::ConnectionNotEstablished'.constantize] : []))
         puts "[RailsAdmin] Could not load model #{m}, assuming model is non existing. (#{$ERROR_INFO})" unless Rails.env.test?
         nil
       end

--- a/spec/rails_admin/abstract_model_spec.rb
+++ b/spec/rails_admin/abstract_model_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe RailsAdmin::AbstractModel do
         expect(RailsAdmin::AbstractModel.new('WithoutTable')).to eq nil
       end
     end
+
+    context 'on ActiveRecord::ConnectionNotEstablished', active_record: true do
+      before do
+        expect(WithoutTable).to receive(:table_exists?).and_raise(ActiveRecord::ConnectionNotEstablished)
+      end
+
+      it 'does not raise error and returns nil' do
+        expect(RailsAdmin::AbstractModel.new('WithoutTable')).to eq nil
+      end
+    end
   end
 
   describe '#to_s' do


### PR DESCRIPTION
Closes #3469

When initializing abstract [(`ActiveRecord`) models](https://github.com/railsadminteam/rails_admin/blob/3d7f3b33a1ca6fabbd8606bb178babae930cce25/lib/rails_admin/abstract_model.rb#L49), `#table_exists?` is used and [calls through the `connection`](https://github.com/rails/rails/blob/086935ea1db543037609cd33f3b4d29e9fdd5c9a/activerecord/lib/active_record/model_schema.rb#L393-L396), which (in the case of a `precompile` step) can raise errors other than the `ActiveRecord::NoDatabaseError` that's [currently handled](https://github.com/railsadminteam/rails_admin/blob/3d7f3b33a1ca6fabbd8606bb178babae930cce25/lib/rails_admin/abstract_model.rb#L22-L25).

I believe this should cover all [PostgreSQL](https://github.com/rails/rails/blob/ffb3a3e01a17de4be457437443dcc7163d0330fe/activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb#L79-L89) and [MySQL](https://github.com/rails/rails/blob/ffb3a3e01a17de4be457437443dcc7163d0330fe/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L45-L55) connection errors handled by Rails.