### PR TITLE
Reset polymorphic id upon type change

### DIFF
--- a/src/rails_admin/widgets.js
+++ b/src/rails_admin/widgets.js
@@ -258,6 +258,7 @@ import I18n from "./i18n";
             "options"
           );
           object_select.data("options", selected_data);
+          object_select.val('');
           object_select.filteringSelect("destroy");
           object_select.filteringSelect(selected_data);
         });


### PR DESCRIPTION
Hi, thank you for your attention. Currently, for polymorphic association fields, the id persists after type is changed, which may be unclear to users and cause a bug if the id is selected before type. With this change, the id field can be reset each time the type field changes. I hope you can approve this merge request. Thank you!