### PR TITLE
Add belongs_to optional/required support to required?

### DIFF
--- a/lib/rails_admin/adapters/active_record.rb
+++ b/lib/rails_admin/adapters/active_record.rb
@@ -135,6 +135,10 @@ module RailsAdmin
         end
       end
 
+      def belongs_to_required_by_default
+        model.belongs_to_required_by_default
+      end
+
     private
 
       def primary_key_scope(scope, id)

--- a/lib/rails_admin/adapters/mongoid.rb
+++ b/lib/rails_admin/adapters/mongoid.rb
@@ -112,6 +112,10 @@ module RailsAdmin
         false
       end
 
+      def belongs_to_required_by_default
+        ::Mongoid.belongs_to_required_by_default
+      end
+
     private
 
       def build_statement(column, type, value, operator)

--- a/spec/rails_admin/config/fields/base_spec.rb
+++ b/spec/rails_admin/config/fields/base_spec.rb
@@ -86,9 +86,15 @@ RSpec.describe RailsAdmin::Config::Fields::Base do
           column :league_id, :integer
           column :division_id, :integer, nil, false
           column :player_id, :integer
+          column :team_id, :integer
+          column :draft_id, :integer
+          column :image_id, :integer
           belongs_to :league, optional: true
           belongs_to :division, optional: true
           belongs_to :player, optional: true
+          belongs_to :team, optional: false
+          belongs_to :draft, required: true
+          belongs_to :image, required: false
           validates_numericality_of(:player_id, only_integer: true)
         end
         @fields = RailsAdmin.config(RelTest).create.fields
@@ -109,6 +115,24 @@ RSpec.describe RailsAdmin::Config::Fields::Base do
       describe 'for column with nullable foreign key and a numericality model validation' do
         it 'is required' do
           expect(@fields.detect { |f| f.name == :player }.required?).to be_truthy
+        end
+      end
+
+      describe 'for belongs_to association with optional: false' do
+        it 'is required' do
+          expect(@fields.detect { |f| f.name == :team }.required?).to be_truthy
+        end
+      end
+
+      describe 'for belongs_to association with required: true' do
+        it 'is required' do
+          expect(@fields.detect { |f| f.name == :draft }.required?).to be_truthy
+        end
+      end
+
+      describe 'for belongs_to association with required: false' do
+        it 'is optional' do
+          expect(@fields.detect { |f| f.name == :image }.required?).to be_falsey
         end
       end
     end


### PR DESCRIPTION
Active Record 7.1.0.beta1 added a lambda to the presence validation added by a belongs_to association. This lambda is only an optimisation to not check presence if the column is unchanged, however it stops RailsAdmin from treating the column as required.