### PR TITLE
Replace deprecated jQuery functions with browser native ones

### DIFF
--- a/spec/support/jquery.simulate.drag-sortable.js
+++ b/spec/support/jquery.simulate.drag-sortable.js
@@ -194,7 +194,7 @@
       relatedTarget: undefined
     }, options || {});
 
-    if ($.isFunction(document.createEvent)) {
+    if (typeof document.createEvent === "function") {
       evt = document.createEvent("MouseEvents");
       evt.initMouseEvent(type, e.bubbles, e.cancelable, e.view, e.detail,
         e.screenX, e.screenY, e.clientX, e.clientY,

--- a/src/rails_admin/filter-box.js
+++ b/src/rails_admin/filter-box.js
@@ -311,7 +311,7 @@ import flatpickr from "flatpickr";
     e.preventDefault();
     $.filters.append(
       $.extend(
-        { index: $.now().toString().slice(6, 11) },
+        { index: Date.now().toString().slice(6, 11) },
         $(this).data("options")
       )
     );

--- a/src/rails_admin/filtering-select.js
+++ b/src/rails_admin/filtering-select.js
@@ -106,7 +106,7 @@ import I18n from "./i18n";
       var self = this;
       var requestIndex = 0;
 
-      if ($.isArray(source)) {
+      if (Array.isArray(source)) {
         return function (request, response) {
           response(self._getResultSet(request, source, false));
         };

--- a/src/rails_admin/remote-form.js
+++ b/src/rails_admin/remote-form.js
@@ -107,7 +107,7 @@ import * as bootstrap from "bootstrap";
       form.bind("ajax:complete", function (event) {
         var data = event.detail[0];
         if (data.status == 200) {
-          var json = $.parseJSON(data.responseText);
+          var json = JSON.parse(data.responseText);
           var option =
             '<option value="' +
             json.id +

--- a/src/rails_admin/vendor/jquery_nested_form.js
+++ b/src/rails_admin/vendor/jquery_nested_form.js
@@ -48,7 +48,7 @@ import jQuery from 'jquery';
       // Make a unique ID for the new child
       var regexp  = new RegExp('new_' + assoc, 'g');
       var new_id  = this.newId();
-      content     = $.trim(content.replace(regexp, new_id));
+      content     = content.replace(regexp, new_id).trim();
 
       var field = this.insertFields(content, assoc, link);
       // bubble up event upto document (through form)
@@ -71,13 +71,13 @@ import jQuery from 'jquery';
     removeFields: function(e) {
       var $link = $(e.currentTarget),
           assoc = $link.data('association'); // Name of child to be removed
-      
+
       var hiddenField = $link.prev('input[type=hidden]');
       hiddenField.val('1');
-      
+
       var field = $link.closest('.fields');
       field.hide();
-      
+
       field
         .trigger({ type: 'nested:fieldRemoved', field: field })
         .trigger({ type: 'nested:fieldRemoved:' + assoc, field: field });

--- a/src/rails_admin/widgets.js
+++ b/src/rails_admin/widgets.js
@@ -395,7 +395,7 @@ import I18n from "./i18n";
       if (array.length) {
         this.array = array;
         options = $(array[0]).data("options");
-        config_options = $.parseJSON(options["config_options"]);
+        config_options = JSON.parse(options["config_options"]);
         if (!window.wysihtml5) {
           $("head").append(
             '<link href="' +
@@ -419,7 +419,7 @@ import I18n from "./i18n";
           return array.each(function () {
             var uploadEnabled;
             options = $(this).data("options");
-            config_options = $.parseJSON(options["config_options"]);
+            config_options = JSON.parse(options["config_options"]);
             if (config_options) {
               if (!config_options["inlineMode"]) {
                 config_options["inlineMode"] = false;
@@ -468,7 +468,7 @@ import I18n from "./i18n";
         .not(".froala-wysiwyged");
       if (array.length) {
         options = $(array[0]).data("options");
-        if (!$.isFunction($.fn.editable)) {
+        if (typeof $.fn.editable !== "function") {
           $("head").append(
             '<link href="' +
               options["csspath"] +


### PR DESCRIPTION
$.isArray -> Array.isArray()
$.isFunction -> typeof
$.now -> Date.now()
$.parseJSON -> JSON.parse()

https://api.jquery.com/jQuery.isArray/
https://api.jquery.com/jQuery.isFunction/
https://api.jquery.com/jQuery.now/
https://api.jquery.com/jQuery.parseJSON/