### PR TITLE
Restore caching in RailsAdmin::Config::Model#excluded?

### DIFF
--- a/lib/rails_admin/config/model.rb
+++ b/lib/rails_admin/config/model.rb
@@ -48,7 +48,9 @@ module RailsAdmin
       end
 
       def excluded?
-        @excluded ||= !RailsAdmin::AbstractModel.all.collect(&:model_name).include?(abstract_model.try(:model_name))
+        return @excluded if defined?(@excluded)
+
+        @excluded = !RailsAdmin::AbstractModel.all.collect(&:model_name).include?(abstract_model.try(:model_name))
       end
 
       def object_label

--- a/spec/rails_admin/config/model_spec.rb
+++ b/spec/rails_admin/config/model_spec.rb
@@ -11,8 +11,21 @@ RSpec.describe RailsAdmin::Config::Model do
     end
 
     it 'returns false when included, true otherwise' do
-      expect(RailsAdmin.config(Player).excluded?).to be_truthy
-      expect(RailsAdmin.config(Comment).excluded?).to be_falsey
+      allow(RailsAdmin::AbstractModel).to receive(:all).and_call_original
+
+      player_config = RailsAdmin.config(Player)
+      expect(player_config.excluded?).to be_truthy
+      expect(RailsAdmin::AbstractModel).to have_received(:all).once
+      # Calling a second time uses the cached value.
+      expect(player_config.excluded?).to be_truthy
+      expect(RailsAdmin::AbstractModel).to have_received(:all).once
+
+      comment_config = RailsAdmin.config(Comment)
+      expect(comment_config.excluded?).to be_falsey
+      expect(RailsAdmin::AbstractModel).to have_received(:all).twice
+      # Calling a second time uses the cached value.
+      expect(comment_config.excluded?).to be_falsey
+      expect(RailsAdmin::AbstractModel).to have_received(:all).twice
     end
   end
 


### PR DESCRIPTION
Partially reverts 2fa86c361b88fbd4c36adaad60be2104e57d75f5. The commit introduced a regression such that RailsAdmin::Config::Model#excluded? stopped caching false values.