### PR TITLE
Replace deprecated $.parseJSON with native JSON.parse

### DIFF
--- a/src/rails_admin/remote-form.js
+++ b/src/rails_admin/remote-form.js
@@ -107,7 +107,7 @@ import * as bootstrap from "bootstrap";
       form.bind("ajax:complete", function (event) {
         var data = event.detail[0];
         if (data.status == 200) {
-          var json = $.parseJSON(data.responseText);
+          var json = JSON.parse(data.responseText);
           var option =
             '<option value="' +
             json.id +

--- a/src/rails_admin/widgets.js
+++ b/src/rails_admin/widgets.js
@@ -395,7 +395,7 @@ import I18n from "./i18n";
       if (array.length) {
         this.array = array;
         options = $(array[0]).data("options");
-        config_options = $.parseJSON(options["config_options"]);
+        config_options = JSON.parse(options["config_options"]);
         if (!window.wysihtml5) {
           $("head").append(
             '<link href="' +
@@ -419,7 +419,7 @@ import I18n from "./i18n";
           return array.each(function () {
             var uploadEnabled;
             options = $(this).data("options");
-            config_options = $.parseJSON(options["config_options"]);
+            config_options = JSON.parse(options["config_options"]);
             if (config_options) {
               if (!config_options["inlineMode"]) {
                 config_options["inlineMode"] = false;


### PR DESCRIPTION
The jQuery function $.parseJSON is deprecated, see:

https://api.jquery.com/jQuery.parseJSON/

The browser native JSON.parse is a drop in replacement.