### PR TITLE
Use status instead of statusText

### DIFF
--- a/src/rails_admin/remote-form.js
+++ b/src/rails_admin/remote-form.js
@@ -105,9 +105,8 @@ import * as bootstrap from "bootstrap/dist/js/bootstrap.esm";
       document.dispatchEvent(event);
 
       form.bind("ajax:complete", function (event) {
-        var data = event.detail[0],
-          status = event.detail[1];
-        if (status == "OK") {
+        var data = event.detail[0];
+        if (data.status == 200) {
           var json = $.parseJSON(data.responseText);
           var option =
             '<option value="' +


### PR DESCRIPTION
As of HTTP/2 the field statusText can be empty ( See: https://github.com/jquery/api.jquery.com/commit/be6de733d57d67634ef07dcfc38163d18945c0e4 ). Thus the field statusText is no longer relyable to base logic on. The field status of the XMLHttpRequest remains intact, so we can base the logic on that field.

We encountered this problem during testing of RailsAdmin 3.0 on local development environments versus acceptance environments. On the acceptance environments the success events wouldn't be fired anymore because the `statusText` was empty and thus the check `status == "OK"` always returned `false`.