### PR TITLE
Replace the use of $.isFunction with typeof operator

### DIFF
--- a/spec/support/jquery.simulate.drag-sortable.js
+++ b/spec/support/jquery.simulate.drag-sortable.js
@@ -194,7 +194,7 @@
       relatedTarget: undefined
     }, options || {});
 
-    if ($.isFunction(document.createEvent)) {
+    if (typeof document.createEvent === "function") {
       evt = document.createEvent("MouseEvents");
       evt.initMouseEvent(type, e.bubbles, e.cancelable, e.view, e.detail,
         e.screenX, e.screenY, e.clientX, e.clientY,

--- a/src/rails_admin/widgets.js
+++ b/src/rails_admin/widgets.js
@@ -468,7 +468,7 @@ import I18n from "./i18n";
         .not(".froala-wysiwyged");
       if (array.length) {
         options = $(array[0]).data("options");
-        if (!$.isFunction($.fn.editable)) {
+        if (typeof $.fn.editable !== "function") {
           $("head").append(
             '<link href="' +
               options["csspath"] +


### PR DESCRIPTION
The jQuery function $.isFunction is deprecated, see:

https://api.jquery.com/jQuery.isFunction/

> As of jQuery 3.3, jQuery.isFunction() has been deprecated. In most
> cases, its use can be replaced by typeof x === "function".

Follow the recommendation.