### PR TITLE
Refactor label classes to badges

### DIFF
--- a/app/views/layouts/rails_admin/_secondary_navigation.html.erb
+++ b/app/views/layouts/rails_admin/_secondary_navigation.html.erb
@@ -17,7 +17,9 @@
     <% end %>
     <% if logout_path.present? %>
       <li class="nav-item">
-        <%= link_to t('admin.misc.log_out'), logout_path, method: logout_method, class: 'nav-link label label-danger', data: {turbo: 'false'} %>
+        <%= link_to logout_path, method: logout_method, class: 'nav-link', data: {turbo: 'false'} do %>
+          <span class="badge bg-danger"><%= t('admin.misc.log_out') %></span>
+        <% end %>
       </li>
     <% end %>
   <% end %>

--- a/lib/rails_admin/config/fields/types/boolean.rb
+++ b/lib/rails_admin/config/fields/types/boolean.rb
@@ -33,7 +33,7 @@ module RailsAdmin
           end
 
           register_instance_option :pretty_value do
-            %(<span class="label label-#{css_classes[form_value]}">#{labels[form_value]}</span>).html_safe
+            %(<span class="badge bg-#{css_classes[form_value]}">#{labels[form_value]}</span>).html_safe
           end
 
           register_instance_option :export_value do

--- a/spec/integration/rails_admin_spec.rb
+++ b/spec/integration/rails_admin_spec.rb
@@ -110,9 +110,9 @@ RSpec.describe RailsAdmin, type: :request do
       is_expected.to have_content 'Log out'
     end
 
-    it 'has label-danger class on log out link' do
+    it 'has bg-danger class on log out link' do
       visit dashboard_path
-      is_expected.to have_selector('.label-danger')
+      is_expected.to have_selector('.bg-danger')
     end
 
     it 'has links for actions which are marked as show_in_navigation' do

--- a/spec/rails_admin/config/fields/types/boolean_spec.rb
+++ b/spec/rails_admin/config/fields/types/boolean_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Boolean do
 
   describe '#pretty_value' do
     {
-      false => %(<span class="label label-danger"><span class="fas fa-times"></span></span>),
-      true => %(<span class="label label-success"><span class="fas fa-check"></span></span>),
-      nil => %(<span class="label label-default"><span class="fas fa-minus"></span></span>),
+      false => %(<span class="badge bg-danger"><span class="fas fa-times"></span></span>),
+      true => %(<span class="badge bg-success"><span class="fas fa-check"></span></span>),
+      nil => %(<span class="badge bg-default"><span class="fas fa-minus"></span></span>),
     }.each do |field_value, expected_result|
       context "when field value is '#{field_value.inspect}'" do
         let(:test_object) { FieldTest.new(boolean_field: field_value) }


### PR DESCRIPTION
From the [migrations documentation](https://getbootstrap.com/docs/4.6/migration/#labels-and-badges) of Bootstrap v4 -> v5:

> - Consolidated .label and .badge to disambiguate from the <label> element and simplify related components.

This change refactors the usage of labels to their counterparts as badges. Namely the logout label/badge and the representation of booleans. These referenced the label classes which no longer exist.

The changes visually:

Logout label / badge:
Currently:
<img width="231" alt="Screenshot 2022-04-04 at 14 52 35" src="https://user-images.githubusercontent.com/442230/161547873-38cc128e-4e65-44d2-acc8-07801a531a57.png">
After this change:
<img width="231" alt="Screenshot 2022-04-04 at 14 52 52" src="https://user-images.githubusercontent.com/442230/161547893-4dbbcbfb-3ce5-446e-9bf6-ce1c2df99a4f.png">

Boolean representation:
Currently:
<img width="63" alt="Screenshot 2022-04-04 at 14 56 17" src="https://user-images.githubusercontent.com/442230/161548563-8de48129-e88b-44c6-9b4b-f084df6c6ced.png">
After this change:
<img width="49" alt="Screenshot 2022-04-04 at 14 56 37" src="https://user-images.githubusercontent.com/442230/161548586-287ba481-d874-42a1-be78-61edb0373497.png">

