### PR TITLE
Add CI testing for Ruby 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.0", 3.1]
+        ruby:
+          - "3.0"
+          - "3.1"
+          - "3.2"
         gemfile: [gemfiles/rails_7.0.gemfile]
         orm: [active_record]
         adapter: [sqlite3]

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ This library aims to support and is [tested against][ghactions] the following Ru
 - Ruby 2.6
 - Ruby 2.7
 - Ruby 3.0
+- Ruby 3.1
+- Ruby 3.2
 - [JRuby][]
 
 [jruby]: http://jruby.org/


### PR DESCRIPTION
Released on 25 Dec 2022:
https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/