### PR TITLE
Bootstrap 5 followup: fix `show` views

### DIFF
--- a/app/views/rails_admin/main/show.html.erb
+++ b/app/views/rails_admin/main/show.html.erb
@@ -10,16 +10,18 @@
             <%= fieldset.help %>
           </p>
         <% end %>
-        <dl>
+        <div class="list-group">
           <% fields.each_with_index do |field, index| %>
-            <dt>
-              <span class="<%= field.type_css_class %> <%= field.css_class %> label label-info">
-                <%= field.label %>
-              </span>
-            </dt>
-            <dd class="well">
-              <%= field.pretty_value %>
-            </dd>
+            <div class="list-group-item border-0 <%= field.type_css_class %> <%= field.css_class %>">
+              <div class="card">
+                <h5 class="card-header bg-light">
+                  <%= field.label %>
+                </h5>
+                <div class="card-body">
+                  <%= field.pretty_value %>
+                </div>
+              </div>
+            </div>
           <% end %>
         </dl>
       </div>

--- a/spec/integration/actions/show_spec.rb
+++ b/spec/integration/actions/show_spec.rb
@@ -112,7 +112,7 @@ RSpec.describe 'Show action', type: :request do
 
       visit show_path(model_name: 'team', id: team.id)
 
-      is_expected.to have_selector('dt .name_field.string_type')
+      is_expected.to have_selector('div .name_field.string_type')
     end
   end
 
@@ -120,7 +120,7 @@ RSpec.describe 'Show action', type: :request do
     it 'is present' do
       visit show_path(model_name: 'team', id: team.id)
 
-      is_expected.to have_selector('dt .name_field.string_type')
+      is_expected.to have_selector('div .name_field.string_type')
     end
   end
 
@@ -225,11 +225,11 @@ RSpec.describe 'Show action', type: :request do
 
       visit show_path(model_name: 'team', id: team.id)
 
-      is_expected.to have_selector('.label', text: 'Name')
-      is_expected.to have_selector('.label', text: 'Logo url')
-      is_expected.to have_selector('.label', text: 'Division')
-      is_expected.to have_selector('.label', text: 'Manager (STRING)')
-      is_expected.to have_selector('.label', text: 'Ballpark (STRING)')
+      is_expected.to have_selector('.card-header', text: 'Name')
+      is_expected.to have_selector('.card-header', text: 'Logo url')
+      is_expected.to have_selector('.card-header', text: 'Division')
+      is_expected.to have_selector('.card-header', text: 'Manager (STRING)')
+      is_expected.to have_selector('.card-header', text: 'Ballpark (STRING)')
     end
   end
 
@@ -278,8 +278,8 @@ RSpec.describe 'Show action', type: :request do
 
       visit show_path(model_name: 'team', id: team.id)
 
-      is_expected.to have_selector('.label', text: 'Team Manager')
-      is_expected.to have_selector('.label', text: 'Some Fans')
+      is_expected.to have_selector('.card-header', text: 'Team Manager')
+      is_expected.to have_selector('.card-header', text: 'Some Fans')
     end
 
     it 'is renameable' do
@@ -295,9 +295,9 @@ RSpec.describe 'Show action', type: :request do
 
       visit show_path(model_name: 'team', id: team.id)
 
-      is_expected.to have_selector('.label', text: 'Renamed field')
-      is_expected.to have_selector('.label', text: 'Division')
-      is_expected.to have_selector('.label', text: 'Name')
+      is_expected.to have_selector('.card-header', text: 'Renamed field')
+      is_expected.to have_selector('.card-header', text: 'Division')
+      is_expected.to have_selector('.card-header', text: 'Name')
     end
 
     it 'is renameable by type' do
@@ -316,7 +316,7 @@ RSpec.describe 'Show action', type: :request do
         'Ballpark (STRING)', 'Mascot (STRING)', 'Founded', 'Wins', 'Losses',
         'Win percentage', 'Revenue', 'Players', 'Fans'
       ].each do |text|
-        is_expected.to have_selector('.label', text: text)
+        is_expected.to have_selector('.card-header', text: text)
       end
     end
 
@@ -336,7 +336,7 @@ RSpec.describe 'Show action', type: :request do
         'Ballpark (STRING)', 'Mascot (STRING)', 'Founded', 'Wins', 'Losses',
         'Win percentage', 'Revenue', 'Players', 'Fans'
       ].each do |text|
-        is_expected.to have_selector('.label', text: text)
+        is_expected.to have_selector('.card-header', text: text)
       end
     end
 
@@ -369,11 +369,11 @@ RSpec.describe 'Show action', type: :request do
       visit show_path(model_name: 'team', id: team.id)
 
       ['Name', 'Logo url', 'Manager', 'Ballpark', 'Mascot'].each do |text|
-        is_expected.not_to have_selector('.label', text: text)
+        is_expected.not_to have_selector('.card-header', text: text)
       end
 
       ['Division', 'Founded', 'Wins', 'Losses', 'Win percentage', 'Revenue', 'Players', 'Fans'].each do |text|
-        is_expected.to have_selector('.label', text: text)
+        is_expected.to have_selector('.card-header', text: text)
       end
     end
 
@@ -389,11 +389,11 @@ RSpec.describe 'Show action', type: :request do
       visit show_path(model_name: 'team', id: team.id)
 
       ['Name', 'Logo url', 'Manager', 'Ballpark', 'Mascot'].each do |text|
-        is_expected.not_to have_selector('.label', text: text)
+        is_expected.not_to have_selector('.card-header', text: text)
       end
 
       ['Division', 'Founded', 'Wins', 'Losses', 'Win percentage', 'Revenue', 'Players', 'Fans'].each do |text|
-        is_expected.to have_selector('.label', text: text)
+        is_expected.to have_selector('.card-header', text: text)
       end
     end
   end
@@ -417,7 +417,7 @@ RSpec.describe 'Show action', type: :request do
         visit show_path(model_name: 'team', id: team.id)
 
         is_expected.to have_selector('.truncated_name_field')
-        is_expected.to have_selector('dd', text: 'fo...')
+        is_expected.to have_selector('.card', text: 'fo...')
       end
     end
 
@@ -452,9 +452,9 @@ RSpec.describe 'Show action', type: :request do
 
     it 'overrides default_scope' do
       visit show_path(model_name: 'comment~confirmed', id: comments[0].id)
-      is_expected.to have_selector('dd', text: 'something')
+      is_expected.to have_selector('.card-body', text: 'something')
       visit show_path(model_name: 'comment~confirmed', id: comments[1].id)
-      is_expected.to have_selector('dd', text: 'anything')
+      is_expected.to have_selector('.card-body', text: 'anything')
     end
   end
 end


### PR DESCRIPTION
Following Bootstrap 5 upgrade (https://github.com/railsadminteam/rails_admin/pull/3455), some of the old design no longer applies (eg. wells, cards [are a suggested replacement](https://getbootstrap.com/docs/5.0/components/card/#about))

Screenshots:

<details>
<summary>Before</summary>

![Screen Shot 2022-03-09 at 15 14 23](https://user-images.githubusercontent.com/4504083/157558452-8437040f-afb7-4836-bef6-7b930772a02a.png)

</details>


<details>
<summary>After</summary>

![Screen Shot 2022-03-09 at 15 41 13](https://user-images.githubusercontent.com/4504083/157558475-08c4b176-26cc-4a10-8ad7-19a815e1ff70.png)

</details>


<details>
<summary>Old style (Bootstrap 3)</summary>

![Screen Shot 2022-03-09 at 15 15 12](https://user-images.githubusercontent.com/4504083/157558467-fd26180f-ba8d-4b22-81f4-4559928ba2e5.png)

</details>