### PR TITLE
Change default response format of the show action to HTML

### DIFF
--- a/lib/rails_admin/config/actions/show.rb
+++ b/lib/rails_admin/config/actions/show.rb
@@ -21,8 +21,8 @@ module RailsAdmin
         register_instance_option :controller do
           proc do
             respond_to do |format|
-              format.json { render json: @object }
               format.html { render @action.template_name }
+              format.json { render json: @object }
             end
           end
         end

--- a/spec/integration/actions/show_spec.rb
+++ b/spec/integration/actions/show_spec.rb
@@ -47,6 +47,16 @@ RSpec.describe 'Show action', type: :request do
     end
   end
 
+  context 'with default format' do
+    it 'responds with HTML' do
+      page.driver.options[:headers] = {'HTTP_ACCEPT' => '*/*'}
+      visit show_path(model_name: 'team', id: team.id)
+
+      response_type = Mime::Type.parse(response_headers['Content-Type']).first
+      expect(response_type).to be_html
+    end
+  end
+
   context 'when compact_show_view is enabled' do
     it 'hides nil fields in show view by default' do
       visit show_path(model_name: 'team', id: team.id)


### PR DESCRIPTION
This is consistent with the other actions. When making HTTP requests using tools that are not web browsers, like `curl` or `fetch` in JavaScript without an explicit `Accept` header Rails will receive the request as with the `Accept` header set to `*/*`. That means that all registered mime types are a potential match and Rails will pick the response type based on the order they're declared in the source code.