### PR TITLE
Fix default sort by behavior when list.sort_by points to a field with a table reference for :sortable

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -59,13 +59,15 @@ module RailsAdmin
       params[:return_to].presence && params[:return_to].include?(request.host) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
     end
 
+    # rubocop:disable Metrics/CyclomaticComplexity
     def get_sort_hash(model_config)
       abstract_model = model_config.abstract_model
       field = model_config.list.fields.detect { |f| f.name.to_s == params[:sort] }
+      # If no sort param, default to the `sort_by` specified in the list config
+      field ||= model_config.list.possible_fields.detect { |f| f.name == model_config.list.sort_by.to_sym }
 
       column =
         if field.nil? || field.sortable == false # use default sort, asked field does not exist or is not sortable
-          field = model_config.list.possible_fields.detect { |f| f.name == model_config.list.sort_by.to_sym }
           "#{abstract_model.table_name}.#{model_config.list.sort_by}"
         elsif field.sortable == true # use the given field
           "#{abstract_model.table_name}.#{field.name}"
@@ -82,6 +84,7 @@ module RailsAdmin
       params[:sort_reverse] ||= 'false'
       {sort: column, sort_reverse: (params[:sort_reverse] == (field&.sort_reverse&.to_s || 'true'))}
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     def redirect_to_on_success
       notice = I18n.t('admin.flash.successful', name: @model_config.label, action: I18n.t("admin.actions.#{@action.key}.done"))

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -42,6 +42,26 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
       end
     end
 
+    context 'when default sort_by points to a field with a table reference for sortable' do
+      before do
+        RailsAdmin.config('Player') do
+          base do
+            field :name do
+              sortable 'teams.name'
+            end
+          end
+
+          list do
+            sort_by :name
+          end
+        end
+      end
+
+      it 'returns the query referenced in the sortable' do
+        expect(controller.send(:get_sort_hash, RailsAdmin.config(Player))).to eq(sort: 'teams.name', sort_reverse: true)
+      end
+    end
+
     it 'works with belongs_to associations with label method virtual' do
       controller.params = {sort: 'parent_category', model_name: 'categories'}
       expect(controller.send(:get_sort_hash, RailsAdmin.config(Category))).to eq(sort: 'categories.parent_category_id', sort_reverse: true)
@@ -227,7 +247,7 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
       controller.params = {model_name: 'team'}
     end
 
-    it 'performs eager-loading with `eagar_load true`' do
+    it 'performs eager-loading with `eager_load true`' do
       RailsAdmin.config Team do
         field :players do
           eager_load true
@@ -237,7 +257,7 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
       controller.send(:get_collection, model_config, nil, false).to_a
     end
 
-    it 'performs eager-loading with custom eagar_load value' do
+    it 'performs eager-loading with custom eager_load value' do
       RailsAdmin.config Team do
         field :players do
           eager_load players: :draft

--- a/spec/dummy_app/Gemfile
+++ b/spec/dummy_app/Gemfile
@@ -30,7 +30,7 @@ group :mongoid do
 end
 
 gem 'carrierwave', '>= 2.0.0.rc', '< 3.0'
-gem 'devise', '>= 3.2', github: 'heartcombo/devise'
+gem 'devise', '>= 3.2', github: 'heartcombo/devise', branch: 'main'
 gem 'dragonfly', '~> 1.0'
 gem 'mini_magick', '>= 3.4'
 gem 'mlb', '>= 0.7', github: 'mshibuya/mlb', branch: 'ruby-3'


### PR DESCRIPTION
On a list page, when a sort param is not specified, the current version of rails admin defaults to appending the `list.sort_by` to the model table. This causes `list.sort_by` to always  be treated as a string when a sort param is not present. This changes the behavior to lookup the field specified in `list.sort_by` rather than treating it as a string.

This also updates the dummy gemfile to point to devise's main branch, as they changed the `master` branch to the name `main`.

For example, if we have the following:
```
RailsAdmin.config('Player') do
    base do
      field :name do
        sortable :'teams.name'
      end
    end

    list do
      sort_by :name
    end
 end
```

the query would be generated with a sort by `players.name`, when we actually want to sort by `teams.name`.

