### PR TITLE
restore 2.x config loading behavior

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -115,10 +115,10 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   CountComments: false
-  Max: 29 # TODO: Lower to 15
+  Max: 30 # TODO: Lower to 15
 
 Metrics/ModuleLength:
-  Max: 228 # TODO: Lower to 100
+  Max: 248 # TODO: Lower to 100
 
 Metrics/ParameterLists:
   Max: 8 # TODO: Lower to 4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -118,7 +118,7 @@ Metrics/MethodLength:
   Max: 29 # TODO: Lower to 15
 
 Metrics/ModuleLength:
-  Max: 217 # TODO: Lower to 100
+  Max: 228 # TODO: Lower to 100
 
 Metrics/ParameterLists:
   Max: 8 # TODO: Lower to 4

--- a/lib/rails_admin.rb
+++ b/lib/rails_admin.rb
@@ -29,7 +29,9 @@ module RailsAdmin
     if entity
       RailsAdmin::Config.model(entity, &block)
     elsif block_given?
-      RailsAdmin::Config.apply(&block)
+      # Immediately evaluate non-model (initializer) config. It's needed to
+      # properly configure routes when there are custom actions.
+      yield RailsAdmin::Config
     else
       RailsAdmin::Config
     end

--- a/lib/rails_admin.rb
+++ b/lib/rails_admin.rb
@@ -29,9 +29,7 @@ module RailsAdmin
     if entity
       RailsAdmin::Config.model(entity, &block)
     elsif block_given?
-      # Immediately evaluate non-model (initializer) config. It's needed to
-      # properly configure routes when there are custom actions.
-      yield RailsAdmin::Config
+      RailsAdmin::Config.apply_core(&block)
     else
       RailsAdmin::Config
     end

--- a/lib/rails_admin/adapters/mongoid/extension.rb
+++ b/lib/rails_admin/adapters/mongoid/extension.rb
@@ -11,9 +11,7 @@ module RailsAdmin
           self.nested_attributes_options = {}
           class << self
             def rails_admin(&block)
-              RailsAdmin.config do |config|
-                config.model(self, &block)
-              end
+              RailsAdmin.config(self, &block)
             end
 
             alias_method :accepts_nested_attributes_for_without_rails_admin, :accepts_nested_attributes_for

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -68,6 +68,11 @@ module RailsAdmin
         ERROR
       end
 
+      RailsAdmin::Config.initialize_core!
+
+      # Force route reload, since it doesn't reflect RailsAdmin action configuration yet
+      app.reload_routes!
+
       RailsAdmin::Version.warn_with_js_version
     end
   end

--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -68,11 +68,6 @@ module RailsAdmin
         ERROR
       end
 
-      RailsAdmin::Config.initialize!
-
-      # Force route reload, since it doesn't reflect RailsAdmin action configuration yet
-      app.reload_routes!
-
       RailsAdmin::Version.warn_with_js_version
     end
   end

--- a/spec/dummy_app/config/initializers/rails_admin.rb
+++ b/spec/dummy_app/config/initializers/rails_admin.rb
@@ -2,7 +2,7 @@
 
 RailsAdmin.config do |c|
   c.asset_source = CI_ASSET
-  c.model 'Team' do
+  c.model Team do
     include_all_fields
     field :color, :color
   end

--- a/spec/rails_admin/config_spec.rb
+++ b/spec/rails_admin/config_spec.rb
@@ -327,6 +327,24 @@ RSpec.describe RailsAdmin::Config do
       end
     end
 
+    context 'when a block is not provided' do
+      let(:model) { described_class.model(Team) }
+      it 'returns the model config' do
+        expect(model).to be_a(RailsAdmin::Config::Model)
+      end
+    end
+
+    context 'when a block is provided' do
+      let(:model) do
+        described_class.model(Team) do
+          field :fans
+        end
+      end
+      it 'does not return the model config' do
+        expect(model).to be_nil
+      end
+    end
+
     context 'when model expanded' do
       before do
         described_class.model(Team) do
@@ -387,6 +405,7 @@ RSpec.describe RailsAdmin::Config do
       end
     end
     before { RailsAdmin::Config.instance_variable_set(:@initialized, false) }
+    before { RailsAdmin::Config.instance_variable_set(:@initializing, false) }
     after do
       RailsAdmin::Config.instance_variable_set(:@initialized, true)
       RailsAdmin::Config.instance_variable_set(:@deferred_blocks, [])
@@ -443,6 +462,11 @@ RSpec.describe RailsAdmin::Config do
     it 're-applies the configuration from the initializer' do
       RailsAdmin::Config.reload!
       expect(RailsAdmin::Config.model(Team).fields.find { |f| f.name == :color }.type).to eq :color
+    end
+
+    it 'does not immediately apply model configuration' do
+      expect(RailsAdmin::Config).not_to receive(:initialize!)
+      RailsAdmin::Config.reload!
     end
 
     it "applies the initializer's configuration first, then models' configurations" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,6 +93,7 @@ RSpec.configure do |config|
     DatabaseCleaner.start
     RailsAdmin::Config.reset
     RailsAdmin::Config.asset_source = CI_ASSET
+    RailsAdmin::Config.initialize_core!
   end
 
   config.after(:each) do


### PR DESCRIPTION
Attempt to restore 2.x config loading behavior where 1) per-model config blocks
only evaluate after all the models are loaded and associations are defined
while 2) initializer config block evaluates immediately so that routes are
configured correctly.

One remaining change compared to 2.x is RailsAdmin::Config#model no longer
returns the model when given a block. With the removal of LazyModel in e4ae669
it is tricky to both defer initialization and return the model class.

Fixes https://github.com/railsadminteam/rails_admin/issues/3490