### PR TITLE
Fix CI following Rails updates

### DIFF
--- a/spec/dummy_app/config/application.rb
+++ b/spec/dummy_app/config/application.rb
@@ -39,7 +39,10 @@ module DummyApp
     config.eager_load_paths += %W[#{config.root}/app/#{CI_ORM}/eager_loaded]
     config.autoload_paths += %W[#{config.root}/lib]
     config.i18n.load_path += Dir[Rails.root.join('app', 'locales', '*.{rb,yml}').to_s]
-    config.active_record.time_zone_aware_types = %i[datetime time] if CI_ORM == :active_record
+    if CI_ORM == :active_record
+      config.active_record.time_zone_aware_types = %i[datetime time]
+      config.active_record.yaml_column_permitted_classes = [Symbol] if config.active_record.respond_to?(:yaml_column_permitted_classes=)
+    end
     config.active_storage.service = :local if defined?(ActiveStorage)
     config.active_storage.replace_on_assign_to_many = false if defined?(ActiveStorage) && ActiveStorage.version < Gem::Version.create('6.1')
 


### PR DESCRIPTION
CI builds from today are failing on `Psych::DisallowedClass` for serialized columns
https://github.com/railsadminteam/rails_admin/blob/4609fc690c7ba5a9fca026ea494c3d0d17d1cfb8/spec/dummy_app/app/active_record/user.rb#L8

Related to recent Rails releases from today (see [announcement](https://discuss.rubyonrails.org/t/cve-2022-32224-possible-rce-escalation-bug-with-serialized-columns-in-active-record/81017). https://github.com/rails/rails/commit/d28f278788b599c0a9f6e3ea437c6642eb56f16c, CVE-2022-32224)