### PR TITLE
Add primary_key to the end of order

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -117,7 +117,7 @@ module RailsAdmin
         direction = options[:sort_reverse] ? :asc : :desc
         case options[:sort]
         when String, Symbol
-          scope.reorder("#{options[:sort]} #{direction}")
+          scope.reorder("#{options[:sort]} #{direction}, #{table_name}.#{primary_key} #{direction}")
         when Array
           scope.reorder(options[:sort].zip(Array.new(options[:sort].size) { direction }).to_h)
         when Hash

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -139,6 +139,7 @@ RSpec.describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
 
       it 'supports ordering' do
         expect(abstract_model.all(sort: 'id', sort_reverse: true)).to eq(@players.sort)
+        expect(abstract_model.all(sort: 'name', sort_reverse: true).to_sql.tr('`', '"')).to include('ORDER BY name asc, players.id asc')
         expect(abstract_model.all(sort: %w[id name], sort_reverse: true).to_sql.tr('`', '"')).to include('ORDER BY "players"."id" ASC, "players"."name" ASC')
         expect(abstract_model.all(include: :team, sort: {players: :name, teams: :name}, sort_reverse: true).to_sql.tr('`', '"')).to include('ORDER BY "players"."name" ASC, "teams"."name" ASC')
         expect { abstract_model.all(sort: 1, sort_reverse: true) }.to raise_error ArgumentError, /Unsupported/


### PR DESCRIPTION
When I use rails_admin with PostgreSQL(latest 14.4), it is unstable to order by columns which are not unique.
Therefore, some records appear in several pages while some don't in any pages.
I would like to solve this problem by adding its primary_key to the end of order.

### Before

![Player___Dummy_App_Admin](https://user-images.githubusercontent.com/50437473/184004071-d3037670-99bc-4402-9219-d60089925d27.jpg)
![Player___Dummy_App_Admin](https://user-images.githubusercontent.com/50437473/184004100-2343f18c-8342-4eb2-a3cc-7528d545bf7a.jpg)

### After

![Player___Dummy_App_Admin](https://user-images.githubusercontent.com/50437473/184004137-1e00a2e0-f053-4740-a45f-4c852964bbb5.jpg)
![Player___Dummy_App_Admin](https://user-images.githubusercontent.com/50437473/184004193-1f178004-c24d-4924-bd6a-35cd60029262.jpg)