### PR TITLE
Tweak `select` form fields class for filters

### DIFF
--- a/src/rails_admin/filter-box.js
+++ b/src/rails_admin/filter-box.js
@@ -21,7 +21,7 @@ import flatpickr from "flatpickr";
 
       if (operators.length > 0) {
         control = $(
-          '<select class="form-control form-control-sm"></select>'
+          '<select class="form-control form-select form-select-sm"></select>'
         ).prop("name", operator_name);
 
         operators.forEach((operator) => {


### PR DESCRIPTION
Bootstrap 5 uses `form-select` (https://getbootstrap.com/docs/5.0/forms/select/) to help indicate the field is a dropdown.

#### Before

![Capture d’écran 2022-10-27 à 13 54 24](https://user-images.githubusercontent.com/4504083/198396742-13f8089c-56b1-4d10-9a24-e56584b4a7c7.png)

#### After

![Capture d’écran 2022-10-27 à 13 54 35](https://user-images.githubusercontent.com/4504083/198396733-cc78a5c5-c4bb-4ca2-9b8b-3285d2d78996.png)