### PR TITLE
Enable RuboCop Style/Encoding and apply auto-fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -162,9 +162,6 @@ Style/DoubleNegation:
 Style/EachWithObject:
   Enabled: false
 
-Style/Encoding:
-  Enabled: false
-
 Style/EndlessMethod:
   Enabled: true
 

--- a/lib/rails_admin/support/csv_converter.rb
+++ b/lib/rails_admin/support/csv_converter.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # frozen_string_literal: true
 
 require 'csv'

--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 lib = File.expand_path('lib', __dir__)

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/dummy_app/app/active_record/carrierwave_uploader.rb
+++ b/spec/dummy_app/app/active_record/carrierwave_uploader.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'mini_magick'

--- a/spec/dummy_app/app/active_record/team.rb
+++ b/spec/dummy_app/app/active_record/team.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 class Team < ActiveRecord::Base

--- a/spec/dummy_app/app/mongoid/carrierwave_uploader.rb
+++ b/spec/dummy_app/app/mongoid/carrierwave_uploader.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'mini_magick'

--- a/spec/dummy_app/app/mongoid/team.rb
+++ b/spec/dummy_app/app/mongoid/team.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 class Team

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 FactoryBot.define do

--- a/spec/integration/actions/history_index_spec.rb
+++ b/spec/integration/actions/history_index_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/integration/actions/history_show_spec.rb
+++ b/spec/integration/actions/history_show_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/integration/actions/index_spec.rb
+++ b/spec/integration/actions/index_spec.rb
@@ -1,4 +1,3 @@
-# coding: utf-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/rails_admin/support/csv_converter_spec.rb
+++ b/spec/rails_admin/support/csv_converter_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/rails_admin/support/datetime_spec.rb
+++ b/spec/rails_admin/support/datetime_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'spec_helper'

--- a/spec/rails_admin/support/hash_helper_spec.rb
+++ b/spec/rails_admin/support/hash_helper_spec.rb
@@ -1,4 +1,3 @@
-# encoding: utf-8
 # frozen_string_literal: true
 
 require 'spec_helper'


### PR DESCRIPTION
Docs on the cop:
https://docs.rubocop.org/rubocop/cops_style.html#styleencoding

Docs on the Ruby style guide:
https://rubystyle.guide/#utf-8

> TIP: UTF-8 has been the default source file encoding since Ruby 2.0.