### PR TITLE
Add support for '%-l' option to Flatpickr.

### DIFF
--- a/lib/rails_admin/support/datetime.rb
+++ b/lib/rails_admin/support/datetime.rb
@@ -21,6 +21,7 @@ module RailsAdmin
         '%-I' => 'h',      # Hour of the day, 12-hour clock (1..12)
         '%k' => 'H',       # Hour of the day, 24-hour clock (0..23)
         '%l' => 'h',       # Hour of the day, 12-hour clock (1..12)
+        '%-l' => 'h',      # Hour of the day, 12-hour clock (1..12)
         '%M' => 'i',       # Minute of the hour (00..59)
         '%-M' => 'i',      # Minute of the hour (00..59)
         '%m' => 'm',       # Month of the year (01..12)

--- a/spec/rails_admin/support/datetime_spec.rb
+++ b/spec/rails_admin/support/datetime_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe RailsAdmin::Support::Datetime do
       '%Y-%m-%dT%H:%M:%S%:z' => 'Y-m-d\TH:i:S+00:00',
       '%HH%MM%SS' => 'H\Hi\MS\S',
       'a%-Ha%-Ma%-Sa%:za' => '\aH\ai\as\a+00:00\a',
+      '%B %-d at %-l:%M %p' => 'F j \a\t h:i K',
     }.each do |strftime_format, flatpickr_format|
       it "convert strftime_format to flatpickr_format - example #{strftime_format}" do
         expect(RailsAdmin::Support::Datetime.to_flatpickr_format(strftime_format)).to eq flatpickr_format


### PR DESCRIPTION
We currently support the options `%-d`, `%-H`, `%-I`, `%-M`, `%-m`, `%-S`, but not `%-l`. Adding `%-l` will prevent an error to be raised when the Ruby format uses this option.

Here's an example of how this could be used:

```ruby
> datetime = DateTime.new(2023, 4, 6, 9, 15)
=> Thu, 06 Apr 2023 09:15:00 +0000
> datetime.strftime("at %-l:%M %p")
=> "at 9:15 AM" # no extra pad before the hour
> datetime.strftime("at %l:%M %p")
=> "at  9:15 AM" # extra pad before the hour
```