### PR TITLE
Fix RuboCop offense Layout/MultilineMethodCallIndentation

### DIFF
--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
           'delete_paperclip_asset' => 'test',
           'should_not_be_here' => 'test',
         }.merge(defined?(ActiveStorage) ? {'active_storage_asset' => 'test', 'remove_active_storage_asset' => 'test', 'active_storage_assets' => 'test', 'remove_active_storage_assets' => 'test'} : {}).
-          merge(defined?(Shrine) ? {'shrine_asset' => 'test', 'remove_shrine_asset' => 'test'} : {}),
+         merge(defined?(Shrine) ? {'shrine_asset' => 'test', 'remove_shrine_asset' => 'test'} : {}),
       )
 
       controller.send(:sanitize_params_for!, :create, RailsAdmin.config(FieldTest), controller.params['field_test'])


### PR DESCRIPTION
```
spec/controllers/rails_admin/main_controller_spec.rb:475:11: C: [Corrected] Layout/MultilineMethodCallIndentation: Align merge with .merge on line 474.
          merge(defined?(Shrine) ? {'shrine_asset' => 'test', 'remove_shrine_asset' => 'test'} : {}),
          ^^^^^
```