### PR TITLE
restore full width for content

### DIFF
--- a/app/views/layouts/rails_admin/application.html.erb
+++ b/app/views/layouts/rails_admin/application.html.erb
@@ -14,7 +14,7 @@
           <%= render "layouts/rails_admin/sidebar_navigation" %>
         </div>
         <div class="col-sm-9 col-sm-offset-3 col-md-10 col-md-offset-2">
-          <div class="container">
+          <div class="container-fluid">
             <%= render template: 'layouts/rails_admin/content' %>
           </div>
         </div>


### PR DESCRIPTION
During the bootstrap 5 update in 6878670 (#3455) this class was changed from
`content` to `container`. The `container` class, unlike `content`, has a max
width of 1320px. Restore prior behavior of using the full width by using
`container-fluid` to avoid wasted whitespace. This is especially useful on
list pages with a large number of columns.

<details>
<summary>Before</summary>

![before non-full width image](https://user-images.githubusercontent.com/1438495/157766893-61665149-0045-4e56-b874-840da38c2ccb.png)

</details>

<details>
<summary>After</summary>

![after full width image](https://user-images.githubusercontent.com/1438495/157766871-99576d1a-9652-4ed3-bc7e-dc1c55eebbda.png)

</details>

<details>
<summary>Bootstrap 3</summary>

![image](https://user-images.githubusercontent.com/1438495/157766924-9bc507a3-6387-4dfc-a542-0cc4a73a2e41.png)

</details>