### PR TITLE
Fix hide/visible option being overridden in child sections

### DIFF
--- a/lib/rails_admin/config/has_fields.rb
+++ b/lib/rails_admin/config/has_fields.rb
@@ -9,8 +9,9 @@ module RailsAdmin
         field = _fields.detect { |f| name == f.name }
 
         # some fields are hidden by default (belongs_to keys, has_many associations in list views.)
-        # unhide them if config specifically defines them
-        field.show if field && !field.instance_variable_get("@#{field.name}_registered").is_a?(Proc)
+        # unhide them if config specifically defines them, unless visibility has already been
+        # explicitly configured (e.g. via `hide`/`show`/`visible`) at a base/parent level.
+        field.show if field && !field.instance_variable_get(:@visible_registered)
         # Specify field as virtual if type is not specifically set and field was not
         # found in default stack
         if field.nil? && type.nil?

--- a/spec/rails_admin/config/has_fields_spec.rb
+++ b/spec/rails_admin/config/has_fields_spec.rb
@@ -29,6 +29,38 @@ RSpec.describe RailsAdmin::Config::HasFields do
     expect { RailsAdmin.config(Team).fields.detect { |f| f.name == :division }.visible? }.to raise_error(/undefined method [`']\[\]' for nil/)
   end
 
+  it 'keeps a field hidden in a section when it is explicitly configured hidden at the base level' do
+    RailsAdmin.config do |config|
+      config.model Team do
+        configure :name do
+          hide { true }
+        end
+
+        edit do
+          field :name
+        end
+      end
+    end
+
+    expect(RailsAdmin.config(Team).edit.fields.detect { |f| f.name == :name }).not_to be_visible
+  end
+
+  it 'keeps a field visible in a section when it is explicitly configured visible at the base level' do
+    RailsAdmin.config do |config|
+      config.model Team do
+        configure :division_id do
+          visible true
+        end
+
+        edit do
+          field :division_id
+        end
+      end
+    end
+
+    expect(RailsAdmin.config(Team).edit.fields.detect { |f| f.name == :division_id }).to be_visible
+  end
+
   it 'assigns properties to new one on overriding existing field' do
     RailsAdmin.config do |config|
       config.model Team do


### PR DESCRIPTION
## Summary

Fixes #3730.

`hide`/`visible` configured on a field at the base level was being silently discarded whenever that same field was explicitly redeclared inside a child section (e.g. `edit do field :email end`).

## Root cause

In `lib/rails_admin/config/has_fields.rb`, `field()` contains a guard meant to auto-unhide fields that are hidden by default (belongs_to keys, has_many associations in list views) only if the user hasn't already explicitly configured that field's visibility:

```ruby
field.show if field && !field.instance_variable_get("@#{field.name}_registered").is_a?(Proc)
```

The intent was to check whether visibility had been explicitly set, but `@#{field.name}_registered` (e.g. `@email_registered`) is never actually assigned anywhere in the codebase. Looking at `register_instance_option` in `lib/rails_admin/config/configurable.rb`, an option's explicit value is stored on an instance variable named after the *option*, not the *field*: for the `visible?` option (registered in `lib/rails_admin/config/hideable.rb`, which backs both `hide` and `show`), that ivar is `@visible_registered`.

Since `@#{field.name}_registered` is always `nil`, `!nil.is_a?(Proc)` is always `true`, so `field.show` fired unconditionally every time a field was redeclared, overwriting any prior `hide`/`visible` configuration - including configuration set at the model's base level before a child section (`edit`, `show`, `list`, etc.) re-declared the same field.

## Fix

Check the ivar that actually holds the explicit visibility state, `@visible_registered`, instead of the always-nil, field-name-based one:

```ruby
field.show if field && !field.instance_variable_get(:@visible_registered)
```

This preserves the original intent (auto-show fields that are hidden only by their *default* `visible?` logic) while no longer clobbering an explicit `hide`/`show`/`visible` call made anywhere earlier in the config chain.

## Test plan

- Added regression specs to `spec/rails_admin/config/has_fields_spec.rb` reproducing the issue: a field marked `hide { true }` at the base level stays hidden after being redeclared with `field :name` in an `edit` block, and a field marked `visible true` at the base stays visible after redeclaration.
- Confirmed the new "keeps a field hidden..." spec fails on current `master` (reproducing the bug) and passes with this fix.
- Ran `bundle exec rspec spec/rails_admin/config/has_fields_spec.rb` - all 8 examples pass.
- Ran the broader `spec/rails_admin/config` suite - no new failures introduced (pre-existing, unrelated failures in ActiveStorage/Carrierwave specs are present identically on `master` without this change, due to local image-processing tooling, not this fix).