### PR TITLE
Fix orderable multiselect buttons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.swp
 .bundle
 .idea/
+.vscode/
 .rvmrc
 .sass-cache
 .yardoc

--- a/src/rails_admin/filtering-multiselect.js
+++ b/src/rails_admin/filtering-multiselect.js
@@ -1,7 +1,6 @@
 import jQuery from "jquery";
 import "jquery-ui/ui/widget";
 import I18n from "./i18n";
-
 (function ($) {
   $.widget("ra.filteringMultiselect", {
     _cache: {},
@@ -112,15 +111,11 @@ import I18n from "./i18n";
       }
       if (this.options.sortable) {
         this.up = $(
-          '<a href="#" class="fas fa-chevron-circle-up ra-multiselect-item-up">' +
-            this.options.regional.up +
-            "</a>"
-        );
+          '<a href="#" class="fas fa-chevron-circle-up ra-multiselect-item-up"></a>'
+        ).attr("title", this.options.regional.up);
         this.down = $(
-          '<a href="#" class="fas fa-chevron-circle-down ra-multiselect-item-down">' +
-            this.options.regional.down +
-            "</a>"
-        );
+          '<a href="#" class="fas fa-chevron-circle-down ra-multiselect-item-down"></a>'
+        ).attr("title", this.options.regional.down);
         columns.center.append(this.up).append(this.down);
       }
 


### PR DESCRIPTION
The Up/Down buttons for a "sortable" multiselect have labels, while the Left/Right buttons do not. These labels are cut off by the multiselect box. This PR removes the labels and uses the regional text as a `title` on the button instead.

**Before**
<img width="645" alt="orderable bug example 1" src="https://user-images.githubusercontent.com/21133757/162064694-522b3f41-cb07-4319-91df-6a5f4ee92675.png">


**After**
<img width="697" alt="orderable fix" src="https://user-images.githubusercontent.com/21133757/162064711-4fb277a9-402b-4dda-b05e-d9cca372f793.png">

