### PR TITLE
Add post install message for upgrading 2.x.x -> 3.x.x

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -24,4 +24,12 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.8.11'
   spec.summary = 'Admin for Rails'
   spec.version = RailsAdmin::Version
+  spec.post_install_message = '
+    ### Upgrading from 2.x.x to 3.x.x ###
+
+    Due to introduction of Webpack/Webpacker support, some additional dependencies and configuration will be needed.
+    Running `bin/rails g rails_admin:install` will suggest required changes, based on the current setup of your app.
+
+    For a complete list of changes, see https://github.com/railsadminteam/rails_admin/blob/master/CHANGELOG.md
+  '
 end


### PR DESCRIPTION
Sample from running against a locally built copy of the last release candidate

```
$ gem install rails_admin-3.0.0.rc.gem --post-install-message

    ### Upgrading from 2.x.x to 3.x.x ###

    Due to introduction of Webpack/Webpacker support, some additional dependency and configuration will be needed.
    Running `bin/rails g rails_admin:install` will suggest required changes, based on the current setup of your app.

    For a complete list of changes, see https://github.com/railsadminteam/rails_admin/blob/master/CHANGELOG.md
  
Successfully installed rails_admin-3.0.0.rc
Parsing documentation for rails_admin-3.0.0.rc
Done installing documentation for rails_admin after 0 seconds
1 gem installed
```

This should help give some more guidance to users upgrading.