### PR TITLE
Switch to the safe navigation operator in spec files

### DIFF
--- a/spec/controllers/rails_admin/application_controller_spec.rb
+++ b/spec/controllers/rails_admin/application_controller_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe RailsAdmin::ApplicationController, type: :controller do
 
     it 'works for dynamic names in the controller context' do
       RailsAdmin.config do |config|
-        config.main_app_name = proc { |controller| [Rails.application.engine_name.try(:titleize), controller.params[:action].titleize] }
+        config.main_app_name = proc { |controller| [Rails.application.engine_name&.titleize, controller.params[:action].titleize] }
       end
       controller.params[:action] = 'dashboard'
       expect(controller.send(:_get_plugin_name)).to eq(['Dummy App Application', 'Dashboard'])

--- a/spec/dummy_app/app/active_record/field_test.rb
+++ b/spec/dummy_app/app/active_record/field_test.rb
@@ -30,7 +30,7 @@ class FieldTest < ActiveRecord::Base
     attr_accessor :remove_active_storage_assets
 
     after_save do
-      Array(remove_active_storage_assets).each { |id| active_storage_assets.find_by_id(id).try(:purge) }
+      Array(remove_active_storage_assets).each { |id| active_storage_assets.find_by_id(id)&.purge }
     end
   end
 


### PR DESCRIPTION
Ruby now has native support safe navigation so it can sometimes be used instead of the Rails Object#try method.

The change is limited to just the specs until other changes can be thoroughly verified. The safe navigation operator is different in that if the object is non-nil and the object does not respond to the method, a NoMethodError will be raised.