### PR TITLE
✨ Listing: ability to add a default_scope

### DIFF
--- a/lib/rails_admin/config/actions/index.rb
+++ b/lib/rails_admin/config/actions/index.rb
@@ -33,14 +33,22 @@ module RailsAdmin
         register_instance_option :controller do
           proc do
             @objects ||= list_entries
+            scope_to_use = :all
 
+            # If the user configured a default_scope, we use it
+            scope_to_use = @model_config.list.default_scope.to_sym if @model_config.list.default_scope.present?
+
+            # If the user configured a list of scope, we will override the one above
             unless @model_config.list.scopes.empty?
               if params[:scope].blank?
-                @objects = @objects.send(@model_config.list.scopes.first) unless @model_config.list.scopes.first.nil?
+                scope_to_use = @model_config.list.scopes.first unless @model_config.list.scopes.first.nil?
               elsif @model_config.list.scopes.collect(&:to_s).include?(params[:scope])
-                @objects = @objects.send(params[:scope].to_sym)
+                scope_to_use = params[:scope].to_sym
               end
             end
+
+            # Now, we filter the objects
+            @objects = @objects.send(scope_to_use)
 
             respond_to do |format|
               format.html do

--- a/lib/rails_admin/config/sections/list.rb
+++ b/lib/rails_admin/config/sections/list.rb
@@ -34,6 +34,10 @@ module RailsAdmin
           parent.abstract_model.primary_key
         end
 
+        register_instance_option :default_scope do
+          :all
+        end
+
         register_instance_option :scopes do
           []
         end

--- a/spec/integration/actions/index_spec.rb
+++ b/spec/integration/actions/index_spec.rb
@@ -1083,6 +1083,32 @@ RSpec.describe 'Index action', type: :request do
     end
   end
 
+  describe 'with default_scope' do
+    before do
+      RailsAdmin.config do |config|
+        config.model Team do
+          list do
+            default_scope :red
+          end
+        end
+      end
+      @teams = [
+        FactoryBot.create(:team, color: 'red'),
+        FactoryBot.create(:team, color: 'red'),
+        FactoryBot.create(:team, color: 'white'),
+        FactoryBot.create(:team, color: 'black'),
+      ]
+    end
+
+    it 'shows only scoped records' do
+      visit index_path(model_name: 'team')
+      is_expected.to have_content(@teams[0].name)
+      is_expected.to have_content(@teams[1].name)
+      is_expected.to have_no_content(@teams[2].name)
+      is_expected.to have_no_content(@teams[3].name)
+    end
+  end
+
   describe 'row CSS class' do
     before do
       RailsAdmin.config do |config|


### PR DESCRIPTION
In some cases, we want to list relationships, so it's better to include them ( usage of `includes` )
This feature will allow you to use a `default_scope` to the list to allow the users to use whichever scope they want in their list.

This can override the use of `scopes` when there's only ONE scope for example