### PR TITLE
Fully specify all ESM imports with an extension

### DIFF
--- a/src/rails_admin/base.js
+++ b/src/rails_admin/base.js
@@ -1,7 +1,7 @@
 import Rails from "@rails/ujs";
 import "@hotwired/turbo-rails";
-import "./jquery";
-import "./vendor/jquery_nested_form";
+import "./jquery.js";
+import "./vendor/jquery_nested_form.js";
 import "bootstrap";
 
 // These jQuery-UI indirect dependencies need to be preloaded to be used within Import maps
@@ -17,15 +17,15 @@ import "jquery-ui/ui/widget.js";
 import "jquery-ui/ui/widgets/menu.js";
 import "jquery-ui/ui/widgets/mouse.js";
 
-import "./abstract-select";
-import "./filter-box";
-import "./filtering-multiselect";
-import "./filtering-select";
-import "./nested-form-hooks";
-import "./remote-form";
-import "./sidescroll";
-import "./ui";
-import "./widgets";
+import "./abstract-select.js";
+import "./filter-box.js";
+import "./filtering-multiselect.js";
+import "./filtering-select.js";
+import "./nested-form-hooks.js";
+import "./remote-form.js";
+import "./sidescroll.js";
+import "./ui.js";
+import "./widgets.js";
 
 if (!window._rails_loaded) {
   Rails.start();

--- a/src/rails_admin/filter-box.js
+++ b/src/rails_admin/filter-box.js
@@ -1,5 +1,5 @@
 import jQuery from "jquery";
-import I18n from "./i18n";
+import I18n from "./i18n.js";
 import flatpickr from "flatpickr";
 
 (function ($) {

--- a/src/rails_admin/filtering-multiselect.js
+++ b/src/rails_admin/filtering-multiselect.js
@@ -1,6 +1,6 @@
 import jQuery from "jquery";
 import "jquery-ui/ui/widget.js";
-import I18n from "./i18n";
+import I18n from "./i18n.js";
 
 (function ($) {
   $.widget("ra.filteringMultiselect", $.ra.abstractSelect, {

--- a/src/rails_admin/filtering-select.js
+++ b/src/rails_admin/filtering-select.js
@@ -1,7 +1,7 @@
 import jQuery from "jquery";
 import "jquery-ui/ui/widget.js";
 import "jquery-ui/ui/widgets/autocomplete.js";
-import I18n from "./i18n";
+import I18n from "./i18n.js";
 
 (function ($) {
   "use strict";

--- a/src/rails_admin/ui.js
+++ b/src/rails_admin/ui.js
@@ -1,6 +1,6 @@
 import jQuery from "jquery";
 import "jquery-ui/ui/effect.js";
-import I18n from "./i18n";
+import I18n from "./i18n.js";
 
 (function ($) {
   $(document).on("click", "#list input.toggle", function () {

--- a/src/rails_admin/widgets.js
+++ b/src/rails_admin/widgets.js
@@ -2,7 +2,7 @@ import jQuery from "jquery";
 import "jquery-ui/ui/widgets/sortable.js";
 import * as bootstrap from "bootstrap";
 import flatpickr from "flatpickr";
-import I18n from "./i18n";
+import I18n from "./i18n.js";
 
 (function ($) {
   document.addEventListener("rails_admin.dom_ready", function (event) {


### PR DESCRIPTION
In some build environments, the extension is mandatory. Without it, I see errors like:

```
ERROR in rails_admin/src/rails_admin/base.js 28:0-19
Module not found: Error: Can't resolve './widgets' in 'rails_admin/src/rails_admin'
Did you mean 'widgets.js'?
BREAKING CHANGE: The request './widgets' failed to resolve only because it was resolved as fully specified
(probably because the origin is strict EcmaScript Module, e. g. a module with javascript mimetype, a '*.mjs' file, or a '*.js' file where the package.json contains '"type": "module"').
The extension in the request is mandatory for it to be fully specified.
Add the extension to the request.
resolve './widgets' in 'rails_admin/src/rails_admin'
  using description file: rails_admin/package.json (relative path: ./src/rails_admin)
    Field 'browser' doesn't contain a valid alias configuration
    using description file: rails_admin/package.json (relative path: ./src/rails_admin/widgets)
      Field 'browser' doesn't contain a valid alias configuration
      rails_admin/src/rails_admin/widgets doesn't exist
```