### PR TITLE
When sorting models for navigation, fallback to model name

### DIFF
--- a/lib/rails_admin/config.rb
+++ b/lib/rails_admin/config.rb
@@ -360,7 +360,13 @@ module RailsAdmin
       def visible_models(bindings)
         visible_models_with_bindings(bindings).sort do |a, b|
           if (weight_order = a.weight <=> b.weight) == 0
-            a.label.casecmp(b.label)
+            result = a.label.casecmp(b.label)
+            if result.zero? && a.try(:model) && b.try(:model)
+              # If two models have the same label, fallback to the model name
+              # for a deterministic ordering.
+              result = a.model.name.casecmp(b.model.name)
+            end
+            result
           else
             weight_order
           end


### PR DESCRIPTION
In my project, several STI models have the same label stored in their translation file. This is because, from the user's perspective, they represent the same abstract concept, even if the developers know differently.

This can sometimes be an issue when rendering the main navigation. As the labels are equal, the listed models can be displayed in either order. It would be better to always display models in a single consistent and deterministic order. This is especially an issue for my project as the end-to-end tests rely on this order to assert correct behavior.