### PR TITLE
Generate correct user edit url

### DIFF
--- a/app/helpers/rails_admin/application_helper.rb
+++ b/app/helpers/rails_admin/application_helper.rb
@@ -31,7 +31,7 @@ module RailsAdmin
 
       if authorized
         edit_url = rails_admin.url_for(
-          action_name: edit_action.action_name,
+          action: edit_action.action_name,
           model_name: abstract_model.to_param,
           controller: 'rails_admin/main',
           id: _current_user.id,


### PR DESCRIPTION
The current generated URL looks like `/user?action_name=edit&id=42`. However, if you use an authorization gem like cancancan this url requires the capability `:index`. If you only allow a user to edit itself, for example `can :edit, ::User, id: user.id`, the current URL would cause an Error to be thrown ( CanCan::AccessDenied ).

When we change action_name to action, the generated URL becomes `/user/42/edit` which matches the capability `can :edit, ::User, id: user.id`.

Fixes #3514.