### PR TITLE
Correct meta tags syntax

### DIFF
--- a/app/views/layouts/rails_admin/_head.html.erb
+++ b/app/views/layouts/rails_admin/_head.html.erb
@@ -1,7 +1,7 @@
-<meta content="IE=edge" http-equiv="X-UA-Compatible"/>
-<meta content="text/html; charset=utf-8" http-equiv="Content-Type"/>
-<meta content="width=device-width, initial-scale=1" name="viewport; charset=utf-8"/>
-<meta content="NONE,NOARCHIVE" name="robots"/>
+<meta content="IE=edge" http-equiv="X-UA-Compatible">
+<meta content="text/html; charset=utf-8" http-equiv="Content-Type">
+<meta content="width=device-width, initial-scale=1" name="viewport; charset=utf-8">
+<meta content="NONE,NOARCHIVE" name="robots">
 <%= csrf_meta_tag %>
 <% case RailsAdmin::config.asset_source
    when :webpacker %>


### PR DESCRIPTION
meta tags are void elements, so this is the correct syntax for them. See also: https://developer.mozilla.org/en-US/docs/Glossary/Void_element