### PR TITLE
Declare JavaScript package is a module

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "files": [
     "src"
   ],
+  "type": "module",
   "main": "src/rails_admin/base.js",
   "sass": "src/rails_admin/styles/base.scss",
   "scripts": {


### PR DESCRIPTION
The package entry point uses the import statement, so it is using module syntax.