### PR TITLE
Stop using update_only to decide to show subform on create

### DIFF
--- a/app/views/rails_admin/main/_form_nested_many.html.erb
+++ b/app/views/rails_admin/main/_form_nested_many.html.erb
@@ -3,7 +3,7 @@
     <a class="<%= (field.active? ? 'active' : '') %> btn btn-info toggler" data-bs-target="<%= form.jquery_namespace(field) %> .collapse" data-bs-toggle="collapse" role="button">
       <i class="fas"></i>
     </a>
-    <% unless field.nested_form[:update_only] || !field.inline_add %>
+    <% if field.inline_add %>
       <%= form.link_to_add "<i class=\"fas fa-plus\"></i> #{wording_for(:link, :new, field.associated_model_config.abstract_model)}".html_safe, field.name, { class: 'btn btn-info' } %>
     <% end %>
   </div>

--- a/app/views/rails_admin/main/_form_nested_one.html.erb
+++ b/app/views/rails_admin/main/_form_nested_one.html.erb
@@ -4,7 +4,7 @@
     <a class="<%= (field.active? ? 'active' : '') %> btn btn-info toggler" data-bs-target="<%= form.jquery_namespace(field) %> .collapse" data-bs-toggle="collapse" role="button">
       <i class="fas"></i>
     </a>
-    <% unless field.nested_form[:update_only] || !field.inline_add %>
+    <% if field.inline_add %>
       <%= form.link_to_add "<i class=\"fas fa-plus\"></i> #{wording_for(:link, :new, field.associated_model_config.abstract_model)}".html_safe, field.name, { class: 'btn btn-info', :'data-add-label' => "<i class=\"fas fa-plus\"></i> #{wording_for(:link, :new, field.associated_model_config.abstract_model)}".gsub("\n", "") } %>
     <% end %>
   </div>

--- a/spec/integration/widgets/nested_many_spec.rb
+++ b/spec/integration/widgets/nested_many_spec.rb
@@ -108,21 +108,13 @@ RSpec.describe 'Nested many widget', type: :request, js: true do
   context 'with nested_attributes_options given' do
     before do
       allow(FieldTest.nested_attributes_options).to receive(:[]).with(any_args).
-        and_return(allow_destroy: true, update_only: false)
-    end
-
-    it 'does not show add button when :update_only is true' do
-      allow(FieldTest.nested_attributes_options).to receive(:[]).with(:nested_field_tests).
-        and_return(allow_destroy: true, update_only: true)
-      visit new_path(model_name: 'field_test')
-      is_expected.to have_selector('.toggler')
-      is_expected.not_to have_selector('#field_test_nested_field_tests_attributes_field .add_nested_fields')
+        and_return(allow_destroy: true)
     end
 
     it 'does not show destroy button except for newly created when :allow_destroy is false', js: false do
       nested_field_tests
       allow(FieldTest.nested_attributes_options).to receive(:[]).with(:nested_field_tests).
-        and_return(allow_destroy: false, update_only: false)
+        and_return(allow_destroy: false)
       visit edit_path(model_name: 'field_test', id: field_test.id)
       expect(find('#field_test_nested_field_tests_attributes_0_title').value).to eq('title 1')
       is_expected.not_to have_selector('form .remove_nested_fields')


### PR DESCRIPTION
Closes #2626 

There seems to be some confusion here about what `:update_only` means in `accepts_nested_attributes_for` in Rails Admin.  It is currently use to decide to show the subform for a child record when creating a new record.  I don't think this is correct. 

https://api.rubyonrails.org/classes/ActiveRecord/NestedAttributes/ClassMethods.html

> For a one-to-one association, this option allows you to specify how nested attributes are going to be used when an associated record already exists. In general, an existing record may either be updated with the new set of attribute values or be replaced by a wholly new record containing those values. By default the :update_only option is false and the nested attributes are used to update the existing record only if they include the record’s :id value. Otherwise a new record will be instantiated and used to replace the existing one. However if the :update_only option is true, the nested attributes are used to update the record’s attributes always, regardless of whether the :id is present. The option is ignored for collection associations.

This PR no longer attempts to use `update_only`, and only looks at `field.inline_add`.

Also as a bonus removing an `unless` with `||` makes my [Grug brain](https://grugbrain.dev/) happy. 