### PR TITLE
Add a "sass" entry point to package.json to simplify webpack imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "src"
   ],
   "main": "src/rails_admin/base.js",
+  "sass": "src/rails_admin/styles/base.scss",
   "scripts": {
     "link": "yarn link && cd spec/dummy_app && yarn link rails_admin",
     "format": "prettier -w ."


### PR DESCRIPTION
Details on how the "sass" entry point is consumed is at:

https://sass-lang.com/documentation/js-api/classes/nodepackageimporter/

Other packages use this. For example Bootstrap:

https://github.com/twbs/bootstrap/blob/ddf5853c7bd8537cf8abc3776181b570b21eaefc/package.json#L39