### PR TITLE
Improve intermittent autocomplete test failures due to stale element

### DIFF
--- a/spec/integration/fields/belongs_to_association_spec.rb
+++ b/spec/integration/fields/belongs_to_association_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe 'BelongsToAssociation field', type: :request do
         visit edit_path(model_name: 'managed_team', id: teams[0].id)
         find('input.ra-filtering-select-input').set('M')
         page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: "ManagingUser ##{users[1].id}")
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("ManagingUser ##{users[1].id}")).click()}
         click_button 'Save'
         teams[0].reload
@@ -130,7 +130,7 @@ RSpec.describe 'BelongsToAssociation field', type: :request do
         visit edit_path(model_name: 'favorite_player', id: favorite_player.id)
         find('.fanship_field input.ra-filtering-select-input').set(fanship.fan_id)
         page.execute_script("document.querySelector('.fanship_field input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: "Fanship ##{fanship.id}")
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Fanship ##{fanship.id}")).click()}
         click_button 'Save'
         is_expected.to have_content 'Favorite player successfully updated'

--- a/spec/integration/fields/has_one_association_spec.rb
+++ b/spec/integration/fields/has_one_association_spec.rb
@@ -113,7 +113,7 @@ RSpec.describe 'HasOneAssociation field', type: :request do
         visit edit_path(model_name: 'managing_user', id: user.id)
         find('input.ra-filtering-select-input').set('T')
         page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: team.name)
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("#{team.name}")).click()}
         click_button 'Save'
         is_expected.to have_content 'Managing user successfully updated'
@@ -164,7 +164,7 @@ RSpec.describe 'HasOneAssociation field', type: :request do
         fill_in 'Name', with: 'someone'
         find('.fanship_field input.ra-filtering-select-input').set(fanship.fan_id)
         page.execute_script("document.querySelector('.fanship_field input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: "Fanship ##{fanship.id}")
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Fanship ##{fanship.id}")).click()}
         click_button 'Save'
         is_expected.to have_content 'Fan successfully created'

--- a/spec/integration/fields/polymorphic_assosiation_spec.rb
+++ b/spec/integration/fields/polymorphic_assosiation_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
       select 'Player', from: 'comment[commentable_type]'
       find('input.ra-filtering-select-input').set('Rob')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Jackie Robinson')
       page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
       click_button 'Save'
       is_expected.to have_content 'Comment successfully created'
@@ -33,7 +33,7 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
       select 'Player', from: 'comment[commentable_type]'
       find('input.ra-filtering-select-input').set('Rob')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Jackie Robinson')
       page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
       select 'Team', from: 'comment[commentable_type]'
       expect(find('#comment_commentable_id', visible: false).value).to eq ''
@@ -51,7 +51,7 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
         find('input.ra-filtering-select-input').set('Rob')
 
         page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Jackie Robinson')
 
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
         click_button 'Save'
@@ -72,12 +72,12 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
       expect(find('select#comment_commentable_id', visible: false).value).to eq team.id.to_s
       find('input.ra-filtering-select-input').set('Los')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Los Angeles Dodgers')
       expect(all('ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to eq ['Los Angeles Dodgers']
       select 'Player', from: 'comment[commentable_type]'
       find('input.ra-filtering-select-input').set('Rob')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Jackie Robinson')
       expect(all('ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to eq ['Rob Wooten', 'Jackie Robinson']
       page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
       click_button 'Save'
@@ -107,7 +107,7 @@ RSpec.describe 'PolymorphicAssociation field', type: :request do
         select 'Player', from: 'comment[commentable_type]'
         find('input.ra-filtering-select-input').set('Rob')
         page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+        expect(page).to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Jackie Robinson')
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Jackie Robinson")).click()}
         click_button 'Save'
         is_expected.to have_content 'Comment successfully updated'

--- a/spec/integration/widgets/filtering_select_spec.rb
+++ b/spec/integration/widgets/filtering_select_spec.rb
@@ -25,22 +25,22 @@ RSpec.describe 'Filtering select widget', type: :request, js: true do
     it 'supports filtering' do
       find('input.ra-filtering-select-input').set('ge')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Los Angeles Dodgers')
       expect(all(:css, 'ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to match_array ['Los Angeles Dodgers', 'Texas Rangers']
       find('input.ra-filtering-select-input').set('Los')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Los Angeles Dodgers')
       expect(all(:css, 'ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to eq ['Los Angeles Dodgers']
       find('input.ra-filtering-select-input').set('Mets')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'No objects found')
       expect(all(:css, 'ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to match_array ['No objects found']
     end
 
     it 'sets id of the selected item' do
       find('input.ra-filtering-select-input').set('Tex')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Texas Rangers')
       page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Texas Rangers")).click()}
       expect(find('#player_team_id', visible: false).value).to eq teams[1].id.to_s
     end
@@ -52,7 +52,7 @@ RSpec.describe 'Filtering select widget', type: :request, js: true do
       expect(find('#player_team_id', visible: false).value).to eq teams[0].id.to_s
       find('input.ra-filtering-select-input').set('Tex')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Texas Rangers')
       page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Texas Rangers")).click()}
       expect(find('#player_team_id', visible: false).value).to eq teams[1].id.to_s
     end
@@ -123,12 +123,12 @@ RSpec.describe 'Filtering select widget', type: :request, js: true do
     it 'supports filtering' do
       find('input.ra-filtering-select-input').set('ge')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Los Angeles Dodgers')
       expect(all(:css, 'ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to match_array ['Los Angeles Dodgers', 'Texas Rangers']
       teams[0].update name: 'Cincinnati Reds'
       find('input.ra-filtering-select-input').set('Red')
       page.execute_script("document.querySelector('input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))")
-      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+      is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Cincinnati Reds')
       expect(all(:css, 'ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to eq ['Cincinnati Reds']
     end
   end
@@ -153,7 +153,7 @@ RSpec.describe 'Filtering select widget', type: :request, js: true do
         expect(all('#draft_player_id option', visible: false).map(&:value).filter(&:present?)).to be_empty
         find('[data-input-for="draft_team_id"] input.ra-filtering-select-input').set('Tex')
         page.execute_script(%{document.querySelector('[data-input-for="draft_team_id"] input.ra-filtering-select-input').dispatchEvent(new KeyboardEvent('keydown'))})
-        is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a')
+        is_expected.to have_selector('ul.ui-autocomplete li.ui-menu-item a', text: 'Texas Rangers')
         page.execute_script %{[...document.querySelectorAll('ul.ui-autocomplete li.ui-menu-item')].find(e => e.innerText.includes("Texas Rangers")).click()}
         within('[data-input-for="draft_player_id"].filtering-select') { find('.dropdown-toggle').click }
         expect(all(:css, 'ul.ui-autocomplete li.ui-menu-item a').map(&:text)).to match_array players.map(&:name)


### PR DESCRIPTION
The jquery UI select widget tests intermittently fail in CI. This is an attempt to fix them by using a more complete and accurate selector. I believe the previous version could get into scenarios where the less specific selector matched a stale element on the page prior to the asynchronous fetch completing.