### PR TITLE
Remove support for end-of-life Ruby 2.6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,11 +14,6 @@ jobs:
         adapter: [sqlite3]
         asset: [webpack]
         include:
-          - ruby: 2.6
-            gemfile: gemfiles/rails_6.0.gemfile
-            orm: active_record
-            adapter: sqlite3
-            asset: sprockets
           - ruby: 2.7
             gemfile: gemfiles/rails_6.1.gemfile
             orm: active_record
@@ -50,16 +45,6 @@ jobs:
             adapter: sqlite3
             asset: sprockets
           - ruby: "3.0"
-            gemfile: gemfiles/rails_6.1.gemfile
-            orm: mongoid
-            adapter: sqlite3
-            asset: sprockets
-          - ruby: jruby-9.3
-            gemfile: gemfiles/rails_6.1.gemfile
-            orm: active_record
-            adapter: mysql2
-            asset: sprockets
-          - ruby: jruby-9.3
             gemfile: gemfiles/rails_6.1.gemfile
             orm: mongoid
             adapter: sqlite3

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -13,7 +13,7 @@ AllCops:
     - "vendor/bundle/**/*"
   NewCops: disable
   SuggestExtensions: false
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.7
 
 Gemspec/DeprecatedAttributeAssignment:
   Enabled: true

--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ If you think you found a bug in RailsAdmin, you can [submit an issue](https://gi
 
 This library aims to support and is [tested against][ghactions] the following Ruby implementations:
 
-- Ruby 2.6
 - Ruby 2.7
 - Ruby 3.0
 - [JRuby][]

--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -40,13 +40,6 @@ module RailsAdmin
     end
 
     def to_csv(options = {})
-      if CSV::VERSION == '3.0.2'
-        raise <<~MSG
-          CSV library bundled with Ruby 2.6.0 has encoding issue, please upgrade Ruby to 2.6.1 or later.
-          https://github.com/ruby/csv/issues/62
-        MSG
-      end
-
       options = HashWithIndifferentAccess.new(options)
       encoding_to = Encoding.find(options[:encoding_to]) if options[:encoding_to].present?
 

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.homepage = 'https://github.com/railsadminteam/rails_admin'
   spec.name = 'rails_admin'
   spec.require_paths = %w[lib]
-  spec.required_ruby_version     = '>= 2.6.0'
+  spec.required_ruby_version     = '>= 2.7.0'
   spec.required_rubygems_version = '>= 1.8.11'
   spec.summary = 'Admin for Rails'
   spec.version = RailsAdmin::Version


### PR DESCRIPTION
Ruby 2.6 has been EOL since 2022-04-12. It is no longer receiving security or bug fixes and its use is not supported. See: https://www.ruby-lang.org/en/downloads/branches/

Removing Ruby 2.6 will reduce the testing and maintenance required for this version. Workarounds can be removed. The RailsAdmin project can begin adopting newer Ruby coding conventions when convenient.

This removes jruby-9.3 from CI testing as that represents Ruby 2.6. jruby-9.4 was not added as that does not pass test suite.