### PR TITLE
Fix filter on enum value in list view

### DIFF
--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -28,7 +28,7 @@ module RailsAdmin
             if abstract_model.model.respond_to?(enum_method)
               abstract_model.model.send(enum_method)
             else
-              (bindings[:object] || abstract_model.model.new).send(enum_method)
+              (bindings&.[](:object) || abstract_model.model.new).send(enum_method)
             end
           end
 


### PR DESCRIPTION
Filtering on enum (in list view) gave the following error:
```
ActionView::Template::Error (undefined method `[]' for nil:NilClass

              (bindings[:object] || abstract_model.model.new).send(enum_method)
                       ^^^^^^^^^):
    54: <div id="list">
    55:   <%= form_tag(index_path(params.except(*%w[page f query])), method: :get) do %>
    56:     <div class="card mb-3 p-3 bg-light">
    57:       <div class="row" data-options="<%= ordered_filter_options.to_json %>" id="filters_box"></div>
    58:       <hr class="filters_box" style="display:<%= ordered_filters.empty? ? 'none' : 'block' %>"/>
    59:       <div class="row">
    60:         <div class="col-sm-6">

rails_admin (3.1.2) lib/rails_admin/config/fields/types/enum.rb:31:in `block in <class:Enum>'
rails_admin (3.1.2) lib/rails_admin/config/configurable.rb:77:in `instance_eval'
rails_admin (3.1.2) lib/rails_admin/config/configurable.rb:77:in `block in register_instance_option'
rails_admin (3.1.2) lib/rails_admin/config/fields/types/enum.rb:14:in `block in <class:Enum>'
rails_admin (3.1.2) lib/rails_admin/config/configurable.rb:77:in `instance_eval'
rails_admin (3.1.2) lib/rails_admin/config/configurable.rb:77:in `block in register_instance_option'
rails_admin (3.1.2) lib/rails_admin/config/fields/base.rb:106:in `filter_options'
rails_admin (3.1.2) app/helpers/rails_admin/main_helper.rb:52:in `block in ordered_filter_options'
rails_admin (3.1.2) app/helpers/rails_admin/main_helper.rb:44:in `map'
rails_admin (3.1.2) app/helpers/rails_admin/main_helper.rb:44:in `ordered_filter_options'
rails_admin (3.1.2) app/views/rails_admin/main/index.html.erb:57
actionview (7.0.8) lib/action_view/helpers/capture_helper.rb:45:in `block in capture'
actionview (7.0.8) lib/action_view/helpers/capture_helper.rb:209:in `with_output_buffer'
actionview (7.0.8) lib/action_view/helpers/capture_helper.rb:45:in `capture'
actionview (7.0.8) lib/action_view/helpers/form_tag_helper.rb:78:in `form_tag'
rails_admin (3.1.2) app/views/rails_admin/main/index.html.erb:55
```

This is because bindings is nil and thus the hash lookup fails. By adding safe navigation we circumvent this error and use the second option namely `abstract_model.model.new`.
