### PR TITLE
dont try to generate blob.signed_url when attachment not saved

### DIFF
--- a/lib/rails_admin/config/fields/types/active_storage.rb
+++ b/lib/rails_admin/config/fields/types/active_storage.rb
@@ -61,7 +61,7 @@ module RailsAdmin
 
           def value
             attachment = super
-            attachment if attachment&.attached?
+            attachment if !attachment&.new_record? && attachment&.attached?
           end
         end
       end


### PR DESCRIPTION
fixes https://github.com/railsadminteam/rails_admin/issues/3685 `Cannot get a signed_id for a new record (ArgumentError)` occurs when parent record fails to save for some reason e.g. validation failure, attachment is attached but not saved.