### PR TITLE
Tidy up trailing whitespace in gem post_install_message

### DIFF
--- a/rails_admin.gemspec
+++ b/rails_admin.gemspec
@@ -25,12 +25,12 @@ Gem::Specification.new do |spec|
   spec.required_rubygems_version = '>= 1.8.11'
   spec.summary = 'Admin for Rails'
   spec.version = RailsAdmin::Version
-  spec.post_install_message = '
+  spec.post_install_message = <<~MSG
     ### Upgrading RailsAdmin from 2.x.x to 3.x.x ###
 
     Due to introduction of Webpack/Webpacker support, some additional dependencies and configuration will be needed.
     Running `bin/rails g rails_admin:install` will suggest required changes, based on the current setup of your app.
 
     For a complete list of changes, see https://github.com/railsadminteam/rails_admin/blob/master/CHANGELOG.md
-  '
+  MSG
 end


### PR DESCRIPTION
Previously, the post_install_message contained trailing whitespace on its last line such that the user's console prompt would be shifted to the right in an unusual way.

Now, follow shell conventions and finish the message with the a final newline and nothing else.

This change also left aligns the message like other Ruby gem post_install_messages do.

Before:

```
$ bundle install

...

Post-install message from rails_admin:

    ### Upgrading RailsAdmin from 2.x.x to 3.x.x ###

    Due to introduction of Webpack/Webpacker support, some additional dependencies and configuration will be needed.
    Running `bin/rails g rails_admin:install` will suggest required changes, based on the current setup of your app.

    For a complete list of changes, see https://github.com/railsadminteam/rails_admin/blob/master/CHANGELOG.md
  jon@localhost$
```

After:

```
### Upgrading RailsAdmin from 2.x.x to 3.x.x ###

Due to introduction of Webpack/Webpacker support, some additional dependencies and configuration will be needed.
Running `bin/rails g rails_admin:install` will suggest required changes, based on the current setup of your app.

For a complete list of changes, see https://github.com/railsadminteam/rails_admin/blob/master/CHANGELOG.md
Successfully installed rails_admin-3.1.2
jon@localhost$
```