### PR TITLE
Replace deprecated $.isArray with Array.isArray

### DIFF
--- a/src/rails_admin/filtering-select.js
+++ b/src/rails_admin/filtering-select.js
@@ -106,7 +106,7 @@ import I18n from "./i18n";
       var self = this;
       var requestIndex = 0;
 
-      if ($.isArray(source)) {
+      if (Array.isArray(source)) {
         return function (request, response) {
           response(self._getResultSet(request, source, false));
         };


### PR DESCRIPTION
Per jQuery documentation, $.isArray is deprecated. Array.isArray is a drop in replacement.

https://api.jquery.com/jQuery.isArray/