### PR TITLE
Fix filter on enum value in list view v2

### DIFF
--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -21,7 +21,7 @@ module RailsAdmin
           end
 
           register_instance_option :enum_method do
-            @enum_method ||= bindings[:object].class.respond_to?("#{name}_enum") || (bindings[:object] || abstract_model.model.new).respond_to?("#{name}_enum") ? "#{name}_enum" : name
+            @enum_method ||= bindings&.[](:object).class.respond_to?("#{name}_enum") || (bindings&.[](:object) || abstract_model.model.new).respond_to?("#{name}_enum") ? "#{name}_enum" : name
           end
 
           register_instance_option :enum do

--- a/lib/rails_admin/config/fields/types/enum.rb
+++ b/lib/rails_admin/config/fields/types/enum.rb
@@ -28,7 +28,7 @@ module RailsAdmin
             if abstract_model.model.respond_to?(enum_method)
               abstract_model.model.send(enum_method)
             else
-              (bindings[:object] || abstract_model.model.new).send(enum_method)
+              (bindings&.[](:object) || abstract_model.model.new).send(enum_method)
             end
           end
 

--- a/spec/rails_admin/config/fields/types/enum_spec.rb
+++ b/spec/rails_admin/config/fields/types/enum_spec.rb
@@ -17,10 +17,16 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Enum do
       end
     end
 
-    it 'auto-detects enumeration' do
+    it 'auto-detects enumeration when bindings provide object' do
       is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
       is_expected.not_to be_multiple
       expect(subject.with(object: Team.new).enum).to eq %w[blue green red]
+    end
+
+    it 'auto-detects enumeration when no bindings provided' do
+      is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
+      is_expected.not_to be_multiple
+      expect(subject.enum).to eq %w[blue green red]
     end
   end
 
@@ -39,9 +45,14 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Enum do
       end
     end
 
-    it 'auto-detects enumeration' do
+    it 'auto-detects enumeration when bindings provide object' do
       is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
       expect(subject.with(object: Team.new).enum).to eq %w[blue green red]
+    end
+
+    it 'auto-detects enumeration when no bindings provided' do
+      is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
+      expect(subject.enum).to eq %w[blue green red]
     end
   end
 

--- a/spec/rails_admin/config/fields/types/enum_spec.rb
+++ b/spec/rails_admin/config/fields/types/enum_spec.rb
@@ -63,9 +63,14 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Enum do
       Team.send(:remove_method, :color_list)
     end
 
-    it 'allows configuration' do
+    it 'allows configuration by enum_method when bindings provide object' do
       is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
       expect(subject.with(object: Team.new).enum).to eq %w[blue green red]
+    end
+
+    it 'allows configuration by enum_method when no bindings provided' do
+      is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
+      expect(subject.enum).to eq %w[blue green red]
     end
   end
 
@@ -87,9 +92,14 @@ RSpec.describe RailsAdmin::Config::Fields::Types::Enum do
       Team.instance_eval { undef :color_list }
     end
 
-    it 'allows configuration' do
+    it 'allows configuration by enum_method when bindings provide object' do
       is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
       expect(subject.with(object: Team.new).enum).to eq %w[blue green red]
+    end
+
+    it 'allows configuration by enum_method when no bindings provided' do
+      is_expected.to be_a(RailsAdmin::Config::Fields::Types::Enum)
+      expect(subject.enum).to eq %w[blue green red]
     end
   end
 


### PR DESCRIPTION
Filtering on legacy enums in a list view gives errors under Rails Admin 3.x (see #3651)

This PR adds to #3647 by adding a test for the fix provided there, as well as providing a similar fix for the `Fields::Types::Enum#enum_method` method.

I've left the original commit by @fuegas as-is to give due credit, but happy to squash the fix with the associated tests if preferred.

I don't fully grasp _why_ the method is called without bindings (not even an empty hash), and it's not clear if that is something that should ever be expected or is a symptom of a bug somewhere else, however either way it is true that the code paths using `abstract_model` were not covered by the existing tests.