### PR TITLE
Enable frozen string literals across the project

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -168,9 +168,6 @@ Style/Encoding:
 Style/EndlessMethod:
   Enabled: true
 
-Style/FrozenStringLiteralComment:
-  Enabled: false
-
 Style/HashConversion:
   Enabled: true
 

--- a/Appraisals
+++ b/Appraisals
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 appraise 'rails-6.0' do
   gem 'rails', '~> 6.0.0'
   gem 'sassc-rails', '~> 2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'appraisal', '>= 2.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/controllers/rails_admin/application_controller.rb
+++ b/app/controllers/rails_admin/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/abstract_model'
 
 module RailsAdmin

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   class MainController < RailsAdmin::ApplicationController
     include ActionView::Helpers::TextHelper

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module ApplicationHelper
     def authorized?(action_name, abstract_model = nil, object = nil)

--- a/app/helpers/rails_admin/form_builder.rb
+++ b/app/helpers/rails_admin/form_builder.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nested_form/builder_mixin'
 
 module RailsAdmin

--- a/app/helpers/rails_admin/main_helper.rb
+++ b/app/helpers/rails_admin/main_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module MainHelper
     def rails_admin_form_for(*args, &block)

--- a/config/initializers/active_record_extensions.rb
+++ b/config/initializers/active_record_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ActiveSupport.on_load(:active_record) do
   module ActiveRecord
     class Base

--- a/config/initializers/mongoid_extensions.rb
+++ b/config/initializers/mongoid_extensions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if defined?(::Mongoid::Document)
   require 'rails_admin/adapters/mongoid/extension'
   Mongoid::Document.include RailsAdmin::Adapters::Mongoid::Extension

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RailsAdmin::Engine.routes.draw do
   controller 'main' do
     RailsAdmin::Config::Actions.all(:root).each { |action| match "/#{action.route_fragment}", action: action.action_name, as: action.action_name, via: action.http_methods }

--- a/lib/generators/rails_admin/install_generator.rb
+++ b/lib/generators/rails_admin/install_generator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails/generators'
 require 'rails_admin/version'
 require File.expand_path('utils', __dir__)

--- a/lib/generators/rails_admin/utils.rb
+++ b/lib/generators/rails_admin/utils.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Generators
     module Utils

--- a/lib/rails_admin.rb
+++ b/lib/rails_admin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/engine'
 require 'rails_admin/abstract_model'
 require 'rails_admin/config'

--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/support/datetime'
 
 module RailsAdmin

--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_record'
 require 'rails_admin/adapters/active_record/association'
 require 'rails_admin/adapters/active_record/object_extension'

--- a/lib/rails_admin/adapters/active_record/association.rb
+++ b/lib/rails_admin/adapters/active_record/association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Adapters
     module ActiveRecord

--- a/lib/rails_admin/adapters/active_record/object_extension.rb
+++ b/lib/rails_admin/adapters/active_record/object_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Adapters
     module ActiveRecord

--- a/lib/rails_admin/adapters/active_record/property.rb
+++ b/lib/rails_admin/adapters/active_record/property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Adapters
     module ActiveRecord

--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mongoid'
 require 'rails_admin/config/sections/list'
 require 'rails_admin/adapters/mongoid/association'

--- a/lib/rails_admin/adapters/mongoid/association.rb
+++ b/lib/rails_admin/adapters/mongoid/association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Adapters
     module Mongoid

--- a/lib/rails_admin/adapters/mongoid/bson.rb
+++ b/lib/rails_admin/adapters/mongoid/bson.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mongoid'
 
 module RailsAdmin

--- a/lib/rails_admin/adapters/mongoid/extension.rb
+++ b/lib/rails_admin/adapters/mongoid/extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Adapters
     module Mongoid

--- a/lib/rails_admin/adapters/mongoid/object_extension.rb
+++ b/lib/rails_admin/adapters/mongoid/object_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Adapters
     module Mongoid

--- a/lib/rails_admin/adapters/mongoid/property.rb
+++ b/lib/rails_admin/adapters/mongoid/property.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Adapters
     module Mongoid

--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/model'
 require 'rails_admin/config/sections/list'
 require 'active_support/core_ext/module/attribute_accessors'
@@ -260,7 +262,7 @@ module RailsAdmin
       def asset_source
         @asset_source ||=
           begin
-            warn <<-MSG.gsub(/^ +/, '').freeze
+            warn <<-MSG.gsub(/^ +/, '')
               [Warning] After upgrading RailsAdmin to 3.x you haven't set asset_source yet, using :sprockets as the default.
               To suppress this message, run 'rails rails_admin:install' to setup the asset delivery method suitable to you.
             MSG

--- a/lib/rails_admin/config/actions.rb
+++ b/lib/rails_admin/config/actions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/base.rb
+++ b/lib/rails_admin/config/actions/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/proxyable'
 require 'rails_admin/config/configurable'
 require 'rails_admin/config/hideable'

--- a/lib/rails_admin/config/actions/bulk_delete.rb
+++ b/lib/rails_admin/config/actions/bulk_delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/dashboard.rb
+++ b/lib/rails_admin/config/actions/dashboard.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/delete.rb
+++ b/lib/rails_admin/config/actions/delete.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/edit.rb
+++ b/lib/rails_admin/config/actions/edit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/export.rb
+++ b/lib/rails_admin/config/actions/export.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/history_index.rb
+++ b/lib/rails_admin/config/actions/history_index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/history_show.rb
+++ b/lib/rails_admin/config/actions/history_show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/index.rb
+++ b/lib/rails_admin/config/actions/index.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'activemodel-serializers-xml'
 
 module RailsAdmin

--- a/lib/rails_admin/config/actions/new.rb
+++ b/lib/rails_admin/config/actions/new.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/show.rb
+++ b/lib/rails_admin/config/actions/show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/actions/show_in_app.rb
+++ b/lib/rails_admin/config/actions/show_in_app.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Actions

--- a/lib/rails_admin/config/configurable.rb
+++ b/lib/rails_admin/config/configurable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     # A module for all configurables.

--- a/lib/rails_admin/config/fields.rb
+++ b/lib/rails_admin/config/fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Fields

--- a/lib/rails_admin/config/fields/association.rb
+++ b/lib/rails_admin/config/fields/association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config'
 require 'rails_admin/config/fields/base'
 

--- a/lib/rails_admin/config/fields/base.rb
+++ b/lib/rails_admin/config/fields/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/proxyable'
 require 'rails_admin/config/configurable'
 require 'rails_admin/config/hideable'

--- a/lib/rails_admin/config/fields/factories/action_text.rb
+++ b/lib/rails_admin/config/fields/factories/action_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 

--- a/lib/rails_admin/config/fields/factories/active_storage.rb
+++ b/lib/rails_admin/config/fields/factories/active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/file_upload'

--- a/lib/rails_admin/config/fields/factories/association.rb
+++ b/lib/rails_admin/config/fields/factories/association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/belongs_to_association'

--- a/lib/rails_admin/config/fields/factories/carrierwave.rb
+++ b/lib/rails_admin/config/fields/factories/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/file_upload'

--- a/lib/rails_admin/config/fields/factories/devise.rb
+++ b/lib/rails_admin/config/fields/factories/devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/password'

--- a/lib/rails_admin/config/fields/factories/dragonfly.rb
+++ b/lib/rails_admin/config/fields/factories/dragonfly.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/file_upload'

--- a/lib/rails_admin/config/fields/factories/enum.rb
+++ b/lib/rails_admin/config/fields/factories/enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types/enum'
 require 'rails_admin/config/fields/types/active_record_enum'

--- a/lib/rails_admin/config/fields/factories/paperclip.rb
+++ b/lib/rails_admin/config/fields/factories/paperclip.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/file_upload'

--- a/lib/rails_admin/config/fields/factories/password.rb
+++ b/lib/rails_admin/config/fields/factories/password.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types/password'
 

--- a/lib/rails_admin/config/fields/factories/shrine.rb
+++ b/lib/rails_admin/config/fields/factories/shrine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/types'
 require 'rails_admin/config/fields/types/file_upload'

--- a/lib/rails_admin/config/fields/group.rb
+++ b/lib/rails_admin/config/fields/group.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/string/inflections'
 require 'rails_admin/config/proxyable'
 require 'rails_admin/config/configurable'

--- a/lib/rails_admin/config/fields/types.rb
+++ b/lib/rails_admin/config/fields/types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/string/inflections'
 require 'rails_admin/config/fields'
 require 'rails_admin/config/fields/association'

--- a/lib/rails_admin/config/fields/types/action_text.rb
+++ b/lib/rails_admin/config/fields/types/action_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/active_record_enum.rb
+++ b/lib/rails_admin/config/fields/types/active_record_enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/enum'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/file_upload'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/all.rb
+++ b/lib/rails_admin/config/fields/types/all.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/action_text'
 require 'rails_admin/config/fields/types/active_record_enum'
 require 'rails_admin/config/fields/types/active_storage'

--- a/lib/rails_admin/config/fields/types/belongs_to_association.rb
+++ b/lib/rails_admin/config/fields/types/belongs_to_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/association'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/boolean.rb
+++ b/lib/rails_admin/config/fields/types/boolean.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Fields

--- a/lib/rails_admin/config/fields/types/bson_object_id.rb
+++ b/lib/rails_admin/config/fields/types/bson_object_id.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/carrierwave.rb
+++ b/lib/rails_admin/config/fields/types/carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/base'
 require 'rails_admin/config/fields/types/file_upload'
 

--- a/lib/rails_admin/config/fields/types/citext.rb
+++ b/lib/rails_admin/config/fields/types/citext.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/ck_editor.rb
+++ b/lib/rails_admin/config/fields/types/ck_editor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/code_mirror.rb
+++ b/lib/rails_admin/config/fields/types/code_mirror.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/color.rb
+++ b/lib/rails_admin/config/fields/types/color.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string_like'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/date.rb
+++ b/lib/rails_admin/config/fields/types/date.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/datetime'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/datetime.rb
+++ b/lib/rails_admin/config/fields/types/datetime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/base'
 require 'rails_admin/support/datetime'
 

--- a/lib/rails_admin/config/fields/types/decimal.rb
+++ b/lib/rails_admin/config/fields/types/decimal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/numeric'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/dragonfly.rb
+++ b/lib/rails_admin/config/fields/types/dragonfly.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/base'
 require 'rails_admin/config/fields/types/file_upload'
 

--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/float.rb
+++ b/lib/rails_admin/config/fields/types/float.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/numeric'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/froala.rb
+++ b/lib/rails_admin/config/fields/types/froala.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_and_belongs_to_many_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/has_many_association'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/has_many_association.rb
+++ b/lib/rails_admin/config/fields/types/has_many_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/association'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/has_one_association.rb
+++ b/lib/rails_admin/config/fields/types/has_one_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/association'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/hidden.rb
+++ b/lib/rails_admin/config/fields/types/hidden.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string_like'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/inet.rb
+++ b/lib/rails_admin/config/fields/types/inet.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/base'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/integer.rb
+++ b/lib/rails_admin/config/fields/types/integer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/numeric'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/json.rb
+++ b/lib/rails_admin/config/fields/types/json.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/multiple_active_storage.rb
+++ b/lib/rails_admin/config/fields/types/multiple_active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/multiple_file_upload'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/multiple_carrierwave.rb
+++ b/lib/rails_admin/config/fields/types/multiple_carrierwave.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/multiple_file_upload'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/multiple_file_upload.rb
+++ b/lib/rails_admin/config/fields/types/multiple_file_upload.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Fields

--- a/lib/rails_admin/config/fields/types/numeric.rb
+++ b/lib/rails_admin/config/fields/types/numeric.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/base'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/paperclip.rb
+++ b/lib/rails_admin/config/fields/types/paperclip.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/base'
 require 'rails_admin/config/fields/types/file_upload'
 

--- a/lib/rails_admin/config/fields/types/password.rb
+++ b/lib/rails_admin/config/fields/types/password.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/polymorphic_association.rb
+++ b/lib/rails_admin/config/fields/types/polymorphic_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/belongs_to_association'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/serialized.rb
+++ b/lib/rails_admin/config/fields/types/serialized.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/shrine.rb
+++ b/lib/rails_admin/config/fields/types/shrine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/file_upload'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/simple_mde.rb
+++ b/lib/rails_admin/config/fields/types/simple_mde.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/string.rb
+++ b/lib/rails_admin/config/fields/types/string.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string_like'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/string_like.rb
+++ b/lib/rails_admin/config/fields/types/string_like.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/base'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/text.rb
+++ b/lib/rails_admin/config/fields/types/text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string_like'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/time.rb
+++ b/lib/rails_admin/config/fields/types/time.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/datetime'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/timestamp.rb
+++ b/lib/rails_admin/config/fields/types/timestamp.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/datetime'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/uuid.rb
+++ b/lib/rails_admin/config/fields/types/uuid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/string'
 
 module RailsAdmin

--- a/lib/rails_admin/config/fields/types/wysihtml5.rb
+++ b/lib/rails_admin/config/fields/types/wysihtml5.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/types/text'
 
 module RailsAdmin

--- a/lib/rails_admin/config/groupable.rb
+++ b/lib/rails_admin/config/groupable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/group'
 
 module RailsAdmin

--- a/lib/rails_admin/config/has_description.rb
+++ b/lib/rails_admin/config/has_description.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     # Provides accessor and autoregistering of model's description.

--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     # Provides accessors and autoregistering of model's fields.

--- a/lib/rails_admin/config/has_groups.rb
+++ b/lib/rails_admin/config/has_groups.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/fields/group'
 
 module RailsAdmin

--- a/lib/rails_admin/config/hideable.rb
+++ b/lib/rails_admin/config/hideable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     # Defines a visibility configuration

--- a/lib/rails_admin/config/inspectable.rb
+++ b/lib/rails_admin/config/inspectable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Inspectable

--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config'
 require 'rails_admin/config/proxyable'
 require 'rails_admin/config/configurable'

--- a/lib/rails_admin/config/proxyable.rb
+++ b/lib/rails_admin/config/proxyable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/proxyable/proxy'
 module RailsAdmin
   module Config

--- a/lib/rails_admin/config/proxyable/proxy.rb
+++ b/lib/rails_admin/config/proxyable/proxy.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Config
     module Proxyable

--- a/lib/rails_admin/config/sections.rb
+++ b/lib/rails_admin/config/sections.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/string/inflections'
 require 'rails_admin/config/sections/base'
 require 'rails_admin/config/sections/edit'

--- a/lib/rails_admin/config/sections/base.rb
+++ b/lib/rails_admin/config/sections/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/proxyable'
 require 'rails_admin/config/configurable'
 require 'rails_admin/config/inspectable'

--- a/lib/rails_admin/config/sections/create.rb
+++ b/lib/rails_admin/config/sections/create.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/edit'
 
 module RailsAdmin

--- a/lib/rails_admin/config/sections/edit.rb
+++ b/lib/rails_admin/config/sections/edit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/base'
 
 module RailsAdmin

--- a/lib/rails_admin/config/sections/export.rb
+++ b/lib/rails_admin/config/sections/export.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/base'
 
 module RailsAdmin

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/base'
 
 module RailsAdmin

--- a/lib/rails_admin/config/sections/modal.rb
+++ b/lib/rails_admin/config/sections/modal.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/edit'
 
 module RailsAdmin

--- a/lib/rails_admin/config/sections/nested.rb
+++ b/lib/rails_admin/config/sections/nested.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/edit'
 
 module RailsAdmin

--- a/lib/rails_admin/config/sections/show.rb
+++ b/lib/rails_admin/config/sections/show.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/base'
 
 module RailsAdmin

--- a/lib/rails_admin/config/sections/update.rb
+++ b/lib/rails_admin/config/sections/update.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/config/sections/edit'
 
 module RailsAdmin

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'kaminari'
 require 'nested_form'
 require 'rails'

--- a/lib/rails_admin/extension.rb
+++ b/lib/rails_admin/extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/extensions/controller_extension'
 
 module RailsAdmin

--- a/lib/rails_admin/extensions/cancancan.rb
+++ b/lib/rails_admin/extensions/cancancan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/extensions/cancancan/authorization_adapter'
 
 RailsAdmin.add_extension(:cancancan, RailsAdmin::Extensions::CanCanCan, authorization: true)

--- a/lib/rails_admin/extensions/cancancan/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/cancancan/authorization_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Extensions
     module CanCanCan

--- a/lib/rails_admin/extensions/controller_extension.rb
+++ b/lib/rails_admin/extensions/controller_extension.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Extensions
     module ControllerExtension

--- a/lib/rails_admin/extensions/paper_trail.rb
+++ b/lib/rails_admin/extensions/paper_trail.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/extensions/paper_trail/auditing_adapter'
 
 RailsAdmin.add_extension(:paper_trail, RailsAdmin::Extensions::PaperTrail, auditing: true)

--- a/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
+++ b/lib/rails_admin/extensions/paper_trail/auditing_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support/core_ext/string/strip'
 
 module RailsAdmin
@@ -49,7 +51,7 @@ module RailsAdmin
           created_at: :created_at,
           message: :event,
         }.freeze
-        E_VERSION_MODEL_NOT_SET = <<-ERROR.strip_heredoc.freeze
+        E_VERSION_MODEL_NOT_SET = <<-ERROR.strip_heredoc
           Please set up PaperTrail's version model explicitly.
 
               config.audit_with :paper_trail, 'User', 'PaperTrail::Version'

--- a/lib/rails_admin/extensions/pundit.rb
+++ b/lib/rails_admin/extensions/pundit.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/extensions/pundit/authorization_adapter'
 
 RailsAdmin.add_extension(:pundit, RailsAdmin::Extensions::Pundit, authorization: true)

--- a/lib/rails_admin/extensions/pundit/authorization_adapter.rb
+++ b/lib/rails_admin/extensions/pundit/authorization_adapter.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Extensions
     module Pundit

--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -1,4 +1,5 @@
 # encoding: UTF-8
+# frozen_string_literal: true
 
 require 'csv'
 

--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   module Support
     class Datetime

--- a/lib/rails_admin/support/esmodule_preprocessor.rb
+++ b/lib/rails_admin/support/esmodule_preprocessor.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   class ESModulePreprocessor
     def self.instance

--- a/lib/rails_admin/support/hash_helper.rb
+++ b/lib/rails_admin/support/hash_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   class HashHelper
     def self.symbolize(obj)

--- a/lib/rails_admin/version.rb
+++ b/lib/rails_admin/version.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module RailsAdmin
   class Version
     MAJOR = 3
     MINOR = 0
     PATCH = 0
-    PRE = 'rc3'.freeze
+    PRE = 'rc3'
 
     class << self
       # @return [String]

--- a/lib/tasks/rails_admin.rake
+++ b/lib/tasks/rails_admin.rake
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :rails_admin do
   desc 'Install rails_admin'
   task :install do

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)

--- a/spec/controllers/rails_admin/application_controller_spec.rb
+++ b/spec/controllers/rails_admin/application_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::ApplicationController, type: :controller do

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/dummy_app/Gemfile
+++ b/spec/dummy_app/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 gem 'rails', '>= 6.0.0'

--- a/spec/dummy_app/Rakefile
+++ b/spec/dummy_app/Rakefile
@@ -1,4 +1,6 @@
 #!/usr/bin/env rake
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/spec/dummy_app/app/active_record/abstract.rb
+++ b/spec/dummy_app/app/active_record/abstract.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Abstract < ActiveRecord::Base
   self.abstract_class = true
 end

--- a/spec/dummy_app/app/active_record/another_field_test.rb
+++ b/spec/dummy_app/app/active_record/another_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AnotherFieldTest < ActiveRecord::Base
   has_many :nested_field_tests, inverse_of: :another_field_test
 end

--- a/spec/dummy_app/app/active_record/ball.rb
+++ b/spec/dummy_app/app/active_record/ball.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Ball < ActiveRecord::Base
   has_one :comment, as: :commentable
 

--- a/spec/dummy_app/app/active_record/carrierwave_uploader.rb
+++ b/spec/dummy_app/app/active_record/carrierwave_uploader.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'mini_magick'
 class CarrierwaveUploader < CarrierWave::Uploader::Base

--- a/spec/dummy_app/app/active_record/category.rb
+++ b/spec/dummy_app/app/active_record/category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Category < ActiveRecord::Base
   belongs_to :parent_category, class_name: 'Category', optional: true
 end

--- a/spec/dummy_app/app/active_record/cms.rb
+++ b/spec/dummy_app/app/active_record/cms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cms
   def self.table_name_prefix
     'cms_'

--- a/spec/dummy_app/app/active_record/cms/basic_page.rb
+++ b/spec/dummy_app/app/active_record/cms/basic_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cms
   class BasicPage < ActiveRecord::Base
     self.table_name = :cms_basic_pages

--- a/spec/dummy_app/app/active_record/comment.rb
+++ b/spec/dummy_app/app/active_record/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment < ActiveRecord::Base
   include Taggable
   belongs_to :commentable, polymorphic: true, optional: true

--- a/spec/dummy_app/app/active_record/comment/confirmed.rb
+++ b/spec/dummy_app/app/active_record/comment/confirmed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment
   class Confirmed < Comment
     default_scope { where(content: 'something') }

--- a/spec/dummy_app/app/active_record/concerns/taggable.rb
+++ b/spec/dummy_app/app/active_record/concerns/taggable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Taggable
   extend ActiveSupport::Concern
   # dummy

--- a/spec/dummy_app/app/active_record/deeply_nested_field_test.rb
+++ b/spec/dummy_app/app/active_record/deeply_nested_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeeplyNestedFieldTest < ActiveRecord::Base
   belongs_to :nested_field_test, inverse_of: :deeply_nested_field_tests
 end

--- a/spec/dummy_app/app/active_record/division.rb
+++ b/spec/dummy_app/app/active_record/division.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Division < ActiveRecord::Base
   self.primary_key = :custom_id
 

--- a/spec/dummy_app/app/active_record/draft.rb
+++ b/spec/dummy_app/app/active_record/draft.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Draft < ActiveRecord::Base
   belongs_to :team
   belongs_to :player

--- a/spec/dummy_app/app/active_record/eager_loaded/basketball.rb
+++ b/spec/dummy_app/app/active_record/eager_loaded/basketball.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Basketball < Ball
 end

--- a/spec/dummy_app/app/active_record/fan.rb
+++ b/spec/dummy_app/app/active_record/fan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Fan < ActiveRecord::Base
   has_and_belongs_to_many :teams
 

--- a/spec/dummy_app/app/active_record/field_test.rb
+++ b/spec/dummy_app/app/active_record/field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class FieldTest < ActiveRecord::Base
   has_many :nested_field_tests, dependent: :destroy, inverse_of: :field_test
   accepts_nested_attributes_for :nested_field_tests, allow_destroy: true

--- a/spec/dummy_app/app/active_record/hardball.rb
+++ b/spec/dummy_app/app/active_record/hardball.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Hardball < Ball
 end

--- a/spec/dummy_app/app/active_record/image.rb
+++ b/spec/dummy_app/app/active_record/image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Image < ActiveRecord::Base
   has_attached_file :file, styles: {medium: '300x300>', thumb: '100x100>'}
   validates_attachment_presence :file

--- a/spec/dummy_app/app/active_record/league.rb
+++ b/spec/dummy_app/app/active_record/league.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class League < ActiveRecord::Base
   has_many :divisions, foreign_key: 'custom_league_id'
   has_many :teams, -> { readonly }, through: :divisions

--- a/spec/dummy_app/app/active_record/managed_team.rb
+++ b/spec/dummy_app/app/active_record/managed_team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ManagedTeam < Team
   belongs_to :user, class_name: 'ManagingUser', foreign_key: :manager, primary_key: :email, optional: true, inverse_of: :teams
 end

--- a/spec/dummy_app/app/active_record/managing_user.rb
+++ b/spec/dummy_app/app/active_record/managing_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ManagingUser < User
   has_one :team, class_name: 'ManagedTeam', foreign_key: :manager, primary_key: :email, inverse_of: :user
   has_many :teams, class_name: 'ManagedTeam', foreign_key: :manager, primary_key: :email, inverse_of: :user

--- a/spec/dummy_app/app/active_record/nested_field_test.rb
+++ b/spec/dummy_app/app/active_record/nested_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NestedFieldTest < ActiveRecord::Base
   belongs_to :field_test, optional: true, inverse_of: :nested_field_tests
   belongs_to :another_field_test, optional: true, inverse_of: :nested_field_tests

--- a/spec/dummy_app/app/active_record/paper_trail_test.rb
+++ b/spec/dummy_app/app/active_record/paper_trail_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PaperTrailTest < ActiveRecord::Base
   has_paper_trail
 end

--- a/spec/dummy_app/app/active_record/paper_trail_test/subclass_in_namespace.rb
+++ b/spec/dummy_app/app/active_record/paper_trail_test/subclass_in_namespace.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PaperTrailTest < ActiveRecord::Base
   class SubclassInNamespace < self
   end

--- a/spec/dummy_app/app/active_record/paper_trail_test_subclass.rb
+++ b/spec/dummy_app/app/active_record/paper_trail_test_subclass.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class PaperTrailTestSubclass < PaperTrailTest
 end

--- a/spec/dummy_app/app/active_record/paper_trail_test_with_custom_association.rb
+++ b/spec/dummy_app/app/active_record/paper_trail_test_with_custom_association.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Trail < PaperTrail::Version
   self.table_name = :custom_versions
 end

--- a/spec/dummy_app/app/active_record/player.rb
+++ b/spec/dummy_app/app/active_record/player.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Player < ActiveRecord::Base
   belongs_to :team, optional: true, inverse_of: :players
   has_one :draft, dependent: :destroy

--- a/spec/dummy_app/app/active_record/read_only_comment.rb
+++ b/spec/dummy_app/app/active_record/read_only_comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReadOnlyComment < Comment
   def readonly?
     true

--- a/spec/dummy_app/app/active_record/restricted_team.rb
+++ b/spec/dummy_app/app/active_record/restricted_team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RestrictedTeam < Team
   has_many :players, foreign_key: :team_id, dependent: :restrict_with_error
 end

--- a/spec/dummy_app/app/active_record/shrine_uploader.rb
+++ b/spec/dummy_app/app/active_record/shrine_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ShrineUploader < Shrine
   plugin :activerecord
 

--- a/spec/dummy_app/app/active_record/shrine_versioning_uploader.rb
+++ b/spec/dummy_app/app/active_record/shrine_versioning_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ShrineVersioningUploader < Shrine
   plugin :activerecord
 

--- a/spec/dummy_app/app/active_record/team.rb
+++ b/spec/dummy_app/app/active_record/team.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 class Team < ActiveRecord::Base
   has_many :players, -> { order :id }, inverse_of: :team

--- a/spec/dummy_app/app/active_record/two_level/namespaced.rb
+++ b/spec/dummy_app/app/active_record/two_level/namespaced.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoLevel
   module Namespaced
     def self.table_name_prefix

--- a/spec/dummy_app/app/active_record/two_level/namespaced/polymorphic_association_test.rb
+++ b/spec/dummy_app/app/active_record/two_level/namespaced/polymorphic_association_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoLevel
   module Namespaced
     class PolymorphicAssociationTest < ActiveRecord::Base

--- a/spec/dummy_app/app/active_record/user.rb
+++ b/spec/dummy_app/app/active_record/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :token_authenticatable, :confirmable, :lockable and :timeoutable

--- a/spec/dummy_app/app/active_record/user/confirmed.rb
+++ b/spec/dummy_app/app/active_record/user/confirmed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User
   class Confirmed < User
   end

--- a/spec/dummy_app/app/active_record/without_table.rb
+++ b/spec/dummy_app/app/active_record/without_table.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class WithoutTable < ActiveRecord::Base
 end

--- a/spec/dummy_app/app/controllers/application_controller.rb
+++ b/spec/dummy_app/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   protect_from_forgery
 end

--- a/spec/dummy_app/app/controllers/players_controller.rb
+++ b/spec/dummy_app/app/controllers/players_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PlayersController < ApplicationController
   def show
     @player = Player.find(params[:id])

--- a/spec/dummy_app/app/jobs/application_job.rb
+++ b/spec/dummy_app/app/jobs/application_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
   # Automatically retry jobs that encountered a deadlock
   # retry_on ActiveRecord::Deadlocked

--- a/spec/dummy_app/app/jobs/null_job.rb
+++ b/spec/dummy_app/app/jobs/null_job.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NullJob < ApplicationJob
   queue_as :default
 

--- a/spec/dummy_app/app/mongoid/another_field_test.rb
+++ b/spec/dummy_app/app/mongoid/another_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AnotherFieldTest
   include Mongoid::Document
 

--- a/spec/dummy_app/app/mongoid/ball.rb
+++ b/spec/dummy_app/app/mongoid/ball.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Ball
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/spec/dummy_app/app/mongoid/carrierwave_uploader.rb
+++ b/spec/dummy_app/app/mongoid/carrierwave_uploader.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'mini_magick'
 class CarrierwaveUploader < CarrierWave::Uploader::Base

--- a/spec/dummy_app/app/mongoid/category.rb
+++ b/spec/dummy_app/app/mongoid/category.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Category
   include Mongoid::Document
 

--- a/spec/dummy_app/app/mongoid/cms.rb
+++ b/spec/dummy_app/app/mongoid/cms.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cms
   def self.table_name_prefix
     'cms_'

--- a/spec/dummy_app/app/mongoid/cms/basic_page.rb
+++ b/spec/dummy_app/app/mongoid/cms/basic_page.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Cms
   class BasicPage
     include Mongoid::Document

--- a/spec/dummy_app/app/mongoid/comment.rb
+++ b/spec/dummy_app/app/mongoid/comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment
   include Mongoid::Document
   field :content, type: String

--- a/spec/dummy_app/app/mongoid/comment/confirmed.rb
+++ b/spec/dummy_app/app/mongoid/comment/confirmed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Comment
   class Confirmed < Comment
     default_scope -> { where(content: 'something') }

--- a/spec/dummy_app/app/mongoid/concerns/taggable.rb
+++ b/spec/dummy_app/app/mongoid/concerns/taggable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Taggable
   extend ActiveSupport::Concern
   # dummy

--- a/spec/dummy_app/app/mongoid/deeply_nested_field_test.rb
+++ b/spec/dummy_app/app/mongoid/deeply_nested_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeeplyNestedFieldTest
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/spec/dummy_app/app/mongoid/division.rb
+++ b/spec/dummy_app/app/mongoid/division.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Division
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/spec/dummy_app/app/mongoid/draft.rb
+++ b/spec/dummy_app/app/mongoid/draft.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Draft
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/spec/dummy_app/app/mongoid/eager_loaded/basketball.rb
+++ b/spec/dummy_app/app/mongoid/eager_loaded/basketball.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Basketball < Ball
 end

--- a/spec/dummy_app/app/mongoid/embed.rb
+++ b/spec/dummy_app/app/mongoid/embed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Embed
   include Mongoid::Document
   field :name, type: String

--- a/spec/dummy_app/app/mongoid/fan.rb
+++ b/spec/dummy_app/app/mongoid/fan.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Fan
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/spec/dummy_app/app/mongoid/field_test.rb
+++ b/spec/dummy_app/app/mongoid/field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/adapters/mongoid'
 
 class FieldTest

--- a/spec/dummy_app/app/mongoid/hardball.rb
+++ b/spec/dummy_app/app/mongoid/hardball.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class Hardball < Ball
 end

--- a/spec/dummy_app/app/mongoid/image.rb
+++ b/spec/dummy_app/app/mongoid/image.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Image
   include Mongoid::Document
   include Mongoid::Paperclip

--- a/spec/dummy_app/app/mongoid/league.rb
+++ b/spec/dummy_app/app/mongoid/league.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class League
   include Mongoid::Document
 

--- a/spec/dummy_app/app/mongoid/managed_team.rb
+++ b/spec/dummy_app/app/mongoid/managed_team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ManagedTeam < Team
   belongs_to :user, class_name: 'ManagingUser', foreign_key: :manager, primary_key: :email, inverse_of: :teams
 end

--- a/spec/dummy_app/app/mongoid/managing_user.rb
+++ b/spec/dummy_app/app/mongoid/managing_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ManagingUser < User
   has_one :team, class_name: 'ManagedTeam', foreign_key: :manager, primary_key: :email, inverse_of: :user
   has_many :teams, class_name: 'ManagedTeam', foreign_key: :manager, primary_key: :email, inverse_of: :user

--- a/spec/dummy_app/app/mongoid/nested_field_test.rb
+++ b/spec/dummy_app/app/mongoid/nested_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class NestedFieldTest
   include Mongoid::Document
 

--- a/spec/dummy_app/app/mongoid/player.rb
+++ b/spec/dummy_app/app/mongoid/player.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Player
   include Mongoid::Document
   include Mongoid::Timestamps

--- a/spec/dummy_app/app/mongoid/read_only_comment.rb
+++ b/spec/dummy_app/app/mongoid/read_only_comment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReadOnlyComment < Comment
   def readonly?
     true

--- a/spec/dummy_app/app/mongoid/restricted_team.rb
+++ b/spec/dummy_app/app/mongoid/restricted_team.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RestrictedTeam < Team
   has_many :players, foreign_key: :team_id, dependent: :restrict_with_error
 end

--- a/spec/dummy_app/app/mongoid/shrine_uploader.rb
+++ b/spec/dummy_app/app/mongoid/shrine_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ShrineUploader < Shrine
   plugin :mongoid
 

--- a/spec/dummy_app/app/mongoid/shrine_versioning_uploader.rb
+++ b/spec/dummy_app/app/mongoid/shrine_versioning_uploader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ShrineVersioningUploader < Shrine
   plugin :mongoid
 

--- a/spec/dummy_app/app/mongoid/team.rb
+++ b/spec/dummy_app/app/mongoid/team.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 class Team
   include Mongoid::Document

--- a/spec/dummy_app/app/mongoid/two_level/namespaced/polymorphic_association_test.rb
+++ b/spec/dummy_app/app/mongoid/two_level/namespaced/polymorphic_association_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module TwoLevel
   module Namespaced
     class PolymorphicAssociationTest

--- a/spec/dummy_app/app/mongoid/user.rb
+++ b/spec/dummy_app/app/mongoid/user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User
   include Mongoid::Document
   include Mongoid::Paperclip

--- a/spec/dummy_app/app/mongoid/user/confirmed.rb
+++ b/spec/dummy_app/app/mongoid/user/confirmed.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class User
   class Confirmed < User
   end

--- a/spec/dummy_app/config.ru
+++ b/spec/dummy_app/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require ::File.expand_path('config/environment', __dir__)

--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require File.expand_path('boot', __dir__)
 
 require 'action_controller/railtie'

--- a/spec/dummy_app/config/boot.rb
+++ b/spec/dummy_app/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 CI_ORM = (ENV['CI_ORM'] || :active_record).to_sym unless defined?(CI_ORM)
 CI_ASSET = (ENV['CI_ASSET'] || :sprockets).to_sym unless defined?(CI_ASSET)
 ENV['BUNDLE_GEMFILE'] ||= File.expand_path('../Gemfile', __dir__)

--- a/spec/dummy_app/config/environment.rb
+++ b/spec/dummy_app/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require File.expand_path('application', __dir__)
 

--- a/spec/dummy_app/config/environments/development.rb
+++ b/spec/dummy_app/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 DummyApp::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy_app/config/environments/production.rb
+++ b/spec/dummy_app/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 DummyApp::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy_app/config/environments/test.rb
+++ b/spec/dummy_app/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 DummyApp::Application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
 

--- a/spec/dummy_app/config/initializers/application_controller_renderer.rb
+++ b/spec/dummy_app/config/initializers/application_controller_renderer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # ApplicationController.renderer.defaults.merge!(

--- a/spec/dummy_app/config/initializers/assets.rb
+++ b/spec/dummy_app/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/spec/dummy_app/config/initializers/backtrace_silencers.rb
+++ b/spec/dummy_app/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/spec/dummy_app/config/initializers/cookies_serializer.rb
+++ b/spec/dummy_app/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This is a new Rails 5.0 default, so introduced as a config to ensure apps made with earlier versions of Rails aren't affected when upgrading.

--- a/spec/dummy_app/config/initializers/cors.rb
+++ b/spec/dummy_app/config/initializers/cors.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Avoid CORS issues when API is called from the frontend app.

--- a/spec/dummy_app/config/initializers/devise.rb
+++ b/spec/dummy_app/config/initializers/devise.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Use this hook to configure devise mailer, warden hooks and so forth.
 # Many of these configuration options can be set straight in your model.
 Devise.setup do |config|

--- a/spec/dummy_app/config/initializers/dragonfly.rb
+++ b/spec/dummy_app/config/initializers/dragonfly.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dragonfly'
 
 # Configure

--- a/spec/dummy_app/config/initializers/filter_parameter_logging.rb
+++ b/spec/dummy_app/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/spec/dummy_app/config/initializers/inflections.rb
+++ b/spec/dummy_app/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/spec/dummy_app/config/initializers/mime_types.rb
+++ b/spec/dummy_app/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/spec/dummy_app/config/initializers/mongoid.rb
+++ b/spec/dummy_app/config/initializers/mongoid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 if CI_ORM == :mongoid
   filename =
     if Mongoid.respond_to?(:belongs_to_required_by_default=)

--- a/spec/dummy_app/config/initializers/rails_admin.rb
+++ b/spec/dummy_app/config/initializers/rails_admin.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 RailsAdmin.config do |c|
   c.model 'Team' do
     include_all_fields

--- a/spec/dummy_app/config/initializers/secret_token.rb
+++ b/spec/dummy_app/config/initializers/secret_token.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Your secret key is used for verifying the integrity of signed cookies.

--- a/spec/dummy_app/config/initializers/session_patch.rb
+++ b/spec/dummy_app/config/initializers/session_patch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'action_dispatch/middleware/session/abstract_store'
 
 # When ORM was switched, but another ORM's model class still exists in session

--- a/spec/dummy_app/config/initializers/session_store.rb
+++ b/spec/dummy_app/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 Rails.application.config.session_store :cookie_store, key: '_dummy_app_session'

--- a/spec/dummy_app/config/initializers/shrine.rb
+++ b/spec/dummy_app/config/initializers/shrine.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'shrine'
 require 'shrine/storage/memory'
 

--- a/spec/dummy_app/config/initializers/wrap_parameters.rb
+++ b/spec/dummy_app/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/spec/dummy_app/config/routes.rb
+++ b/spec/dummy_app/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 DummyApp::Application.routes.draw do
   # Needed for :show_in_app tests
   resources :players, only: [:show]

--- a/spec/dummy_app/db/migrate/00000000000001_create_divisions_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000001_create_divisions_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDivisionsMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :divisions do |t|

--- a/spec/dummy_app/db/migrate/00000000000002_create_drafts_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000002_create_drafts_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDraftsMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :drafts do |t|

--- a/spec/dummy_app/db/migrate/00000000000003_create_leagues_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000003_create_leagues_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateLeaguesMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :leagues do |t|

--- a/spec/dummy_app/db/migrate/00000000000004_create_players_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000004_create_players_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePlayersMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :players do |t|

--- a/spec/dummy_app/db/migrate/00000000000005_create_teams_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000005_create_teams_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTeamsMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :teams do |t|

--- a/spec/dummy_app/db/migrate/00000000000006_devise_create_users.rb
+++ b/spec/dummy_app/db/migrate/00000000000006_devise_create_users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DeviseCreateUsers < ActiveRecord::Migration[5.0]
   def self.up
     create_table :users do |t|

--- a/spec/dummy_app/db/migrate/00000000000007_create_histories_table.rb
+++ b/spec/dummy_app/db/migrate/00000000000007_create_histories_table.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateHistoriesTable < ActiveRecord::Migration[5.0]
   def self.up
     create_table :histories do |t|

--- a/spec/dummy_app/db/migrate/00000000000008_create_fans_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000008_create_fans_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateFansMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :fans do |t|

--- a/spec/dummy_app/db/migrate/00000000000009_create_fans_teams_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000009_create_fans_teams_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateFansTeamsMigration < ActiveRecord::Migration[5.0]
   def self.up
     create_table :fans_teams, id: false do |t|

--- a/spec/dummy_app/db/migrate/00000000000010_add_revenue_to_team_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000010_add_revenue_to_team_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRevenueToTeamMigration < ActiveRecord::Migration[5.0]
   def self.up
     add_column :teams, :revenue, :decimal, precision: 18, scale: 2

--- a/spec/dummy_app/db/migrate/00000000000011_add_suspended_to_player_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000011_add_suspended_to_player_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddSuspendedToPlayerMigration < ActiveRecord::Migration[5.0]
   def self.up
     add_column :players, :suspended, :boolean, default: false

--- a/spec/dummy_app/db/migrate/00000000000012_add_avatar_columns_to_user.rb
+++ b/spec/dummy_app/db/migrate/00000000000012_add_avatar_columns_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddAvatarColumnsToUser < ActiveRecord::Migration[5.0]
   def self.up
     add_column :users, :avatar_file_name,    :string

--- a/spec/dummy_app/db/migrate/00000000000013_add_roles_to_user.rb
+++ b/spec/dummy_app/db/migrate/00000000000013_add_roles_to_user.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRolesToUser < ActiveRecord::Migration[5.0]
   def self.up
     add_column :users, :roles, :string

--- a/spec/dummy_app/db/migrate/00000000000014_add_color_to_team_migration.rb
+++ b/spec/dummy_app/db/migrate/00000000000014_add_color_to_team_migration.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddColorToTeamMigration < ActiveRecord::Migration[5.0]
   def self.up
     add_column :teams, :color, :string

--- a/spec/dummy_app/db/migrate/20101223222233_create_rel_tests.rb
+++ b/spec/dummy_app/db/migrate/20101223222233_create_rel_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateRelTests < ActiveRecord::Migration[5.0]
   def self.up
     create_table :rel_tests do |t|

--- a/spec/dummy_app/db/migrate/20110103205808_create_comments.rb
+++ b/spec/dummy_app/db/migrate/20110103205808_create_comments.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateComments < ActiveRecord::Migration[5.0]
   def self.up
     create_table :comments do |t|

--- a/spec/dummy_app/db/migrate/20110123042530_rename_histories_to_rails_admin_histories.rb
+++ b/spec/dummy_app/db/migrate/20110123042530_rename_histories_to_rails_admin_histories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameHistoriesToRailsAdminHistories < ActiveRecord::Migration[5.0]
   def self.up
     rename_table :histories, :rails_admin_histories

--- a/spec/dummy_app/db/migrate/20110224184303_create_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20110224184303_create_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateFieldTests < ActiveRecord::Migration[5.0]
   def self.up
     create_table :field_tests do |t|

--- a/spec/dummy_app/db/migrate/20110328193014_create_cms_basic_pages.rb
+++ b/spec/dummy_app/db/migrate/20110328193014_create_cms_basic_pages.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCmsBasicPages < ActiveRecord::Migration[5.0]
   def self.up
     create_table :cms_basic_pages do |t|

--- a/spec/dummy_app/db/migrate/20110329183136_remove_league_id_from_teams.rb
+++ b/spec/dummy_app/db/migrate/20110329183136_remove_league_id_from_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RemoveLeagueIdFromTeams < ActiveRecord::Migration[5.0]
   def self.up
     remove_column :teams, :league_id

--- a/spec/dummy_app/db/migrate/20110607152842_add_format_to_field_test.rb
+++ b/spec/dummy_app/db/migrate/20110607152842_add_format_to_field_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddFormatToFieldTest < ActiveRecord::Migration[5.0]
   def self.up
     add_column :field_tests, :format, :string

--- a/spec/dummy_app/db/migrate/20110714095433_create_balls.rb
+++ b/spec/dummy_app/db/migrate/20110714095433_create_balls.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateBalls < ActiveRecord::Migration[5.0]
   def self.up
     create_table :balls, force: true do |t|

--- a/spec/dummy_app/db/migrate/20110831090841_add_protected_field_and_restricted_field_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20110831090841_add_protected_field_and_restricted_field_to_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddProtectedFieldAndRestrictedFieldToFieldTests < ActiveRecord::Migration[5.0]
   def change
     add_column :field_tests, :restricted_field, :string

--- a/spec/dummy_app/db/migrate/20110901131551_change_division_primary_key.rb
+++ b/spec/dummy_app/db/migrate/20110901131551_change_division_primary_key.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeDivisionPrimaryKey < ActiveRecord::Migration[5.0]
   def up
     drop_table :divisions

--- a/spec/dummy_app/db/migrate/20110901142530_rename_league_id_foreign_key_on_divisions.rb
+++ b/spec/dummy_app/db/migrate/20110901142530_rename_league_id_foreign_key_on_divisions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RenameLeagueIdForeignKeyOnDivisions < ActiveRecord::Migration[5.0]
   def change
     rename_column :divisions, :league_id, :custom_league_id

--- a/spec/dummy_app/db/migrate/20110901150912_set_primary_key_not_null_for_divisions.rb
+++ b/spec/dummy_app/db/migrate/20110901150912_set_primary_key_not_null_for_divisions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SetPrimaryKeyNotNullForDivisions < ActiveRecord::Migration[5.0]
   def up
     drop_table :divisions

--- a/spec/dummy_app/db/migrate/20110901154834_change_length_for_rails_admin_histories.rb
+++ b/spec/dummy_app/db/migrate/20110901154834_change_length_for_rails_admin_histories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeLengthForRailsAdminHistories < ActiveRecord::Migration[5.0]
   def up
     change_column :rails_admin_histories, :message, :text

--- a/spec/dummy_app/db/migrate/20111108143642_add_dragonfly_and_carrierwave_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20111108143642_add_dragonfly_and_carrierwave_to_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDragonflyAndCarrierwaveToFieldTests < ActiveRecord::Migration[5.0]
   def change
     add_column :field_tests, :paperclip_asset_file_name, :string

--- a/spec/dummy_app/db/migrate/20111115041025_add_type_to_balls.rb
+++ b/spec/dummy_app/db/migrate/20111115041025_add_type_to_balls.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddTypeToBalls < ActiveRecord::Migration[5.0]
   def change
     add_column :balls, :type, :string

--- a/spec/dummy_app/db/migrate/20111123092549_create_nested_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20111123092549_create_nested_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateNestedFieldTests < ActiveRecord::Migration[5.0]
   def change
     create_table :nested_field_tests do |t|

--- a/spec/dummy_app/db/migrate/20111130075338_add_dragonfly_asset_name_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20111130075338_add_dragonfly_asset_name_to_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddDragonflyAssetNameToFieldTests < ActiveRecord::Migration[5.0]
   def change
     add_column :field_tests, :dragonfly_asset_name, :string

--- a/spec/dummy_app/db/migrate/20111215083258_create_foo_bars.rb
+++ b/spec/dummy_app/db/migrate/20111215083258_create_foo_bars.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateFooBars < ActiveRecord::Migration[5.0]
   def change
     create_table :foo_bars do |t|

--- a/spec/dummy_app/db/migrate/20120117151733_add_custom_field_to_teams.rb
+++ b/spec/dummy_app/db/migrate/20120117151733_add_custom_field_to_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCustomFieldToTeams < ActiveRecord::Migration[5.0]
   def change
     add_column :teams, :custom_field, :string

--- a/spec/dummy_app/db/migrate/20120118122004_add_categories.rb
+++ b/spec/dummy_app/db/migrate/20120118122004_add_categories.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCategories < ActiveRecord::Migration[5.0]
   def change
     create_table :categories do |t|

--- a/spec/dummy_app/db/migrate/20120319041705_drop_rel_tests.rb
+++ b/spec/dummy_app/db/migrate/20120319041705_drop_rel_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DropRelTests < ActiveRecord::Migration[5.0]
   def self.up
     drop_table :rel_tests

--- a/spec/dummy_app/db/migrate/20120720075608_create_another_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20120720075608_create_another_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateAnotherFieldTests < ActiveRecord::Migration[5.0]
   def change
     create_table :another_field_tests do |t|

--- a/spec/dummy_app/db/migrate/20120928075608_create_images.rb
+++ b/spec/dummy_app/db/migrate/20120928075608_create_images.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateImages < ActiveRecord::Migration[5.0]
   def change
     create_table :images do |t|

--- a/spec/dummy_app/db/migrate/20140412075608_create_deeply_nested_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20140412075608_create_deeply_nested_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateDeeplyNestedFieldTests < ActiveRecord::Migration[5.0]
   def change
     create_table :deeply_nested_field_tests do |t|

--- a/spec/dummy_app/db/migrate/20140826093220_create_paper_trail_tests.rb
+++ b/spec/dummy_app/db/migrate/20140826093220_create_paper_trail_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreatePaperTrailTests < ActiveRecord::Migration[5.0]
   def change
     create_table :paper_trail_tests do |t|

--- a/spec/dummy_app/db/migrate/20140826093552_create_versions.rb
+++ b/spec/dummy_app/db/migrate/20140826093552_create_versions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateVersions < ActiveRecord::Migration[5.0]
   def change
     create_table :versions do |t|

--- a/spec/dummy_app/db/migrate/20150815102450_add_refile_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20150815102450_add_refile_to_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddRefileToFieldTests < ActiveRecord::Migration[5.0]
   def change
     add_column :field_tests, :refile_asset_id, :string

--- a/spec/dummy_app/db/migrate/20151027181550_change_field_test_id_to_nested_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20151027181550_change_field_test_id_to_nested_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ChangeFieldTestIdToNestedFieldTests < ActiveRecord::Migration[5.0]
   def change
     change_column :nested_field_tests, :field_test_id, :integer, null: false

--- a/spec/dummy_app/db/migrate/20160728152942_add_main_sponsor_to_teams.rb
+++ b/spec/dummy_app/db/migrate/20160728152942_add_main_sponsor_to_teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddMainSponsorToTeams < ActiveRecord::Migration[5.0]
   def change
     add_column :teams, :main_sponsor, :integer, default: 0, null: false

--- a/spec/dummy_app/db/migrate/20160728153058_add_formation_to_players.rb
+++ b/spec/dummy_app/db/migrate/20160728153058_add_formation_to_players.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddFormationToPlayers < ActiveRecord::Migration[5.0]
   def change
     add_column :players, :formation, :string, default: 'substitute', null: false

--- a/spec/dummy_app/db/migrate/20171229220713_add_enum_fields_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20171229220713_add_enum_fields_to_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddEnumFieldsToFieldTests < ActiveRecord::Migration[5.0]
   def change
     add_column :field_tests, :string_enum_field,  :string

--- a/spec/dummy_app/db/migrate/20180701084251_create_active_storage_tables.active_storage.rb
+++ b/spec/dummy_app/db/migrate/20180701084251_create_active_storage_tables.active_storage.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This migration comes from active_storage (originally 20170806125915)
 class CreateActiveStorageTables < ActiveRecord::Migration[5.0]
   def change

--- a/spec/dummy_app/db/migrate/20180707101855_add_carrierwave_assets_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20180707101855_add_carrierwave_assets_to_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddCarrierwaveAssetsToFieldTests < ActiveRecord::Migration[5.0]
   def change
     add_column :field_tests, :carrierwave_assets, :string, after: :carrierwave_asset

--- a/spec/dummy_app/db/migrate/20181029101829_add_shrine_data_to_field_tests.rb
+++ b/spec/dummy_app/db/migrate/20181029101829_add_shrine_data_to_field_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddShrineDataToFieldTests < ActiveRecord::Migration[5.0]
   def change
     add_column :field_tests, :shrine_asset_data, :text

--- a/spec/dummy_app/db/migrate/20190531065324_create_action_text_tables.action_text.rb
+++ b/spec/dummy_app/db/migrate/20190531065324_create_action_text_tables.action_text.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateActionTextTables < ActiveRecord::Migration[5.0]
   def change
     create_table :action_text_rich_texts do |t|

--- a/spec/dummy_app/db/migrate/20201127111952_update_active_storage_tables.rb
+++ b/spec/dummy_app/db/migrate/20201127111952_update_active_storage_tables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class UpdateActiveStorageTables < ActiveRecord::Migration[5.0]
   def change
     add_column :active_storage_blobs, :service_name, :string, null: false, default: 'local'

--- a/spec/dummy_app/db/migrate/20210811121027_create_two_level_namespaced_polymorphic_association_tests.rb
+++ b/spec/dummy_app/db/migrate/20210811121027_create_two_level_namespaced_polymorphic_association_tests.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateTwoLevelNamespacedPolymorphicAssociationTests < ActiveRecord::Migration[5.0]
   def change
     create_table :two_level_namespaced_polymorphic_association_tests do |t|

--- a/spec/dummy_app/db/migrate/20210812115908_create_custom_versions.rb
+++ b/spec/dummy_app/db/migrate/20210812115908_create_custom_versions.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CreateCustomVersions < ActiveRecord::Migration[5.0]
   def change
     create_table :custom_versions do |t|

--- a/spec/dummy_app/db/migrate/20211011235734_add_bool_field_open.rb
+++ b/spec/dummy_app/db/migrate/20211011235734_add_bool_field_open.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AddBoolFieldOpen < ActiveRecord::Migration[6.0]
   def change
     add_column :field_tests, :open, :boolean

--- a/spec/dummy_app/db/seeds.rb
+++ b/spec/dummy_app/db/seeds.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'mlb'
 
 user_model     = RailsAdmin::AbstractModel.new(User)

--- a/spec/dummy_app/lib/does_not_load_autoload_paths_not_in_eager_load.rb
+++ b/spec/dummy_app/lib/does_not_load_autoload_paths_not_in_eager_load.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module DoesNotLoadAutoloadPathsNotInEagerLoad
   raise 'This file is in app.paths.autoload but not app.paths.eager_load and ' \
         ' should not be autoloaded by rails_admin'

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 FactoryBot.define do
   factory :player do

--- a/spec/helpers/rails_admin/application_helper_spec.rb
+++ b/spec/helpers/rails_admin/application_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::ApplicationHelper, type: :helper do

--- a/spec/helpers/rails_admin/form_builder_spec.rb
+++ b/spec/helpers/rails_admin/form_builder_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin::FormBuilder', type: :helper do

--- a/spec/helpers/rails_admin/main_helper_spec.rb
+++ b/spec/helpers/rails_admin/main_helper_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::MainHelper, type: :helper do

--- a/spec/integration/actions/base_spec.rb
+++ b/spec/integration/actions/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Base action', type: :request do

--- a/spec/integration/actions/bulk_delete_spec.rb
+++ b/spec/integration/actions/bulk_delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'BulkDelete action', type: :request do

--- a/spec/integration/actions/dashboard_spec.rb
+++ b/spec/integration/actions/dashboard_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Dashboard action', type: :request do

--- a/spec/integration/actions/delete_spec.rb
+++ b/spec/integration/actions/delete_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Delete action', type: :request do

--- a/spec/integration/actions/edit_spec.rb
+++ b/spec/integration/actions/edit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Edit action', type: :request do

--- a/spec/integration/actions/export_spec.rb
+++ b/spec/integration/actions/export_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'csv'
 

--- a/spec/integration/actions/history_index_spec.rb
+++ b/spec/integration/actions/history_index_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/integration/actions/history_show_spec.rb
+++ b/spec/integration/actions/history_show_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/integration/actions/index_spec.rb
+++ b/spec/integration/actions/index_spec.rb
@@ -1,4 +1,5 @@
 # coding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/integration/actions/new_spec.rb
+++ b/spec/integration/actions/new_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'New action', type: :request do

--- a/spec/integration/actions/show_spec.rb
+++ b/spec/integration/actions/show_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Show action', type: :request do

--- a/spec/integration/auditing/rails_admin_paper_trail_spec.rb
+++ b/spec/integration/auditing/rails_admin_paper_trail_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin PaperTrail auditing', active_record: true do

--- a/spec/integration/authorization/cancancan_spec.rb
+++ b/spec/integration/authorization/cancancan_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin CanCanCan Authorization', type: :request do

--- a/spec/integration/authorization/pundit_spec.rb
+++ b/spec/integration/authorization/pundit_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin Pundit Authorization', type: :request do

--- a/spec/integration/fields/action_text_spec.rb
+++ b/spec/integration/fields/action_text_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 if defined?(ActionText)

--- a/spec/integration/fields/active_record_enum_spec.rb
+++ b/spec/integration/fields/active_record_enum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'ActiveRecordEnum field', type: :request, active_record: true do

--- a/spec/integration/fields/base_spec.rb
+++ b/spec/integration/fields/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Base field', type: :request do

--- a/spec/integration/fields/belongs_to_association_spec.rb
+++ b/spec/integration/fields/belongs_to_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'BelongsToAssociation field', type: :request do

--- a/spec/integration/fields/boolean_spec.rb
+++ b/spec/integration/fields/boolean_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Boolean field', type: :request do

--- a/spec/integration/fields/carrierwave_spec.rb
+++ b/spec/integration/fields/carrierwave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Carrierwave field', type: :request, active_record: true do

--- a/spec/integration/fields/ck_editor_spec.rb
+++ b/spec/integration/fields/ck_editor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'CKEditor field', type: :request do

--- a/spec/integration/fields/code_mirror_spec.rb
+++ b/spec/integration/fields/code_mirror_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'CodeMirror field', type: :request do

--- a/spec/integration/fields/color_spec.rb
+++ b/spec/integration/fields/color_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Color field', type: :request do

--- a/spec/integration/fields/date_spec.rb
+++ b/spec/integration/fields/date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Date field', type: :request do

--- a/spec/integration/fields/datetime_spec.rb
+++ b/spec/integration/fields/datetime_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Datetime field', type: :request do

--- a/spec/integration/fields/enum_spec.rb
+++ b/spec/integration/fields/enum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Enum field', type: :request, active_record: true do

--- a/spec/integration/fields/file_upload_spec.rb
+++ b/spec/integration/fields/file_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'FileUpload field', type: :request do

--- a/spec/integration/fields/floara_spec.rb
+++ b/spec/integration/fields/floara_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Floara field', type: :request do

--- a/spec/integration/fields/has_and_belongs_to_many_association_spec.rb
+++ b/spec/integration/fields/has_and_belongs_to_many_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'HasAndBelongsToManyAssociation field', type: :request do

--- a/spec/integration/fields/has_many_association_spec.rb
+++ b/spec/integration/fields/has_many_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'HasManyAssociation field', type: :request do

--- a/spec/integration/fields/has_one_association_spec.rb
+++ b/spec/integration/fields/has_one_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'HasOneAssociation field', type: :request do

--- a/spec/integration/fields/hidden_spec.rb
+++ b/spec/integration/fields/hidden_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Hidden field', type: :request do

--- a/spec/integration/fields/multiple_carrierwave_spec.rb
+++ b/spec/integration/fields/multiple_carrierwave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'MultipleCarrierwave field', type: :request, active_record: true do

--- a/spec/integration/fields/multiple_file_upload_spec.rb
+++ b/spec/integration/fields/multiple_file_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'MultipleFileUpload field', type: :request do

--- a/spec/integration/fields/paperclip_spec.rb
+++ b/spec/integration/fields/paperclip_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Paperclip field', type: :request do

--- a/spec/integration/fields/polymorphic_assosiation_spec.rb
+++ b/spec/integration/fields/polymorphic_assosiation_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'PolymorphicAssociation field', type: :request do

--- a/spec/integration/fields/serialized_spec.rb
+++ b/spec/integration/fields/serialized_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Serialized field', type: :request do

--- a/spec/integration/fields/shrine_spec.rb
+++ b/spec/integration/fields/shrine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Shrine field', type: :request, active_record: true do

--- a/spec/integration/fields/simple_mde_spec.rb
+++ b/spec/integration/fields/simple_mde_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'SimpleMDE field', type: :request do

--- a/spec/integration/fields/time_spec.rb
+++ b/spec/integration/fields/time_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Time field', type: :request, active_record: true do

--- a/spec/integration/fields/wysihtml5_spec.rb
+++ b/spec/integration/fields/wysihtml5_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Wysihtml5 field', type: :request do

--- a/spec/integration/rails_admin_spec.rb
+++ b/spec/integration/rails_admin_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin, type: :request do

--- a/spec/integration/widgets/datetimepicker_spec.rb
+++ b/spec/integration/widgets/datetimepicker_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Datetimepicker widget', type: :request, js: true do

--- a/spec/integration/widgets/filter_box_spec.rb
+++ b/spec/integration/widgets/filter_box_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Filter box widget', type: :request, js: true do

--- a/spec/integration/widgets/filtering_multi_select_spec.rb
+++ b/spec/integration/widgets/filtering_multi_select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Filtering multi-select widget', type: :request, js: true do

--- a/spec/integration/widgets/filtering_select_spec.rb
+++ b/spec/integration/widgets/filtering_select_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Filtering select widget', type: :request, js: true do

--- a/spec/integration/widgets/nested_many_spec.rb
+++ b/spec/integration/widgets/nested_many_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Nested many widget', type: :request, js: true do

--- a/spec/integration/widgets/nested_one_spec.rb
+++ b/spec/integration/widgets/nested_one_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Nested one widget', type: :request, js: true do

--- a/spec/integration/widgets/remote_form_spec.rb
+++ b/spec/integration/widgets/remote_form_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'Remote form widget', type: :request, js: true do

--- a/spec/orm/active_record.rb
+++ b/spec/orm/active_record.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/adapters/active_record'
 
 ActiveRecord::Base.connection.data_sources.each do |table|

--- a/spec/orm/mongoid.rb
+++ b/spec/orm/mongoid.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rails_admin/adapters/mongoid'
 
 Paperclip.logger = Logger.new(nil)

--- a/spec/policies.rb
+++ b/spec/policies.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationPolicy
   attr_reader :user, :record
 

--- a/spec/rails_admin/abstract_model_spec.rb
+++ b/spec/rails_admin/abstract_model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::AbstractModel do

--- a/spec/rails_admin/active_record_extension_spec.rb
+++ b/spec/rails_admin/active_record_extension_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require File.expand_path('../../config/initializers/active_record_extensions', __dir__)
 

--- a/spec/rails_admin/adapters/active_record/association_spec.rb
+++ b/spec/rails_admin/adapters/active_record/association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'timecop'
 

--- a/spec/rails_admin/adapters/active_record/object_extension_spec.rb
+++ b/spec/rails_admin/adapters/active_record/object_extension_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin::Adapters::ActiveRecord::ObjectExtension', active_record: true do

--- a/spec/rails_admin/adapters/active_record/property_spec.rb
+++ b/spec/rails_admin/adapters/active_record/property_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'timecop'
 

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'timecop'
 

--- a/spec/rails_admin/adapters/mongoid/association_spec.rb
+++ b/spec/rails_admin/adapters/mongoid/association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin::Adapters::Mongoid::Association', mongoid: true do

--- a/spec/rails_admin/adapters/mongoid/object_extension_spec.rb
+++ b/spec/rails_admin/adapters/mongoid/object_extension_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin::Adapters::Mongoid::ObjectExtension', mongoid: true do

--- a/spec/rails_admin/adapters/mongoid/property_spec.rb
+++ b/spec/rails_admin/adapters/mongoid/property_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin::Adapters::Mongoid::Property', mongoid: true do

--- a/spec/rails_admin/adapters/mongoid_spec.rb
+++ b/spec/rails_admin/adapters/mongoid_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe 'RailsAdmin::Adapters::Mongoid', mongoid: true do

--- a/spec/rails_admin/config/actions/base_spec.rb
+++ b/spec/rails_admin/config/actions/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Actions::Base do

--- a/spec/rails_admin/config/actions_spec.rb
+++ b/spec/rails_admin/config/actions_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Actions do

--- a/spec/rails_admin/config/configurable_spec.rb
+++ b/spec/rails_admin/config/configurable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Configurable do

--- a/spec/rails_admin/config/fields/association_spec.rb
+++ b/spec/rails_admin/config/fields/association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Association do

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Base do

--- a/spec/rails_admin/config/fields/types/action_text_spec.rb
+++ b/spec/rails_admin/config/fields/types/action_text_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 if defined?(ActionText)

--- a/spec/rails_admin/config/fields/types/active_record_enum_spec.rb
+++ b/spec/rails_admin/config/fields/types/active_record_enum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::ActiveRecordEnum, active_record: true do

--- a/spec/rails_admin/config/fields/types/active_storage_spec.rb
+++ b/spec/rails_admin/config/fields/types/active_storage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 if defined?(ActiveStorage)

--- a/spec/rails_admin/config/fields/types/belongs_to_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/belongs_to_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::BelongsToAssociation do

--- a/spec/rails_admin/config/fields/types/boolean_spec.rb
+++ b/spec/rails_admin/config/fields/types/boolean_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Boolean do

--- a/spec/rails_admin/config/fields/types/bson_object_id_spec.rb
+++ b/spec/rails_admin/config/fields/types/bson_object_id_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::BsonObjectId do

--- a/spec/rails_admin/config/fields/types/carrierwave_spec.rb
+++ b/spec/rails_admin/config/fields/types/carrierwave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Carrierwave do

--- a/spec/rails_admin/config/fields/types/citext_spec.rb
+++ b/spec/rails_admin/config/fields/types/citext_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Citext do

--- a/spec/rails_admin/config/fields/types/ck_editor_spec.rb
+++ b/spec/rails_admin/config/fields/types/ck_editor_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::CKEditor do

--- a/spec/rails_admin/config/fields/types/code_mirror_spec.rb
+++ b/spec/rails_admin/config/fields/types/code_mirror_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::CodeMirror do

--- a/spec/rails_admin/config/fields/types/color_spec.rb
+++ b/spec/rails_admin/config/fields/types/color_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Color do

--- a/spec/rails_admin/config/fields/types/date_spec.rb
+++ b/spec/rails_admin/config/fields/types/date_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Date do

--- a/spec/rails_admin/config/fields/types/datetime_spec.rb
+++ b/spec/rails_admin/config/fields/types/datetime_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Datetime do

--- a/spec/rails_admin/config/fields/types/decimal_spec.rb
+++ b/spec/rails_admin/config/fields/types/decimal_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Decimal do

--- a/spec/rails_admin/config/fields/types/drangonfly_spec.rb
+++ b/spec/rails_admin/config/fields/types/drangonfly_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Dragonfly do

--- a/spec/rails_admin/config/fields/types/enum_spec.rb
+++ b/spec/rails_admin/config/fields/types/enum_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Enum do

--- a/spec/rails_admin/config/fields/types/file_upload_spec.rb
+++ b/spec/rails_admin/config/fields/types/file_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::FileUpload do

--- a/spec/rails_admin/config/fields/types/float_spec.rb
+++ b/spec/rails_admin/config/fields/types/float_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Float do

--- a/spec/rails_admin/config/fields/types/froala_spec.rb
+++ b/spec/rails_admin/config/fields/types/froala_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Froala do

--- a/spec/rails_admin/config/fields/types/has_and_belongs_to_many_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/has_and_belongs_to_many_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::HasAndBelongsToManyAssociation do

--- a/spec/rails_admin/config/fields/types/has_many_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/has_many_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::HasManyAssociation do

--- a/spec/rails_admin/config/fields/types/has_one_association_spec.rb
+++ b/spec/rails_admin/config/fields/types/has_one_association_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::HasOneAssociation do

--- a/spec/rails_admin/config/fields/types/hidden_spec.rb
+++ b/spec/rails_admin/config/fields/types/hidden_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Hidden do

--- a/spec/rails_admin/config/fields/types/inet_spec.rb
+++ b/spec/rails_admin/config/fields/types/inet_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Inet do

--- a/spec/rails_admin/config/fields/types/integer_spec.rb
+++ b/spec/rails_admin/config/fields/types/integer_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Integer do

--- a/spec/rails_admin/config/fields/types/json_spec.rb
+++ b/spec/rails_admin/config/fields/types/json_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Json do

--- a/spec/rails_admin/config/fields/types/multiple_active_storage_spec.rb
+++ b/spec/rails_admin/config/fields/types/multiple_active_storage_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 if defined?(ActiveStorage)

--- a/spec/rails_admin/config/fields/types/multiple_carrierwave_spec.rb
+++ b/spec/rails_admin/config/fields/types/multiple_carrierwave_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'base64'
 

--- a/spec/rails_admin/config/fields/types/multiple_file_upload_spec.rb
+++ b/spec/rails_admin/config/fields/types/multiple_file_upload_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::MultipleFileUpload do

--- a/spec/rails_admin/config/fields/types/numeric_spec.rb
+++ b/spec/rails_admin/config/fields/types/numeric_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Numeric do

--- a/spec/rails_admin/config/fields/types/paperclip_spec.rb
+++ b/spec/rails_admin/config/fields/types/paperclip_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Paperclip do

--- a/spec/rails_admin/config/fields/types/password_spec.rb
+++ b/spec/rails_admin/config/fields/types/password_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Password do

--- a/spec/rails_admin/config/fields/types/serialized_spec.rb
+++ b/spec/rails_admin/config/fields/types/serialized_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Serialized do

--- a/spec/rails_admin/config/fields/types/shrine_spec.rb
+++ b/spec/rails_admin/config/fields/types/shrine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 if defined?(Shrine)

--- a/spec/rails_admin/config/fields/types/simple_mde_spec.rb
+++ b/spec/rails_admin/config/fields/types/simple_mde_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::SimpleMDE do

--- a/spec/rails_admin/config/fields/types/string_like_spec.rb
+++ b/spec/rails_admin/config/fields/types/string_like_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::StringLike do

--- a/spec/rails_admin/config/fields/types/string_spec.rb
+++ b/spec/rails_admin/config/fields/types/string_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::String do

--- a/spec/rails_admin/config/fields/types/text_spec.rb
+++ b/spec/rails_admin/config/fields/types/text_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Text do

--- a/spec/rails_admin/config/fields/types/time_spec.rb
+++ b/spec/rails_admin/config/fields/types/time_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Time, active_record: true do

--- a/spec/rails_admin/config/fields/types/timestamp_spec.rb
+++ b/spec/rails_admin/config/fields/types/timestamp_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Timestamp, active_record: true do

--- a/spec/rails_admin/config/fields/types/uuid_spec.rb
+++ b/spec/rails_admin/config/fields/types/uuid_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Uuid do

--- a/spec/rails_admin/config/fields/types/wysihtml5_spec.rb
+++ b/spec/rails_admin/config/fields/types/wysihtml5_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields::Types::Wysihtml5 do

--- a/spec/rails_admin/config/fields_spec.rb
+++ b/spec/rails_admin/config/fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Fields, mongoid: true do

--- a/spec/rails_admin/config/has_description_spec.rb
+++ b/spec/rails_admin/config/has_description_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::HasDescription do

--- a/spec/rails_admin/config/has_fields_spec.rb
+++ b/spec/rails_admin/config/has_fields_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::HasFields do

--- a/spec/rails_admin/config/model_spec.rb
+++ b/spec/rails_admin/config/model_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Model do

--- a/spec/rails_admin/config/proxyable_spec.rb
+++ b/spec/rails_admin/config/proxyable_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Proxyable do

--- a/spec/rails_admin/config/sections/list_spec.rb
+++ b/spec/rails_admin/config/sections/list_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Sections::List do

--- a/spec/rails_admin/config/sections_spec.rb
+++ b/spec/rails_admin/config/sections_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config::Sections do

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Config do

--- a/spec/rails_admin/engine_spec.rb
+++ b/spec/rails_admin/engine_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Engine do

--- a/spec/rails_admin/extentions/paper_trail/auditing_adapter_spec.rb
+++ b/spec/rails_admin/extentions/paper_trail/auditing_adapter_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe RailsAdmin::Extensions::PaperTrail::VersionProxy do

--- a/spec/rails_admin/install_generator_spec.rb
+++ b/spec/rails_admin/install_generator_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 require 'generators/rails_admin/install_generator'
 

--- a/spec/rails_admin/support/csv_converter_spec.rb
+++ b/spec/rails_admin/support/csv_converter_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/rails_admin/support/datetime_spec.rb
+++ b/spec/rails_admin/support/datetime_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/rails_admin/support/hash_helper_spec.rb
+++ b/spec/rails_admin/support/hash_helper_spec.rb
@@ -1,4 +1,5 @@
 # encoding: utf-8
+# frozen_string_literal: true
 
 require 'spec_helper'
 

--- a/spec/shared_examples/shared_examples_for_field_types.rb
+++ b/spec/shared_examples/shared_examples_for_field_types.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.shared_examples 'a generic field type' do |column_name, field_type|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Configure Rails Envinronment
 ENV['RAILS_ENV'] = 'test'
 CI_ORM = (ENV['CI_ORM'] || :active_record).to_sym

--- a/spec/support/cuprite_logger.rb
+++ b/spec/support/cuprite_logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ConsoleLogger
   def self.puts(message)
     warn(message) unless message.start_with?('    ◀', "\n\n▶")

--- a/spec/support/fakeio.rb
+++ b/spec/support/fakeio.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'stringio'
 

--- a/spec/support/fixtures.rb
+++ b/spec/support/fixtures.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 def file_path(*paths)
   File.expand_path(File.join(File.dirname(__FILE__), '../fixtures', *paths))
 end


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/cops_style.html#stylefrozenstringliteralcomment

This feature is designed to help transition from mutable string literals
to frozen string literals. The "frozen_string_literal: true" magic
comment was added to the top of all files to enable frozen string
literals. Frozen string literals may be default in future Ruby. Using
frozen string literals is good practice and easier to reason about.