### PR TITLE
Fix image_html path

### DIFF
--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -43,7 +43,7 @@ module RailsAdmin
               url = resource_url
               if image
                 thumb_url = resource_url(thumb_method)
-                image_html = v.image_tag(thumb_url, class: 'img-thumbnail')
+                image_html = v.image_tag(resource_url, class: 'img-thumbnail')
                 url == thumb_url ? image_html : v.link_to(image_html, url, target: '_blank', rel: 'noopener noreferrer')
               else
                 v.link_to(link_name, url, target: '_blank', rel: 'noopener noreferrer')


### PR DESCRIPTION
situation: Picture was not able to be correctly displayed in a record referring to an active storage picture

error identified: incorrect link given to show the picture in the view

fix provided:
replace `thumb_url` in `image_html = v.image_tag(thumb_url, class: 'img-thumbnail')` by `resource_url`
