### PR TITLE
Replace &rdquo; entity with inline <q> element

### DIFF
--- a/app/views/rails_admin/main/delete.html.erb
+++ b/app/views/rails_admin/main/delete.html.erb
@@ -1,6 +1,6 @@
 <h4>
   <%= t("admin.form.are_you_sure_you_want_to_delete_the_object", model_name: @abstract_model.pretty_name.downcase) %>
-  &ldquo;<strong><%= @model_config.with(object: @object).object_label %></strong>&rdquo;
+  <q><strong><%= @model_config.with(object: @object).object_label %></strong></q>
   <%= t("admin.form.all_of_the_following_related_items_will_be_deleted") %>
 </h4>
 <ul>


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/q

> Most modern browsers implement this by surrounding the text in
> quotation marks.

Importantly, this uses the localized quotation glyph. In English, this is the same left/right quotation mark.