### PR TITLE
Avoid eager loading Turbo Ruby files

### DIFF
--- a/lib/rails_admin/engine.rb
+++ b/lib/rails_admin/engine.rb
@@ -5,7 +5,6 @@ require 'nested_form'
 require 'rails'
 require 'rails_admin'
 require 'rails_admin/version'
-require 'turbo-rails'
 
 module RailsAdmin
   class Engine < Rails::Engine


### PR DESCRIPTION
Some projects use RailsAdmin without using Turbo or ActionCable. In these applications, when the Rails configuration option `config.eager_load` is set to true, the RailsAdmin requirement of turbo will result in eager loading files that can't load.

The result is the following error:

```
.../vendor/bundle/ruby/3.3.0/gems/turbo-rails-2.0.5/app/channels/turbo/streams_channel.rb:34:in `<top (required)>': uninitialized constant ActionCable (NameError)

class Turbo::StreamsChannel < ActionCable::Channel::Base
                              ^^^^^^^^^^^
Did you mean?  ActionMailer
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/kernel.rb:26:in `require'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/helpers.rb:139:in `const_get'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/helpers.rb:139:in `cget'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/eager_load.rb:175:in `block in actual_eager_load_dir'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/helpers.rb:42:in `block in ls'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/helpers.rb:25:in `each'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/helpers.rb:25:in `ls'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/eager_load.rb:170:in `actual_eager_load_dir'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/eager_load.rb:17:in `block (2 levels) in eager_load'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/eager_load.rb:16:in `each'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/eager_load.rb:16:in `block in eager_load'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/eager_load.rb:10:in `synchronize'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader/eager_load.rb:10:in `eager_load'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader.rb:413:in `block in eager_load_all'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader.rb:411:in `each'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/loader.rb:411:in `eager_load_all'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/application/finisher.rb:80:in `block in <module:Finisher>'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:32:in `instance_exec'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:32:in `run'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:61:in `block in run_initializers'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:231:in `block in tsort_each'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:353:in `block (2 levels) in each_strongly_connected_component'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:434:in `each_strongly_connected_component_from'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:352:in `block in each_strongly_connected_component'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:350:in `each'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:350:in `call'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:350:in `each_strongly_connected_component'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:229:in `tsort_each'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/tsort.rb:208:in `tsort_each'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/initializable.rb:60:in `run_initializers'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/application.rb:426:in `initialize!'
	from .../config/environment.rb:7:in `<top (required)>'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from .../vendor/bundle/ruby/3.3.0/gems/zeitwerk-2.6.14/lib/zeitwerk/kernel.rb:34:in `require'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/application.rb:402:in `require_environment!'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/command/actions.rb:20:in `boot_application!'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/commands/console/console_command.rb:105:in `perform'
	from .../vendor/bundle/ruby/3.3.0/gems/thor-1.3.1/lib/thor/command.rb:28:in `run'
	from .../vendor/bundle/ruby/3.3.0/gems/thor-1.3.1/lib/thor/invocation.rb:127:in `invoke_command'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/command/base.rb:178:in `invoke_command'
	from .../vendor/bundle/ruby/3.3.0/gems/thor-1.3.1/lib/thor.rb:527:in `dispatch'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/command/base.rb:73:in `perform'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/command.rb:71:in `block in invoke'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/command.rb:149:in `with_argv'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/command.rb:69:in `invoke'
	from .../vendor/bundle/ruby/3.3.0/gems/railties-7.1.3.4/lib/rails/commands.rb:18:in `<top (required)>'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/bundled_gems.rb:74:in `require'
	from /home/jon/.rubies/ruby-3.3.2/lib/ruby/3.3.0/bundled_gems.rb:74:in `block (2 levels) in replace_require'
	from bin/rails:4:in `<main>'
```

As a workaround, my application requires ActionCable, but it doesn't actually use it.

Removing the eager loading, does not remove using Turbo in the frontend. There is no change there.