### PR TITLE
Fix `_discard` leaking into SQL for multi-select enum filters

### DIFF
--- a/lib/rails_admin/abstract_model.rb
+++ b/lib/rails_admin/abstract_model.rb
@@ -140,6 +140,10 @@ module RailsAdmin
       end
 
       def to_statement
+        if @value.is_a?(Array) && @value.include?('_discard')
+          @value = @value.reject { |v| v == '_discard' }
+          return if @value.empty?
+        end
         return if [@operator, @value].any? { |v| v == '_discard' }
 
         unary_operators[@operator] || unary_operators[@value] ||

--- a/spec/controllers/rails_admin/main_controller_spec.rb
+++ b/spec/controllers/rails_admin/main_controller_spec.rb
@@ -472,7 +472,7 @@ RSpec.describe RailsAdmin::MainController, type: :controller do
           'delete_paperclip_asset' => 'test',
           'should_not_be_here' => 'test',
         }.merge(defined?(ActiveStorage) ? {'active_storage_asset' => 'test', 'remove_active_storage_asset' => 'test', 'active_storage_assets' => 'test', 'remove_active_storage_assets' => 'test'} : {}).
-          merge(defined?(Shrine) ? {'shrine_asset' => 'test', 'remove_shrine_asset' => 'test'} : {}),
+         merge(defined?(Shrine) ? {'shrine_asset' => 'test', 'remove_shrine_asset' => 'test'} : {}),
       )
 
       controller.send(:sanitize_params_for!, :create, RailsAdmin.config(FieldTest), controller.params['field_test'])

--- a/spec/rails_admin/adapters/active_record_spec.rb
+++ b/spec/rails_admin/adapters/active_record_spec.rb
@@ -305,6 +305,11 @@ RSpec.describe 'RailsAdmin::Adapters::ActiveRecord', active_record: true do
       end
     end
 
+    it "strips '_discard' from array values" do
+      expect(build_statement(:enum, ['_discard'], nil)).to be_nil
+      expect(build_statement(:enum, %w[_discard foo bar], nil)).to eq(['(field IN (?))', %w[foo bar]])
+    end
+
     describe 'string type queries' do
       it 'supports string type query' do
         expect(build_statement(:string, '', nil)).to be_nil

--- a/spec/rails_admin/adapters/mongoid_spec.rb
+++ b/spec/rails_admin/adapters/mongoid_spec.rb
@@ -277,6 +277,11 @@ RSpec.describe 'RailsAdmin::Adapters::Mongoid', mongoid: true do
       end
     end
 
+    it "strips '_discard' from array values" do
+      expect(@abstract_model.send(:build_statement, :name, :enum, ['_discard'], nil)).to be_nil
+      expect(@abstract_model.send(:build_statement, :name, :enum, %w[_discard foo bar], nil)).to eq(name: {'$in' => %w[foo bar]})
+    end
+
     it "supports '_blank' operator" do
       [['_blank', ''], ['', '_blank']].each do |value, operator|
         expect(@abstract_model.send(:build_statement, :name, :string, value, operator)).to eq(name: {'$in' => [nil, '']})

--- a/src/rails_admin/filter-box.js
+++ b/src/rails_admin/filter-box.js
@@ -102,7 +102,10 @@ import flatpickr from "flatpickr";
                 $(this).attr("selected", true);
             });
             if (multiple)
-              control.find("option[value^=_],option[disabled]").hide();
+              control
+                .find("option[value^=_],option[disabled]")
+                .hide()
+                .prop("selected", false);
           }
           break;
         case "citext":


### PR DESCRIPTION
## Summary

When an enum filter is used in multi-select mode, `_discard` (the `"..."` placeholder) gets submitted as a literal value on subsequent page loads, producing SQL like:

```sql
WHERE (users.role IN ('_discard','admin','editor'))
```

This PR fixes both the client-side and server-side causes.

## Steps to reproduce

1. Have a model with an enum field (e.g. `role` on `User`)
2. Navigate to the index page and open the filter for that enum field
3. Select multiple values (e.g. `admin` and `editor`) and submit the filter
4. On the filtered results page, **do not touch the filter select** — just click "Filter" (submit) again
5. Observe the generated SQL: `_discard` appears as a value in the `IN (...)` clause

## Root cause

**Client-side** (`src/rails_admin/filter-box.js`): When restoring a multi-select filter on page reload, `_discard` remains implicitly selected because `.prop("multiple", true)` preserves the default selection, and the code only hides the option without deselecting it.

**Server-side** (`lib/rails_admin/abstract_model.rb`): The `_discard` guard only checks scalar equality (`v == '_discard'`), which is always false when `@value` is an array like `['_discard', 'admin', 'editor']`.

## Fix

- **Client-side**: Add `.prop("selected", false)` when hiding special options in multi-select mode
- **Server-side**: Strip `_discard` from array values as defense-in-depth; return nil if the array becomes empty after stripping