### PR TITLE
fix is_blank and is_present filters for uuid columns

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -201,6 +201,8 @@ module RailsAdmin
           case @type
           when :boolean
             boolean_unary_operators
+          when :uuid
+            uuid_unary_operators
           when :integer, :decimal, :float
             numeric_unary_operators
           else
@@ -230,6 +232,7 @@ module RailsAdmin
           )
         end
         alias_method :numeric_unary_operators, :boolean_unary_operators
+        alias_method :uuid_unary_operators, :boolean_unary_operators
 
         def range_filter(min, max)
           if min && max && min == max

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -583,13 +583,13 @@ RSpec.describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
 
       it "supports '_blank' operator" do
         [['_blank', ''], ['', '_blank']].each do |value, operator|
-          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NULL)"])
+          expect(build_statement(:uuid, value, operator)).to eq(['(field IS NULL)'])
         end
       end
 
       it "supports '_present' operator" do
         [['_present', ''], ['', '_present']].each do |value, operator|
-          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NOT NULL)"])
+          expect(build_statement(:uuid, value, operator)).to eq(['(field IS NOT NULL)'])
         end
       end
 
@@ -607,13 +607,13 @@ RSpec.describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
 
       it "supports '_empty' operator" do
         [['_empty', ''], ['', '_empty']].each do |value, operator|
-          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NULL)"])
+          expect(build_statement(:uuid, value, operator)).to eq(['(field IS NULL)'])
         end
       end
 
       it "supports '_not_empty' operator" do
         [['_not_empty', ''], ['', '_not_empty']].each do |value, operator|
-          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NOT NULL)"])
+          expect(build_statement(:uuid, value, operator)).to eq(['(field IS NOT NULL)'])
         end
       end
     end

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -575,9 +575,47 @@ RSpec.describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
       end
     end
 
-    it 'supports uuid type query' do
-      uuid = SecureRandom.uuid
-      expect(build_statement(:uuid, uuid, nil)).to eq(['(field = ?)', uuid])
+    describe 'uuid type queries' do
+      it 'supports uuid type query' do
+        uuid = SecureRandom.uuid
+        expect(build_statement(:uuid, uuid, nil)).to eq(['(field = ?)', uuid])
+      end
+
+      it "supports '_blank' operator" do
+        [['_blank', ''], ['', '_blank']].each do |value, operator|
+          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NULL)"])
+        end
+      end
+
+      it "supports '_present' operator" do
+        [['_present', ''], ['', '_present']].each do |value, operator|
+          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NOT NULL)"])
+        end
+      end
+
+      it "supports '_null' operator" do
+        [['_null', ''], ['', '_null']].each do |value, operator|
+          expect(build_statement(:uuid, value, operator)).to eq(['(field IS NULL)'])
+        end
+      end
+
+      it "supports '_not_null' operator" do
+        [['_not_null', ''], ['', '_not_null']].each do |value, operator|
+          expect(build_statement(:uuid, value, operator)).to eq(['(field IS NOT NULL)'])
+        end
+      end
+
+      it "supports '_empty' operator" do
+        [['_empty', ''], ['', '_empty']].each do |value, operator|
+          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NULL)"])
+        end
+      end
+
+      it "supports '_not_empty' operator" do
+        [['_not_empty', ''], ['', '_not_empty']].each do |value, operator|
+          expect(build_statement(:uuid, value, operator)).to eq(["(field IS NOT NULL)"])
+        end
+      end
     end
   end
 


### PR DESCRIPTION
Using "is present" and "is blank" filters for UUID columns causes "PG::InvalidTextRepresentation" since UUID type cannot be represented with empty string. 

Empty string search is removed for UUID as well as boolean, integer, decimal and float columns.