### PR TITLE
Define jQuery object in separate file to support esbuild

### DIFF
--- a/lib/rails_admin/config/configurable.rb
+++ b/lib/rails_admin/config/configurable.rb
@@ -57,7 +57,7 @@ module RailsAdmin
 
           # If it's a boolean create an alias for it and remove question mark
           if option_name.end_with?('?')
-            scope.send(:define_method, "#{(+option_name).chop!}?") do
+            scope.send(:define_method, "#{option_name.chop!}?") do
               send(option_name)
             end
           end

--- a/lib/rails_admin/config/configurable.rb
+++ b/lib/rails_admin/config/configurable.rb
@@ -57,7 +57,7 @@ module RailsAdmin
 
           # If it's a boolean create an alias for it and remove question mark
           if option_name.end_with?('?')
-            scope.send(:define_method, "#{option_name.chop!}?") do
+            scope.send(:define_method, "#{(+option_name).chop!}?") do
               send(option_name)
             end
           end

--- a/src/rails_admin/base.js
+++ b/src/rails_admin/base.js
@@ -1,6 +1,6 @@
 import Rails from "@rails/ujs";
 import "@hotwired/turbo-rails";
-import jQuery from "jquery";
+import "./jquery";
 import "./vendor/jquery_nested_form";
 import "bootstrap";
 
@@ -27,4 +27,3 @@ import "./ui";
 import "./widgets";
 
 Rails.start();
-window.$ = window.jQuery = jQuery;

--- a/src/rails_admin/jquery.js
+++ b/src/rails_admin/jquery.js
@@ -1,0 +1,2 @@
+import jQuery from "jquery";
+window.$ = window.jQuery = jQuery;

--- a/src/rails_admin/jquery.js
+++ b/src/rails_admin/jquery.js
@@ -1,3 +1,4 @@
 import jQuery from "jquery";
 
-window.$ = window.jQuery = jQuery;
+window.$ = jQuery;
+window.jQuery = jQuery;

--- a/src/rails_admin/jquery.js
+++ b/src/rails_admin/jquery.js
@@ -1,2 +1,3 @@
 import jQuery from "jquery";
+
 window.$ = window.jQuery = jQuery;

--- a/src/rails_admin/jquery.js
+++ b/src/rails_admin/jquery.js
@@ -1,4 +1,3 @@
 import jQuery from "jquery";
 
-window.$ = jQuery;
-window.jQuery = jQuery;
+window.$ = window.jQuery = jQuery;


### PR DESCRIPTION
### Background
During our migration from webpacker to esbuild, our apps using `rails_admin` began to fail during builds, along with Chrome showing a `jQuery is not defined` error in the Console:

![image](https://user-images.githubusercontent.com/7328966/203870600-3620c81a-9762-49a0-9357-9897c9d97616.png)

We traced the root cause to the order of these actions in `src/rails_admin/base.js`:
- [Line 3](https://github.com/railsadminteam/rails_admin/blob/9997c1095066aaac39afb27bf8de705cf6ccb1ef/src/rails_admin/base.js#L3): import `jquery`
- [Lines 8-18](https://github.com/railsadminteam/rails_admin/blob/9997c1095066aaac39afb27bf8de705cf6ccb1ef/src/rails_admin/base.js#L8-L18): import `jquery-ui`
- [Line 30](https://github.com/railsadminteam/rails_admin/blob/9997c1095066aaac39afb27bf8de705cf6ccb1ef/src/rails_admin/base.js#L30): `window.$ = window.jQuery = jQuery;`

The `jquery-ui` modules are imported before `window.$` is defined, causing the above issues.

To add support for esbuild and to avoid issues with async and hoisting, we suggest importing and initialising `jQuery` together.

### Changes
- Move the jQuery initialiser into a separate file to import and define jQuery together