### PR TITLE
Optimize/simplify viable_models file path to class name logic

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -364,19 +364,16 @@ module RailsAdmin
 
     private
 
-      def lchomp(base, arg)
-        base.to_s.reverse.chomp(arg.to_s.reverse).reverse
-      end
-
       def viable_models
         included_models.collect(&:to_s).presence || begin
           @@system_models ||= # memoization for tests
             ([Rails.application] + Rails::Engine.subclasses.collect(&:instance)).flat_map do |app|
               (app.paths['app/models'].to_a + app.config.eager_load_paths).collect do |load_path|
                 Dir.glob(app.root.join(load_path)).collect do |load_dir|
+                  path_prefix = "#{app.root.join(load_dir)}/"
                   Dir.glob("#{load_dir}/**/*.rb").collect do |filename|
                     # app/models/module/class.rb => module/class.rb => module/class => Module::Class
-                    lchomp(filename, "#{app.root.join(load_dir)}/").chomp('.rb').camelize
+                    filename.delete_prefix(path_prefix).chomp('.rb').camelize
                   end
                 end
               end


### PR DESCRIPTION
Use `String#delete_prefix` to reduce object allocations and simplify the existing logic that converts a file path to a class name when loading candidate models during startup. Also, move repeated path creation to respective outer loop to further cut back on string objects.

Profiler setup on a small project
```ruby
MemoryProfiler.report { RailsAdmin::Config.send(:viable_models) }.pretty_print(to_file: "prof-#{Time.now.to_i}.txt")
```

Original code:
```
allocated objects by file
-----------------------------------
     11885  ruby/2.7.6/lib/ruby/2.7.0/pathname.rb
      4180  rails_admin/lib/rails_admin/config.rb
```

After patch:
```
allocated objects by file
-----------------------------------
      2141  ruby/2.7.6/lib/ruby/2.7.0/pathname.rb
      1780  rails_admin/lib/rails_admin/config.rb
```