### PR TITLE
Fix: edit_user_link rendering

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -222,7 +222,6 @@ module RailsAdmin
           image_tag(gravatar_url(_current_user.email), alt: ''),
 
         content_tag(:span, _current_user.email),
-
       ].filter(&:present?).join.html_safe
     end
 

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -461,69 +461,59 @@ RSpec.describe RailsAdmin::ApplicationHelper, type: :helper do
     end
 
     describe '#edit_user_link' do
-      let(:current_user) { FactoryBot.create :user, email: 'admin@example.com' }
-      let(:gravatar_image_tag) { '<img alt="" src="https://secure.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=30" />' }
-
-      subject { helper.edit_user_link }
-
-      before do
-        expect(helper).to receive(:_current_user).at_least(:once) { current_user }
+      it "don't include email column" do
+        allow(helper).to receive(:_current_user).and_return(FactoryBot.create(:player))
+        result = helper.edit_user_link
+        expect(result).to eq nil
       end
 
-      context 'without email column' do
-        let(:current_user) { FactoryBot.create :player }
-
-        it { should be_nil }
+      it 'include email column' do
+        allow(helper).to receive(:_current_user).and_return(FactoryBot.create(:user))
+        result = helper.edit_user_link
+        expect(result).to match('href')
       end
 
-      context 'gravatar enabled' do
-        before do
-          RailsAdmin.config { |config| config.show_gravatar = true }
+      it 'show gravatar' do
+        allow(helper).to receive(:_current_user).and_return(FactoryBot.create(:user))
+        result = helper.edit_user_link
+        expect(result).to include('gravatar')
+      end
+
+      it "don't show gravatar" do
+        RailsAdmin.config do |config|
+          config.show_gravatar = false
         end
 
-        it { should match 'href' }
-        it { should match %r{href=".[^"]+/admin/user\?action_name=edit&amp;id=#{current_user.id}"} }
-
-        it { should include 'gravatar' }
-        it { should include gravatar_image_tag }
-
-        it { should include current_user.email }
+        allow(helper).to receive(:_current_user).and_return(FactoryBot.create(:user))
+        result = helper.edit_user_link
+        expect(result).not_to include('gravatar')
       end
 
-      context 'gravatar disabled' do
+      context 'when the user is not authorized to perform edit' do
+        let(:user) { FactoryBot.create(:user) }
         before do
-          RailsAdmin.config { |config| config.show_gravatar = false }
-        end
-
-        it { should_not include 'gravatar' }
-      end
-
-      context 'when the user is not authorized to perform edit, gravatar enabled' do
-        before do
-          RailsAdmin.config { |config| config.show_gravatar = true }
           allow_any_instance_of(RailsAdmin::Config::Actions::Edit).to receive(:authorized?).and_return(false)
+          allow(helper).to receive(:_current_user).and_return(user)
         end
 
-        it { should_not match 'href' }
-
-        it { should include 'gravatar' }
-        it { should include gravatar_image_tag }
-
-        it { should include current_user.email }
-      end
-
-      context 'when the user is not authorized to perform edit, gravatar disabled' do
-        before do
-          RailsAdmin.config { |config| config.show_gravatar = false }
-          allow_any_instance_of(RailsAdmin::Config::Actions::Edit).to receive(:authorized?).and_return(false)
+        it 'show gravatar and email without a link' do
+          result = helper.edit_user_link
+          expect(result).to include('gravatar')
+          expect(result).to include(user.email)
+          expect(result).not_to match('href')
         end
 
-        it { should_not match 'href' }
+        it 'without gravatar and email without a link' do
+          RailsAdmin.config do |config|
+            config.show_gravatar = false
+          end
 
-        it { should_not include 'gravatar' }
-
-        it { should include current_user.email }
-        it { should include "<span>#{current_user.email}</span>" }
+          result = helper.edit_user_link
+          expect(result).not_to include('gravatar')
+          expect(result).not_to match('href')
+          expect(result).to include(user.email)
+          expect(result).to match("<span class=\"nav-link\"><span>#{user.email}</span></span>")
+        end
       end
     end
   end


### PR DESCRIPTION
if `config.show_gravatar` is e.g. `false`, "false" becomes part of the render output as `false` is not nil and therefore not removed on `#compact`

if there is no edit-user action to be found, the rendered output was 2 nested spans, which messed up layout.
