### PR TITLE
Replace deprecate $.now with native Date.now

### DIFF
--- a/src/rails_admin/filter-box.js
+++ b/src/rails_admin/filter-box.js
@@ -311,7 +311,7 @@ import flatpickr from "flatpickr";
     e.preventDefault();
     $.filters.append(
       $.extend(
-        { index: $.now().toString().slice(6, 11) },
+        { index: Date.now().toString().slice(6, 11) },
         $(this).data("options")
       )
     );


### PR DESCRIPTION
The jQuery method $.now is deprecated, see:

https://api.jquery.com/jQuery.now/

Replace it with recommended Date.now().