### PR TITLE
fix images detection issues for file_upload types

### DIFF
--- a/lib/rails_admin/config/fields/types/file_upload.rb
+++ b/lib/rails_admin/config/fields/types/file_upload.rb
@@ -52,7 +52,7 @@ module RailsAdmin
           end
 
           register_instance_option :image? do
-            mime_type = Mime::Type.lookup_by_extension(resource_url.to_s.split('.').last)
+            mime_type = Mime::Type.lookup_by_extension(resource_url.to_s.split('.').last&.split('?')&.first)
             mime_type.to_s.match?(/^image/)
           end
 


### PR DESCRIPTION
This PR fixes an issue for the `FileUpload` type especially for the `:image?` instance_option,
some file uploading Gems add a query string part to the file/image URL, `paperclip` for example adds timestamp value to the file's URL and in the current implementation having query string will result in NOT considering the file as an image even when it's an image 