### PR TITLE
avoid nil values in defined fields that can happen, e.g., if the data…

### DIFF
--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -89,7 +89,7 @@ module RailsAdmin
         else
           defined = field_names.collect { |field_name| _fields.detect { |f| f.name == field_name } }
         end
-        defined.collect do |f|
+        defined.compact.collect do |f|
           unless f.defined
             f.defined = true
             f.order = _fields.count(&:defined)


### PR DESCRIPTION
…base is not yet migrated to match the code.
fixes #3546 