### PR TITLE
Vulnerability fix: validate return_to param using request.host

### DIFF
--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -56,14 +56,11 @@ module RailsAdmin
     end
 
     def back_or_index
-      params[:return_to].presence && allowed_return_to?(params[:return_to]) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
+      allowed_return_to?(params[:return_to].to_s) ? params[:return_to] : index_path
     end
 
     def allowed_return_to?(url)
-      return true if url.starts_with?(request.base_url)
-      return false unless url.to_s.start_with?('/')
-
-      !url.to_s.start_with?('//')
+      url != request.fullpath && url.start_with?(request.base_url, '/') && !url.start_with?('//')
     end
 
     def get_sort_hash(model_config)

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -56,7 +56,14 @@ module RailsAdmin
     end
 
     def back_or_index
-      params[:return_to].presence && params[:return_to].starts_with?(request.base_url) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
+      params[:return_to].presence && allowed_return_to?(params[:return_to]) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
+    end
+
+    def allowed_return_to?(url)
+      return true if url.starts_with?(request.base_url)
+      return false unless url.to_s.start_with?('/')
+
+      !url.to_s.start_with?('//')
     end
 
     def get_sort_hash(model_config)

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -56,8 +56,7 @@ module RailsAdmin
     end
 
     def back_or_index
-      params[:return_to].presence && params[:return_to].starts_with?(request.base_url) &&
-        (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
+      params[:return_to].presence && params[:return_to].starts_with?(request.base_url) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
     end
 
     def get_sort_hash(model_config)

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -56,7 +56,7 @@ module RailsAdmin
     end
 
     def back_or_index
-      params[:return_to].presence && params[:return_to].include?(request.host) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
+      params[:return_to].presence && params[:return_to].starts_with?(request.host) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
     end
 
     def get_sort_hash(model_config)

--- a/app/controllers/rails_admin/main_controller.rb
+++ b/app/controllers/rails_admin/main_controller.rb
@@ -56,7 +56,8 @@ module RailsAdmin
     end
 
     def back_or_index
-      params[:return_to].presence && params[:return_to].starts_with?(request.host) && (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
+      params[:return_to].presence && params[:return_to].starts_with?(request.base_url) &&
+        (params[:return_to] != request.fullpath) ? params[:return_to] : index_path
     end
 
     def get_sort_hash(model_config)

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -485,12 +485,12 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
 
     it 'returns back to return_to url when return_path does start_with the request.host' do
       return_to_url = "#{request.host}/teams"
-      controller.params = { return_to: return_to_url }
+      controller.params = {return_to: return_to_url}
       expect(controller.send(:back_or_index)).to eq(return_to_url)
     end
 
     it 'returns back to index when return_path does not start_with the request.host' do
-      controller.params = { return_to:"https://google.com?#{request.host}" }
+      controller.params = {return_to: "https://google.com?#{request.host}"}
       expect(controller.send(:back_or_index)).to eq(index_path)
     end
   end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -483,14 +483,26 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
       expect(controller.send(:back_or_index)).to eq(index_path)
     end
 
-    it 'returns back to return_to url when return_path does start_with the request.host' do
-      return_to_url = "#{request.host}/teams"
+    it 'returns back to return_to url when it starts with same protocol and host' do
+      return_to_url = "http://#{request.host}/teams"
       controller.params = {return_to: return_to_url}
       expect(controller.send(:back_or_index)).to eq(return_to_url)
     end
 
-    it 'returns back to index when return_path does not start_with the request.host' do
-      controller.params = {return_to: "https://google.com?#{request.host}"}
+    it 'returns back to index url when return_to path does not start with protocol' do
+      return_to_url = "#{request.host}/teams"
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+
+    it 'returns back to index when return_to url starts with different protocol' do
+      return_to_url = "https://#{request.host}/teams"
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+
+    it 'returns back to index when return_to does not start with the same protocol and host' do
+      controller.params = {return_to: "http://google.com?#{request.host}"}
       expect(controller.send(:back_or_index)).to eq(index_path)
     end
   end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -470,4 +470,28 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
       )
     end
   end
+
+  describe 'back_or_index' do
+    before do
+      allow(controller).to receive(:index_path).and_return(index_path)
+    end
+
+    let(:index_path) { "/"}
+
+    it "returns back to index when return_to is not defined" do
+      controller.params = {}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+
+    it "returns back to return_to url when return_path does start_with the request.host" do
+      return_to_url = "#{request.host}/teams"
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(return_to_url)
+    end
+
+    it "returns back to index when return_path does not start_with the request.host" do
+      controller.params = {return_to:"https://google.com?#{request.host}"}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+  end
 end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -476,21 +476,21 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
       allow(controller).to receive(:index_path).and_return(index_path)
     end
 
-    let(:index_path) { "/"}
+    let(:index_path) { '/' }
 
-    it "returns back to index when return_to is not defined" do
+    it 'returns back to index when return_to is not defined' do
       controller.params = {}
       expect(controller.send(:back_or_index)).to eq(index_path)
     end
 
-    it "returns back to return_to url when return_path does start_with the request.host" do
+    it 'returns back to return_to url when return_path does start_with the request.host' do
       return_to_url = "#{request.host}/teams"
-      controller.params = {return_to: return_to_url}
+      controller.params = { return_to: return_to_url }
       expect(controller.send(:back_or_index)).to eq(return_to_url)
     end
 
-    it "returns back to index when return_path does not start_with the request.host" do
-      controller.params = {return_to:"https://google.com?#{request.host}"}
+    it 'returns back to index when return_path does not start_with the request.host' do
+      controller.params = { return_to:"https://google.com?#{request.host}" }
       expect(controller.send(:back_or_index)).to eq(index_path)
     end
   end

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -489,19 +489,49 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
       expect(controller.send(:back_or_index)).to eq(return_to_url)
     end
 
-    it 'returns back to index url when return_to path does not start with protocol' do
+    it 'returns back to return_to url when it contains a path' do
+      return_to_url = '/teams'
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(return_to_url)
+    end
+
+    it 'returns back to index path when return_to path does not start with slash' do
+      return_to_url = 'teams'
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+
+    it 'returns back to index path when return_to url does not start with full protocol' do
       return_to_url = "#{request.host}/teams"
       controller.params = {return_to: return_to_url}
       expect(controller.send(:back_or_index)).to eq(index_path)
     end
 
-    it 'returns back to index when return_to url starts with different protocol' do
-      return_to_url = "https://#{request.host}/teams"
+    it 'returns back to index path when return_to url starts with double slash' do
+      return_to_url = "//#{request.host}/teams"
       controller.params = {return_to: return_to_url}
       expect(controller.send(:back_or_index)).to eq(index_path)
     end
 
-    it 'returns back to index when return_to does not start with the same protocol and host' do
+    it 'returns back to index path when return_to url starts with tripple slash' do
+      return_to_url = "///#{request.host}/teams"
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+
+    it 'returns back to index path when return_to url does not have host' do
+      return_to_url = 'http:///teams'
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+
+    it 'returns back to index path when return_to url starts with different protocol' do
+      return_to_url = "other://#{request.host}/teams"
+      controller.params = {return_to: return_to_url}
+      expect(controller.send(:back_or_index)).to eq(index_path)
+    end
+
+    it 'returns back to index path when return_to does not start with the same protocol and host' do
       controller.params = {return_to: "http://google.com?#{request.host}"}
       expect(controller.send(:back_or_index)).to eq(index_path)
     end


### PR DESCRIPTION
## Context 
An internal team audits the Maxwell Rails apps occasionally, and in the last run, they discovered a vulnerability. Please take a look at the details bellow:

> An arbitrary redirect vulnerability occurs when an application URL redirects users to a 3rd-party, attacker-controlled website. As users recognize the application URL, they are likely to interact with the link. This can be used for phishing attacks against application users.
> 
> The rails_admin gem allows a redirect URL to be specified as a GET parameter. The validation of this URL does not properly check the redirect’s host, allowing it to be used as an arbitrary redirect.

## Solution
Validate the URL starts with the ~`request.host`~ `request.base_url`
