### PR TITLE
Remove duplicate global assignment of window.jQuery

### DIFF
--- a/app/views/layouts/rails_admin/_head.html.erb
+++ b/app/views/layouts/rails_admin/_head.html.erb
@@ -25,8 +25,6 @@
   <%= javascript_importmap_module_preload_tags(RailsAdmin::Engine.importmap) %>
   <%= javascript_importmap_shim_nonce_configuration_tag if respond_to? :javascript_importmap_shim_nonce_configuration_tag %>
   <%= javascript_importmap_shim_tag if respond_to? :javascript_importmap_shim_tag %>
-  <%= # Preload jQuery and make it global, unless jQuery UI fails to initialize
-      tag.script "import jQuery from 'jquery'; window.jQuery = jQuery;".html_safe, type: "module" %>
   <%= javascript_import_module_tag 'rails_admin' %>
 <% else
      raise "Unknown asset_source: #{RailsAdmin::config.asset_source}"

--- a/spec/integration/rails_admin_spec.rb
+++ b/spec/integration/rails_admin_spec.rb
@@ -47,6 +47,9 @@ RSpec.describe RailsAdmin, type: :request do
         is_expected.to have_selector('head script[src^="/assets/rails_admin"][src$=".js"]', visible: false)
       when :webpacker
         is_expected.to have_selector('head script[src^="/packs-test/js/rails_admin"][src$=".js"]', visible: false)
+      when :importmap
+        is_expected.to have_selector('head script[type="module"]', text: 'import "rails_admin"', visible: false)
+        is_expected.not_to have_selector('head script[type="module"]', text: 'window.jQuery', visible: false)
       end
     end
   end


### PR DESCRIPTION
The window.jQuery global variable is already assigned in
src/rails_admin/jquery.js, so the one in the head template is an unnecessary duplicate.