### PR TITLE
Remove string mutation

### DIFF
--- a/lib/rails_admin/config/configurable.rb
+++ b/lib/rails_admin/config/configurable.rb
@@ -57,7 +57,8 @@ module RailsAdmin
 
           # If it's a boolean create an alias for it and remove question mark
           if option_name.end_with?('?')
-            scope.send(:define_method, "#{option_name.chop!}?") do
+            option_name = option_name.chop
+            scope.send(:define_method, "#{option_name}?") do
               send(option_name)
             end
           end


### PR DESCRIPTION
There are a lot of warnings about a string "will be frozen in the future" (depending on the users code base).

E.g.
```
/Users/bb/.asdf/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rails_admin-3.3.0/lib/rails_admin/config/configurable.rb:60: warning: string returned by :visible?.to_s will be frozen in the future
/Users/bb/.asdf/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rails_admin-3.3.0/lib/rails_admin/config/configurable.rb:60: warning: string returned by :active?.to_s will be frozen in the future
/Users/bb/.asdf/installs/ruby/3.4.8/lib/ruby/gems/3.4.0/gems/rails_admin-3.3.0/lib/rails_admin/config/configurable.rb:60: warning: string returned by :visible?.to_s will be frozen in the future
```

This fixes it by not mutating the option_name string inline but explicitly reassigning.


