### PR TITLE
Adds focus: false to newly created modal dialogs

### DIFF
--- a/src/rails_admin/remote-form.js
+++ b/src/rails_admin/remote-form.js
@@ -183,6 +183,7 @@ import * as bootstrap from "bootstrap";
         new bootstrap.Modal(widget.dialog[0], {
           keyboard: true,
           backdrop: true,
+          focus: false,
           show: true,
         }).show();
       }


### PR DESCRIPTION
Without forcing focus false, the modal will not allow other modals to have focus for their inputs. This breaks tools like CKEditor.

From local testing, there are no negative side effects with not forcing focus on open.

Closes #3538 