### PR TITLE
Remove @babel/runtime as an unnecessary direct dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "format": "prettier -w ."
   },
   "dependencies": {
-    "@babel/runtime": "^7.16.7",
     "@fortawesome/fontawesome-free": ">=5.15.0 <7.0.0",
     "@hotwired/turbo-rails": "^7.1.0",
     "@popperjs/core": "^2.11.0",


### PR DESCRIPTION
The project doesn't import `@babel/runtime` or use it directly, so remove it as a dependency to reduce downstream version conflicts and node_modules bloat. For example, projects wishing to upgrade to Babel 8. 