### PR TITLE
Upgrade @hotwired/turbo-rails to resolve security warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "@babel/runtime": "^7.16.7",
     "@fortawesome/fontawesome-free": ">=5.15.0 <7.0.0",
-    "@hotwired/turbo-rails": "^7.1.0",
+    "@hotwired/turbo-rails": "^8.0.21",
     "@popperjs/core": "^2.11.0",
     "@rails/ujs": "^7.1.3-4",
     "bootstrap": "^5.1.3",

--- a/spec/dummy_app/config/webpack/environment.js
+++ b/spec/dummy_app/config/webpack/environment.js
@@ -1,3 +1,31 @@
 const { environment } = require("@rails/webpacker");
+const path = require("path");
+
+const babelConfig = path.resolve(__dirname, "../../babel.config.js");
+const hotwiredPackages = /node_modules\/@hotwired\/turbo(?:-rails)?\//;
+const babelLoader = environment.loaders.get("babel");
+const babelUse = babelLoader.use[0];
+const babelExclude = babelLoader.exclude;
+const nodeModulesLoader = environment.loaders.get("nodeModules");
+const nodeModulesUse = nodeModulesLoader.use[0];
+const nodeModulesExclude = nodeModulesLoader.exclude;
+
+babelUse.options.configFile = babelConfig;
+babelLoader.include.push(hotwiredPackages);
+babelLoader.exclude = (modulePath) => {
+  if (hotwiredPackages.test(modulePath)) {
+    return false;
+  }
+  return babelExclude.test(modulePath);
+};
+
+nodeModulesUse.options.configFile = babelConfig;
+nodeModulesUse.options.babelrc = false;
+nodeModulesLoader.exclude = (modulePath) => {
+  if (hotwiredPackages.test(modulePath)) {
+    return true;
+  }
+  return nodeModulesExclude.test(modulePath);
+};
 
 module.exports = environment;

--- a/spec/dummy_app/config/webpacker.yml
+++ b/spec/dummy_app/config/webpacker.yml
@@ -10,7 +10,10 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: ["node_modules/rails_admin/src"]
+  additional_paths:
+    - node_modules/rails_admin/src
+    - node_modules/@hotwired/turbo
+    - node_modules/@hotwired/turbo-rails
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/spec/dummy_app/webpack.config.js
+++ b/spec/dummy_app/webpack.config.js
@@ -18,4 +18,21 @@ module.exports = {
       maxChunks: 1,
     }),
   ],
+  module: {
+    rules: [
+      {
+        test: /\.(js|mjs)$/,
+        include: [
+          path.resolve(__dirname, "app/javascript"),
+          /node_modules\/@hotwired\/turbo(?:-rails)?\//,
+        ],
+        use: {
+          loader: "babel-loader",
+          options: {
+            configFile: path.resolve(__dirname, "babel.config.js"),
+          },
+        },
+      },
+    ],
+  },
 };


### PR DESCRIPTION
Details of the security vulnerability are available at:

https://github.com/hotwired/turbo/security/advisories/GHSA-qppm-g56g-fpvp

> A race condition in Turbo Frames allows delayed HTTP responses to
> restore stale session cookies after session-modifying operations.

As a result, my project started receiving the following warning:

> Dependabot cannot update @hotwired/turbo to a non-vulnerable version
>
> The latest possible version that can be installed is 7.3.0 because of the following conflicting dependencies:
>
> rails_admin@3.3.0 requires @hotwired/turbo@^7.3.0 via @hotwired/turbo-rails@7.3.0
> No patched version available for @hotwired/turbo
>
> The earliest fixed version is 8.0.21.