### PR TITLE
Update hover / active behavior for side navigation links

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -123,6 +123,7 @@ module RailsAdmin
         nav_icon = node.navigation_icon ? %(<i class="#{node.navigation_icon}"></i>).html_safe : ''
         css_classes = ['nav-link']
         css_classes.push("nav-level-#{level}") if level > 0
+        css_classes.push('active') if defined?(@action) && current_action?(@action, model_param)
         li = content_tag :li, data: {model: model_param} do
           link_to nav_icon + node.label_plural, url, class: css_classes.join(' ')
         end

--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -120,10 +120,11 @@ module RailsAdmin
         abstract_model = node.abstract_model
         model_param = abstract_model.to_param
         url         = rails_admin.url_for(action: :index, controller: 'rails_admin/main', model_name: model_param)
-        level_class = " nav-level-#{level}" if level > 0
         nav_icon = node.navigation_icon ? %(<i class="#{node.navigation_icon}"></i>).html_safe : ''
+        css_classes = ['nav-link']
+        css_classes.push("nav-level-#{level}") if level > 0
         li = content_tag :li, data: {model: model_param} do
-          link_to nav_icon + node.label_plural, url, class: "nav-link#{level_class}"
+          link_to nav_icon + node.label_plural, url, class: css_classes.join(' ')
         end
         child_nodes = parent_groups[abstract_model.model_name]
         child_nodes ? li + navigation(parent_groups, child_nodes, level + 1) : li

--- a/src/rails_admin/styles/base/theming.scss
+++ b/src/rails_admin/styles/base/theming.scss
@@ -42,6 +42,16 @@ body.rails_admin {
     > li > a {
       padding: ($navbar-padding-y / 2) ($grid-gutter-width / 2);
 
+      &.active {
+        background-color: map-get($theme-colors, primary);
+        color: color-contrast(map-get($theme-colors, primary));
+      }
+
+      &:hover {
+        background-color: map-get($theme-colors, primary);
+        color: color-contrast(map-get($theme-colors, primary));
+      }
+
       &.nav-level-1 {
         padding-left: $grid-gutter-width;
       }


### PR DESCRIPTION
We noticed that the sidenav active / hover behavior from RailsAdmin 2.x did not carry over to RailsAdmin 3.0. This adds `hover` behavior to the side nav, and the `active` class to the side nav element that corresponds to the current model context - both of which can be overridden in user themes to maintain the current behavior. 

![side-nav-check](https://user-images.githubusercontent.com/4504083/164093772-d9e29a56-2df1-482d-ab5c-c05de8730b27.gif)

📝 I'm having trouble getting the 2.x branch running to demo the old behavior, but it can be seen in the [demo app](http://rails-admin-tb.herokuapp.com/admin/draft) linked from the README