### PR TITLE
Add whitespace after navigation icon

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -94,7 +94,7 @@ module RailsAdmin
       actions(:root).select(&:show_in_sidebar).group_by(&:sidebar_label).collect do |label, nodes|
         li_stack = nodes.map do |node|
           url = rails_admin.url_for(action: node.action_name, controller: 'rails_admin/main')
-          nav_icon = node.link_icon ? %(<i class="#{node.link_icon}"></i> ).html_safe : ''
+          nav_icon = node.link_icon ? %(<i class="#{node.link_icon}"></i>).html_safe : ''
           content_tag :li do
             link_to nav_icon + " " + wording_for(:menu, node), url, class: "nav-link"
           end

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -94,7 +94,7 @@ module RailsAdmin
       actions(:root).select(&:show_in_sidebar).group_by(&:sidebar_label).collect do |label, nodes|
         li_stack = nodes.map do |node|
           url = rails_admin.url_for(action: node.action_name, controller: 'rails_admin/main')
-          nav_icon = node.link_icon ? %(<i class="#{node.link_icon}"></i>).html_safe : ''
+          nav_icon = node.link_icon ? %(<i class="#{node.link_icon}"></i> ).html_safe : ''
           content_tag :li do
             link_to nav_icon + " " + wording_for(:menu, node), url, class: "nav-link"
           end
@@ -121,7 +121,7 @@ module RailsAdmin
         model_param = abstract_model.to_param
         url         = rails_admin.url_for(action: :index, controller: 'rails_admin/main', model_name: model_param)
         level_class = " nav-level-#{level}" if level > 0
-        nav_icon = node.navigation_icon ? %(<i class="#{node.navigation_icon}"></i>).html_safe : ''
+        nav_icon = node.navigation_icon ? %(<i class="#{node.navigation_icon}"></i> ).html_safe : ''
         li = content_tag :li, data: {model: model_param} do
           link_to nav_icon + node.label_plural, url, class: "nav-link#{level_class}"
         end


### PR DESCRIPTION
As discussed by mshibuya and codealchemy in [upgrade to Bootstrap v5](https://github.com/railsadminteam/rails_admin/pull/3455/files#r780533297) the rendering of icons should not be fixed with CSS but adding a whitespace between the icon and the text.

This change applies that solution to the icons in the sidebar navigation as well.