### PR TITLE
Simplify heredocs with squiggly syntax

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -208,7 +208,7 @@ module RailsAdmin
       yield
     rescue LoadError => e
       if /sassc/.match?(e.message)
-        e = e.exception <<-MSG.gsub(/^\s{10}/, '')
+        e = e.exception <<~MSG
           #{e.message}
           RailsAdmin requires the gem sassc-rails, make sure to put `gem 'sassc-rails'` to Gemfile.
         MSG

--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -54,7 +54,7 @@ module RailsAdmin
         scope
       rescue NoMethodError => e
         if /page/.match?(e.message)
-          e = e.exception <<-ERROR.gsub(/^\s{12}/, '')
+          e = e.exception <<~ERROR
             #{e.message}
             If you don't have kaminari-mongoid installed, add `gem 'kaminari-mongoid'` to your Gemfile.
           ERROR

--- a/lib/rails_admin/adapters/mongoid/association.rb
+++ b/lib/rails_admin/adapters/mongoid/association.rb
@@ -113,10 +113,10 @@ module RailsAdmin
         def nested_options
           nested = nested_attributes_options.try { |o| o[name] }
           if !nested && %i[embeds_one embeds_many].include?(macro.to_sym) && !cyclic?
-            raise <<-MSG.gsub(/^\s+/, '')
-            Embbeded association without accepts_nested_attributes_for can't be handled by RailsAdmin,
-            because embedded model doesn't have top-level access.
-            Please add `accepts_nested_attributes_for :#{association.name}' line to `#{model}' model.
+            raise <<~MSG
+              Embbeded association without accepts_nested_attributes_for can't be handled by RailsAdmin,
+              because embedded model doesn't have top-level access.
+              Please add `accepts_nested_attributes_for :#{association.name}' line to `#{model}' model.
             MSG
           end
 

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -262,7 +262,7 @@ module RailsAdmin
       def asset_source
         @asset_source ||=
           begin
-            warn <<-MSG.gsub(/^ +/, '')
+            warn <<~MSG
               [Warning] After upgrading RailsAdmin to 3.x you haven't set asset_source yet, using :sprockets as the default.
               To suppress this message, run 'rails rails_admin:install' to setup the asset delivery method suitable to you.
             MSG

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -303,13 +303,13 @@ module RailsAdmin
         def value
           bindings[:object].safe_send(name)
         rescue NoMethodError => e
-          raise e.exception <<-ERROR.gsub(/^\s{10}/, '')
-          #{e.message}
-          If you want to use a RailsAdmin virtual field(= a field without corresponding instance method),
-          you should declare 'formatted_value' in the field definition.
-            field :#{name} do
-              formatted_value{ bindings[:object].call_some_method }
-            end
+          raise e.exception <<~ERROR
+            #{e.message}
+            If you want to use a RailsAdmin virtual field(= a field without corresponding instance method),
+            you should declare 'formatted_value' in the field definition.
+              field :#{name} do
+                formatted_value{ bindings[:object].call_some_method }
+              end
           ERROR
         end
 

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -51,7 +51,7 @@ module RailsAdmin
           created_at: :created_at,
           message: :event,
         }.freeze
-        E_VERSION_MODEL_NOT_SET = <<-ERROR.strip_heredoc
+        E_VERSION_MODEL_NOT_SET = <<~ERROR
           Please set up PaperTrail's version model explicitly.
 
               config.audit_with :paper_trail, 'User', 'PaperTrail::Version'

--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -41,7 +41,7 @@ module RailsAdmin
 
     def to_csv(options = {})
       if CSV::VERSION == '3.0.2'
-        raise <<-MSG.gsub(/^\s+/, '')
+        raise <<~MSG
           CSV library bundled with Ruby 2.6.0 has encoding issue, please upgrade Ruby to 2.6.1 or later.
           https://github.com/ruby/csv/issues/62
         MSG

--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -52,7 +52,7 @@ module RailsAdmin
             when '%z' # Time zone as hour and minute offset from UTC (e.g. +0900)
               Time.zone.formatted_offset(false)
             else
-              FLATPICKR_TRANSLATIONS[match] or raise <<-MSG.gsub(/^\s{16}/, '')
+              FLATPICKR_TRANSLATIONS[match] or raise <<~MSG
                 Unsupported strftime directive '#{match}' was found. Please consider explicitly setting flatpickr_format instance option for the field.
                   field(:name_of_field) { flatpickr_format '...' }
               MSG

--- a/spec/rails_admin/install_generator_spec.rb
+++ b/spec/rails_admin/install_generator_spec.rb
@@ -12,10 +12,10 @@ RSpec.describe RailsAdmin::InstallGenerator, type: :generator do
     File.write(File.join(destination_root, 'package.json'), '{"license": "MIT"}')
     FileUtils.touch File.join(destination_root, 'Gemfile')
     FileUtils.mkdir_p(File.join(destination_root, 'config/initializers'))
-    File.write(File.join(destination_root, 'config/routes.rb'), <<-RUBY.gsub(/^ {4}/, ''))
-    Rails.application.routes.draw do
-      # empty
-    end
+    File.write(File.join(destination_root, 'config/routes.rb'), <<~RUBY)
+      Rails.application.routes.draw do
+        # empty
+      end
     RUBY
   end
 
@@ -58,10 +58,10 @@ RSpec.describe RailsAdmin::InstallGenerator, type: :generator do
   end
 
   it 'inserts asset_source option to RailsAdmin Initializer' do
-    File.write(File.join(destination_root, 'config/initializers/rails_admin.rb'), <<-RUBY.gsub(/^ {4}/, ''))
-    RailsAdmin.config do |config|
-      # empty
-    end
+    File.write(File.join(destination_root, 'config/initializers/rails_admin.rb'), <<~RUBY)
+      RailsAdmin.config do |config|
+        # empty
+      end
     RUBY
     Dir.chdir(destination_root) do
       run_generator


### PR DESCRIPTION
The squiggly syntax removes the need to chop leading white space from
the string.

https://ruby-doc.org/core-3.0.2/doc/syntax/literals_rdoc.html#label-Here+Documents+-28heredocs-29