### PR TITLE
Replace `asset-url` with `url` in Sass files

### DIFF
--- a/vendor/assets/stylesheets/rails_admin/font-awesome.scss
+++ b/vendor/assets/stylesheets/rails_admin/font-awesome.scss
@@ -12,7 +12,7 @@
   font-style: normal;
   font-weight: 900;
   font-display: block;
-  src: asset-url("rails_admin/fa-solid-900.woff2") format("woff2"), asset-url("rails_admin/fa-solid-900.ttf") format("truetype"); }
+  src: url("rails_admin/fa-solid-900.woff2") format("woff2"), url("rails_admin/fa-solid-900.ttf") format("truetype"); }
 
 .fa,
 .fas,


### PR DESCRIPTION
Both Sprockets and Propshaft will replace `url` with a digested version [1]. This change allows to use these Sass files with other Sass implementations like, Dartsass [2].

This also helps with: https://github.com/railsadminteam/rails_admin/issues/3697.

[1] https://github.com/rails/dartsass-rails/issues/18#issuecomment-1113972661
[2] https://github.com/rails/dartsass-rails