### PR TITLE
Show a thumbnail of all representable Active Storage files + images

### DIFF
--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -18,10 +18,7 @@ module RailsAdmin
           end
 
           register_instance_option :image? do
-            if value
-              mime_type = Mime::Type.lookup_by_extension(value.filename.extension_without_delimiter)
-              mime_type.to_s.match?(/^image/)
-            end
+            value.representable? if value
           end
 
           register_instance_option :eager_load do
@@ -43,11 +40,11 @@ module RailsAdmin
           def resource_url(thumb = false)
             return nil unless value
 
-            if thumb && value.variable?
+            if thumb && value.representable?
               thumb = thumb_method if thumb == true
-              variant = value.variant(thumb)
+              repr = value.representation(thumb)
               Rails.application.routes.url_helpers.rails_blob_representation_path(
-                variant.blob.signed_id, variant.variation.key, variant.blob.filename, only_path: true
+                repr.blob.signed_id, repr.variation.key, repr.blob.filename, only_path: true
               )
             else
               Rails.application.routes.url_helpers.rails_blob_path(value, only_path: true)

--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -18,7 +18,7 @@ module RailsAdmin
           end
 
           register_instance_option :image? do
-            value.representable? if value
+            value&.representable?
           end
 
           register_instance_option :eager_load do

--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -18,7 +18,9 @@ module RailsAdmin
           end
 
           register_instance_option :image? do
-            value&.representable?
+            if value
+              value.representable? || mime_type(value.filename).to_s.match?(/^image/)
+            end
           end
 
           register_instance_option :eager_load do
@@ -54,6 +56,10 @@ module RailsAdmin
           def value
             attachment = super
             attachment if attachment&.attached?
+          end
+
+          def mime_type(filename_obj)
+            Mime::Type.lookup_by_extension(filename_obj.extension_without_delimiter)
           end
         end
       end

--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -18,9 +18,7 @@ module RailsAdmin
           end
 
           register_instance_option :image? do
-            if value
-              value.representable? || mime_type(value.filename).to_s.match?(/^image/)
-            end
+            value && (value.representable? || mime_type(value.filename).to_s.match?(/^image/))
           end
 
           register_instance_option :eager_load do

--- a/lib/rails_admin/config/fields/types/multiple_active_storage.rb
+++ b/lib/rails_admin/config/fields/types/multiple_active_storage.rb
@@ -23,7 +23,9 @@ module RailsAdmin
             end
 
             register_instance_option :image? do
-              value&.representable?
+              if value
+                value.representable? || mime_type(value.filename).to_s.match?(/^image/)
+              end
             end
 
             def resource_url(thumb = false)
@@ -37,6 +39,10 @@ module RailsAdmin
               else
                 Rails.application.routes.url_helpers.rails_blob_path(value, only_path: true)
               end
+            end
+
+            def mime_type(filename_obj)
+              Mime::Type.lookup_by_extension(filename_obj.extension_without_delimiter)
             end
           end
 

--- a/lib/rails_admin/config/fields/types/multiple_active_storage.rb
+++ b/lib/rails_admin/config/fields/types/multiple_active_storage.rb
@@ -23,9 +23,7 @@ module RailsAdmin
             end
 
             register_instance_option :image? do
-              if value
-                value.representable? || mime_type(value.filename).to_s.match?(/^image/)
-              end
+              value && (value.representable? || mime_type(value.filename).to_s.match?(/^image/))
             end
 
             def resource_url(thumb = false)

--- a/lib/rails_admin/config/fields/types/multiple_active_storage.rb
+++ b/lib/rails_admin/config/fields/types/multiple_active_storage.rb
@@ -23,7 +23,7 @@ module RailsAdmin
             end
 
             register_instance_option :image? do
-              value.representable? if value
+              value&.representable?
             end
 
             def resource_url(thumb = false)

--- a/lib/rails_admin/config/fields/types/multiple_active_storage.rb
+++ b/lib/rails_admin/config/fields/types/multiple_active_storage.rb
@@ -23,19 +23,16 @@ module RailsAdmin
             end
 
             register_instance_option :image? do
-              if value
-                mime_type = Mime::Type.lookup_by_extension(value.filename.extension_without_delimiter)
-                mime_type.to_s.match?(/^image/)
-              end
+              value.representable? if value
             end
 
             def resource_url(thumb = false)
               return nil unless value
 
-              if thumb && value.variable?
-                variant = value.variant(thumb_method)
+              if thumb && value.representable?
+                repr = value.representation(thumb_method)
                 Rails.application.routes.url_helpers.rails_blob_representation_path(
-                  variant.blob.signed_id, variant.variation.key, variant.blob.filename, only_path: true
+                  repr.blob.signed_id, repr.variation.key, repr.blob.filename, only_path: true
                 )
               else
                 Rails.application.routes.url_helpers.rails_blob_path(value, only_path: true)


### PR DESCRIPTION
Currently, only images have a preview when using Active Storage attachments. Preview of videos (and potentially other file formats) are supported, however, but one needs to use _representable_ instead of only _previewable_. This PR switches to using _representable_.

Tested with movie previews and images on multiple upload.

Note that we still need to look at the image mime-type, to show e.g. SVG images (which are not representable, but can still be shown directly - great that there is an automated test for this).

See also:
- https://edgeguides.rubyonrails.org/active_storage_overview.html
- https://edgeapi.rubyonrails.org/classes/ActiveStorage/Blob/Representable.html